### PR TITLE
Affichage de la différence lors de l'édition d'une saisie

### DIFF
--- a/source/components/Results.js
+++ b/source/components/Results.js
@@ -1,4 +1,4 @@
-import { isEmpty, path, contains } from 'ramda'
+import { isEmpty, path, contains, propEq } from 'ramda'
 import React, { Component } from 'react'
 import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
@@ -11,6 +11,7 @@ import ProgressTip from 'Components/ProgressTip'
 @withRouter
 @connect(state => ({
 	analysis: state.analysis,
+	oldAnalysis: state.oldAnalysis,
 	targetName: state.targetName,
 	conversationStarted: !isEmpty(state.form),
 	conversationFirstAnswer: path(['form', 'conversation', 'values'])(state),
@@ -21,6 +22,7 @@ export default class Results extends Component {
 	render() {
 		let {
 			analysis,
+			oldAnalysis,
 			targetName,
 			conversationStarted,
 			conversationFirstAnswer,
@@ -30,7 +32,14 @@ export default class Results extends Component {
 
 		if (!analysis) return null
 
-		let { targets } = analysis
+		let targets = oldAnalysis
+			? oldAnalysis.targets.map(t => {
+					let newTargetValue = analysis.targets.find(
+						propEq('dottedName', t.dottedName)
+					).nodeValue
+					return { ...t, newValue: newTargetValue }
+				})
+			: analysis.targets
 
 		let onRulePage = contains('/regle/')(location.pathname)
 		return (

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -75,11 +75,11 @@ export var FormDecorator = formType => RenderField =>
 			props passées à ce dernier, car React 15.2 n'aime pas les attributes inconnus
 			des balises html, <input> dans notre cas.
 			*/
+			//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 			let submit = () => setTimeout(() => stepAction('fold', fieldName), 1),
 				stepProps = {
 					...this.props.step,
 					inverted,
-					//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 					submit,
 					setFormValue: (value, name = fieldName) => setFormValue(name, value)
 				}

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -13,9 +13,11 @@ export default ({
 	type,
 	title,
 	conversationStarted,
-	nodeValue: ruleValue
+	nodeValue: ruleValue,
+	newValue
 }) =>
 	do {
+		console.log(newValue)
 		let unsatisfied = ruleValue == null,
 			irrelevant = ruleValue == 0,
 			number = typeof ruleValue == 'number' && ruleValue > 0
@@ -31,20 +33,39 @@ export default ({
 				<div className="rule-box">
 					<span className="rule-name">{title}</span>
 					<RuleValue
-						{...{ unsatisfied, irrelevant, conversationStarted, ruleValue }}
+						{...{
+							unsatisfied,
+							irrelevant,
+							conversationStarted,
+							ruleValue,
+							newValue
+						}}
 					/>
 				</div>
 			</Link>
 		</span>
 	}
 
-let RuleValue = ({ unsatisfied, irrelevant, conversationStarted, ruleValue }) =>
+let RuleValue = ({
+	unsatisfied,
+	irrelevant,
+	conversationStarted,
+	ruleValue,
+	newValue
+}) =>
 	do {
 		let [className, text] = irrelevant
 			? ['irrelevant', "Vous n'êtes pas concerné"]
 			: unsatisfied
 				? ['unsatisfied', 'En attente de vos réponses...']
-				: ['figure', humanFigure(0)(ruleValue) + ' €']
+				: [
+						'figure',
+						humanFigure(0)(ruleValue) +
+							' €' +
+							(typeof newValue === 'number'
+								? ` + ${humanFigure(0)(newValue - ruleValue)}`
+								: '')
+					]
 
 		{
 			/*<p><i className="fa fa-lightbulb-o" aria-hidden="true"></i><em>Pourquoi ?</em></p> */

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { encodeRuleName } from 'Engine/rules'
 import classNames from 'classnames'
-import { capitalise0 } from '../../utils'
 let fmt = new Intl.NumberFormat('fr-FR').format
 export let humanFigure = decimalDigits => value =>
 	fmt(value.toFixed(decimalDigits))
@@ -45,7 +44,7 @@ let RuleValue = ({ unsatisfied, irrelevant, conversationStarted, ruleValue }) =>
 			? ['irrelevant', "Vous n'êtes pas concerné"]
 			: unsatisfied
 				? ['unsatisfied', 'En attente de vos réponses...']
-				: ['figure', humanFigure(2)(ruleValue) + ' €']
+				: ['figure', humanFigure(0)(ruleValue) + ' €']
 
 		{
 			/*<p><i className="fa fa-lightbulb-o" aria-hidden="true"></i><em>Pourquoi ?</em></p> */

--- a/source/debounceFormChangeActions.js
+++ b/source/debounceFormChangeActions.js
@@ -1,0 +1,34 @@
+// Thank you, github.com/ryanseddon/redux-debounced
+
+export default () => {
+	let timers = {}
+
+	let time = 500
+
+	let middleware = () => dispatch => action => {
+		let { type } = action
+
+		let key = type
+
+		const shouldDebounce = key === '@@redux-form/CHANGE'
+
+		if (!shouldDebounce) {
+			return dispatch(action)
+		}
+
+		if (timers[key]) {
+			clearTimeout(timers[key])
+		}
+
+		dispatch(action)
+		return new Promise(resolve => {
+			timers[key] = setTimeout(() => {
+				resolve(dispatch({ type: 'USER_INPUT_UPDATE' }))
+			}, time)
+		})
+	}
+
+	middleware._timers = timers
+
+	return middleware
+}

--- a/source/entry.js
+++ b/source/entry.js
@@ -1,12 +1,17 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { compose, createStore } from 'redux'
+import { compose, createStore, applyMiddleware } from 'redux'
 import App from './containers/App'
 import reducers from './reducers'
 import DevTools from './DevTools'
 import { AppContainer } from 'react-hot-loader'
+import debounceFormChangeActions from './debounceFormChangeActions'
 
-let store = createStore(reducers, compose(DevTools.instrument()))
+let createStoreWithMiddleware = applyMiddleware(debounceFormChangeActions())(
+	createStore
+)
+
+let store = createStoreWithMiddleware(reducers, compose(DevTools.instrument()))
 
 let anchor = document.querySelector('#js')
 

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -77,7 +77,13 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 	)
 
 	if (action.type === 'USER_INPUT_UPDATE') {
-		return { ...state, analysis, situationGate: situationWithDefaults(state) }
+		let oldAnalysis = state.oldAnalysis
+		return {
+			...state,
+			analysis,
+			oldAnalysis: oldAnalysis || state.analysis,
+			situationGate: situationWithDefaults(state)
+		}
 	}
 
 	let nextWithDefaults = getNextSteps(situationWithDefaults(state), analysis),
@@ -88,6 +94,7 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 		...state,
 		targetNames,
 		analysis,
+		oldAnalysis: null,
 		situationGate: situationWithDefaults(state),
 		explainedVariable: null,
 		done,
@@ -172,6 +179,7 @@ export default reduceReducers(
 
 		parsedRules: (state = null) => state,
 		analysis: (state = null) => state,
+		oldAnalysis: (state = null) => state,
 
 		targetNames: (state = null) => state,
 

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -51,7 +51,7 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 	if (!state.parsedRules) state.parsedRules = parseAll(flatRules)
 
 	if (
-		![START_CONVERSATION, STEP_ACTION, '@@redux-form/CHANGE'].includes(
+		![START_CONVERSATION, STEP_ACTION, 'USER_INPUT_UPDATE'].includes(
 			action.type
 		)
 	)
@@ -76,7 +76,7 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 		situationWithDefaults(state)
 	)
 
-	if (action.type === '@@redux-form/CHANGE') {
+	if (action.type === 'USER_INPUT_UPDATE') {
 		return { ...state, analysis, situationGate: situationWithDefaults(state) }
 	}
 


### PR DESCRIPTION
Permet, par exemple lors de l'augmentation du salaire saisi, de voir dans la barre de
résultat l'impact sur les objectifs **en terme de différence introduite**.

Design à travailler, intérêt à valider par rapport à l'apport déjà intéressant de #151. 

Le besoin nous a été donné lors des tests utilisateurs : pouvoir jongler entre par exemple cadre/non cadre et voir l'impact de l'un ou l'autre en différence. 