### PR TITLE
Résolution du bug du salaire nul dans le tableau niveau 2

### DIFF
--- a/source/components/ResultsGrid.js
+++ b/source/components/ResultsGrid.js
@@ -11,7 +11,8 @@ import {
 	pathOr,
 	toPairs,
 	keys,
-	head
+	head,
+	find
 } from 'ramda'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'


### PR DESCRIPTION
Du aux changements d'import de Ramda : j'avais oublié d'importer
'find'... C'est ma faute (et celle du linter qui n'est pas dérangé par find() sans import parce que array.find existe). 