### PR TITLE
Recalcul immédiat

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"nearley": "^2.9.2",
 		"npm": "^5.3.0",
 		"ramda": "^0.25.0",
+		"rc-progress": "^2.2.5",
 		"react": "^16.2.0",
 		"react-addons-css-transition-group": "^15.6.2",
 		"react-color": "^2.13.8",

--- a/source/actions.js
+++ b/source/actions.js
@@ -2,8 +2,8 @@
 // The state keeps track of which of them have been submitted
 // The user can also come back to one of his answers and edit it
 export const STEP_ACTION = 'STEP_ACTION'
-export function stepAction(name, step) {
-	return { type: STEP_ACTION, name, step }
+export function stepAction(name, step, source) {
+	return { type: STEP_ACTION, name, step, source }
 }
 
 export const START_CONVERSATION = 'START_CONVERSATION'

--- a/source/components/ProgressTip.css
+++ b/source/components/ProgressTip.css
@@ -15,6 +15,9 @@
 
 progress::-webkit-progress-bar {
 	background: white;
+	border-color: black;
+	border-width: 1px;
+	border-style: solid;
 }
 
 progress::-webkit-progress-value {

--- a/source/components/ProgressTip.css
+++ b/source/components/ProgressTip.css
@@ -1,6 +1,6 @@
 #sim .tip {
 	font-style: italic;
-	margin-bottom: 1em;
+	margin-bottom: -0.3em;
 	text-align: center;
 }
 #sim .tip p {
@@ -11,14 +11,4 @@
 	background: white;
 	border-width: 1px;
 	border-style: solid;
-}
-
-progress::-webkit-progress-bar {
-	background: white;
-	border-color: black;
-	border-width: 1px;
-	border-style: solid;
-}
-
-progress::-webkit-progress-value {
 }

--- a/source/components/ProgressTip.js
+++ b/source/components/ProgressTip.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import './ProgressTip.css'
+import { Line } from 'rc-progress'
 
 @withRouter
 @connect(state => ({
 	done: state.done,
 	foldedSteps: state.foldedSteps,
 	nextSteps: state.nextSteps,
-	textColourOnWhite: state.themeColours.textColourOnWhite
+	colour: state.themeColours.colour
 }))
 export default class ProgressTip extends Component {
 	state = {
@@ -21,7 +22,7 @@ export default class ProgressTip extends Component {
 			})
 	}
 	render() {
-		let { done, nextSteps, foldedSteps, textColourOnWhite } = this.props,
+		let { done, nextSteps, foldedSteps, colour } = this.props,
 			nbQuestions = nextSteps.length
 		if (!done) return null
 		return (
@@ -35,10 +36,14 @@ export default class ProgressTip extends Component {
 						{nbQuestions === 1
 							? 'Une dernière question !'
 							: `Il reste moins de ${nbQuestions} questions`}
-						<ProgressBar
-							foldedSteps={foldedSteps}
-							nbQuestions={nbQuestions}
-							colour={textColourOnWhite}
+						<Line
+							percent={
+								100 * foldedSteps.length / (foldedSteps.length + nbQuestions)
+							}
+							strokeWidth="1"
+							strokeColor={colour}
+							trailColor="white"
+							strokeLinecap="butt"
 						/>
 					</p>
 				)}
@@ -46,13 +51,3 @@ export default class ProgressTip extends Component {
 		)
 	}
 }
-
-let ProgressBar = ({ foldedSteps, nbQuestions, colour }) => (
-	<progress
-		value={foldedSteps.length}
-		max={foldedSteps.length + nbQuestions}
-		style={{
-			borderColor: colour
-		}}
-	/>
-)

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -25,7 +25,7 @@ export var FormDecorator = formType => RenderField =>
 				formValueSelector('conversation')(state, 'inversions.' + dottedName)
 		}),
 		dispatch => ({
-			stepAction: (name, step) => dispatch(stepAction(name, step)),
+			stepAction: (name, step, source) => dispatch(stepAction(name, step, source)),
 			setFormValue: (field, value) =>
 				dispatch(change('conversation', field, value))
 		})
@@ -76,7 +76,7 @@ export var FormDecorator = formType => RenderField =>
 			des balises html, <input> dans notre cas.
 			*/
 			//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
-			let submit = () => setTimeout(() => stepAction('fold', fieldName), 1),
+			let submit = (cause) => setTimeout(() => stepAction('fold', fieldName, cause), 1),
 				stepProps = {
 					...this.props.step,
 					inverted,
@@ -121,7 +121,7 @@ export var FormDecorator = formType => RenderField =>
 							<IgnoreStepButton
 								action={() => {
 									setFormValue(fieldName, '' + defaultValue)
-									submit()
+									submit('ignore')
 								}}
 							/>
 						)}
@@ -159,7 +159,7 @@ export var FormDecorator = formType => RenderField =>
 					</span>
 					<button
 						className="edit"
-						onClick={() => stepAction('unfold', dottedName)}
+						onClick={() => stepAction('unfold', dottedName, 'unfold')}
 						style={{ color: themeColours.textColourOnWhite }}
 					>
 						<i className="fa fa-pencil" aria-hidden="true" />

--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -75,11 +75,11 @@ export var FormDecorator = formType => RenderField =>
 			props passées à ce dernier, car React 15.2 n'aime pas les attributes inconnus
 			des balises html, <input> dans notre cas.
 			*/
+			//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 			let submit = () => setTimeout(() => stepAction('fold', fieldName), 1),
 				stepProps = {
 					...this.props.step,
 					inverted,
-					//TODO hack, enables redux-form/CHANGE to update the form state before the traverse functions are run
 					submit,
 					setFormValue: (value, name = fieldName) => setFormValue(name, value)
 				}

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -40,9 +40,6 @@ export default class Input extends Component {
 								? { border: '2px dashed #ddd' }
 								: { border: `1px solid ${themeColours.textColourOnWhite}` }
 						}
-						onKeyDown={({ key }) =>
-							key == 'Enter' && (submitDisabled ? input.onBlur() : submit())
-						}
 					/>
 					{suffixed && (
 						<label

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -8,7 +8,7 @@ import SendButton from './SendButton'
 @FormDecorator('input')
 export default class Input extends Component {
 	state = {
-		hoverSuggestion: null
+		lastValue: ''
 	}
 	render() {
 		let {
@@ -20,7 +20,6 @@ export default class Input extends Component {
 			answerSuffix = valueType.suffix,
 			suffixed = answerSuffix != null,
 			inputError = dirty && error,
-			{ hoverSuggestion } = this.state,
 			submitDisabled = !dirty || inputError
 
 		return (
@@ -33,7 +32,6 @@ export default class Input extends Component {
 						}}
 						type="text"
 						{...input}
-						value={hoverSuggestion != null ? hoverSuggestion : input.value}
 						className={classnames({ suffixed })}
 						id={'step-' + dottedName}
 						{...attributes}
@@ -104,7 +102,7 @@ export default class Input extends Component {
 		)
 	}
 	renderSuggestions(themeColours) {
-		let { setFormValue, submit, suggestions, inverted } = this.props.stepProps
+		let { setFormValue, suggestions, inverted } = this.props.stepProps
 
 		if (!suggestions || inverted) return null
 		return (
@@ -114,16 +112,21 @@ export default class Input extends Component {
 					{toPairs(suggestions).map(([text, value]) => (
 						<li
 							key={value}
-							onClick={e =>
-								setFormValue('' + value) && submit() && e.preventDefault()
+							onClick={() => {
+								this.setState({ lastValue: null })
+								setFormValue('' + value)
+							}}
+							onMouseOver={() => {
+								this.setState({ lastValue: this.props.input.value })
+								setFormValue('' + value)
+							}}
+							onMouseOut={() =>
+								this.state.lastValue != null &&
+								setFormValue('' + this.state.lastValue)
 							}
-							onMouseOver={() => this.setState({ hoverSuggestion: value })}
-							onMouseOut={() => this.setState({ hoverSuggestion: null })}
 							style={{ color: themeColours.textColourOnWhite }}
 						>
-							<a href="#" title="cliquer pour valider">
-								{text}
-							</a>
+							<span title="cliquez pour insérer cette suggestion">{text}</span>
 						</li>
 					))}
 				</ul>

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -114,7 +114,7 @@ export default class Input extends Component {
 								setFormValue('' + value)
 								if (this.state.suggestion !== value)
 									this.setState({ suggestion: value })
-								else this.props.stepProps.submit()
+								else this.props.stepProps.submit('suggestion')
 							}}
 							onMouseOver={() => {
 								this.setState({ lastValue: this.props.input.value })

--- a/source/components/conversation/Input.js
+++ b/source/components/conversation/Input.js
@@ -112,6 +112,9 @@ export default class Input extends Component {
 							onClick={() => {
 								this.setState({ lastValue: null })
 								setFormValue('' + value)
+								if (this.state.suggestion !== value)
+									this.setState({ suggestion: value })
+								else this.props.stepProps.submit()
 							}}
 							onMouseOver={() => {
 								this.setState({ lastValue: this.props.input.value })

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -133,8 +133,16 @@ let RadioLabel = props => (
 
 @HoverDecorator
 class RadioLabelContent extends Component {
+	state = {
+		active: null
+	}
+	click = value => () => {
+		this.props.setFormValue(value)
+		if (this.state.active !== value) this.setState({ active: value })
+		else this.props.submit()
+	}
 	render() {
-		let { value, label, input, hover, themeColours, setFormValue } = this.props,
+		let { value, label, input, hover, themeColours } = this.props,
 			// value = when(is(Object), prop('value'))(choice),
 			labelStyle = Object.assign(
 				value === input.value || hover
@@ -149,7 +157,7 @@ class RadioLabelContent extends Component {
 				<input
 					type="radio"
 					{...input}
-					onClick={() => setFormValue(value)}
+					onClick={this.click(value)}
 					value={value}
 					checked={value === input.value ? 'checked' : ''}
 				/>

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -139,7 +139,7 @@ class RadioLabelContent extends Component {
 	click = value => () => {
 		this.props.setFormValue(value)
 		if (this.state.active !== value) this.setState({ active: value })
-		else this.props.submit()
+		else this.props.submit('dblClick')
 	}
 	render() {
 		let { value, label, input, hover, themeColours } = this.props,

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -4,7 +4,7 @@ import { answer, answered } from './userAnswerButtonStyle'
 import HoverDecorator from '../HoverDecorator'
 import Explicable from './Explicable'
 import { pipe, split, reverse, reduce, is } from 'ramda'
-
+import SendButton from './SendButton'
 /* Ceci est une saisie de type "radio" : l'utilisateur choisit une réponse dans une liste, ou une liste de listes.
 	Les données @choices sont un arbre de type:
 	- nom: motif CDD # La racine, unique, qui formera la Question. Ses enfants sont les choix possibles
@@ -21,26 +21,33 @@ import { pipe, split, reverse, reduce, is } from 'ramda'
 
 */
 
-let dottedNameToObject = pipe(
-	split(' . '),
-	reverse,
-	reduce((memo, next) => ({ [next]: memo }), 'oui')
-)
-
 // FormDecorator permet de factoriser du code partagé par les différents types de saisie,
 // dont Question est un example
 @FormDecorator('question')
 export default class Question extends Component {
 	render() {
-		let { stepProps: { choices } } = this.props
+		let {
+			stepProps: { choices },
+			themeColours,
+			stepProps: { submit }
+		} = this.props
+		let choiceElements = is(Array)(choices)
+			? this.renderBinaryQuestion()
+			: this.renderChildren(choices)
 
-		if (is(Array)(choices)) return this.renderBinaryQuestion()
-		else return this.renderChildren(choices)
+		return (
+			<>
+				{choiceElements}
+				<SendButton
+					{...{ disabled: false, themeColours, error: false, submit }}
+				/>
+			</>
+		)
 	}
 	renderBinaryQuestion() {
 		let {
 			input, // vient de redux-form
-			stepProps: { submit, choices },
+			stepProps: { submit, choices, setFormValue },
 			themeColours
 		} = this.props
 
@@ -49,7 +56,7 @@ export default class Question extends Component {
 				{choices.map(({ value, label }) => (
 					<RadioLabel
 						key={value}
-						{...{ value, label, input, submit, themeColours }}
+						{...{ value, label, input, submit, themeColours, setFormValue }}
 					/>
 				))}
 			</ul>
@@ -62,7 +69,7 @@ export default class Question extends Component {
 				themeColours
 			} = this.props,
 			{ name } = input,
-			{ submit } = stepProps,
+			{ submit, setFormValue } = stepProps,
 			// seront stockées ainsi dans le state :
 			// [parent object path]: dotted name relative to parent
 			relativeDottedName = radioDottedName =>
@@ -79,7 +86,8 @@ export default class Question extends Component {
 								input,
 								submit,
 								themeColours,
-								dottedName: null
+								dottedName: null,
+								setFormValue
 							}}
 						/>
 					</li>
@@ -101,7 +109,8 @@ export default class Question extends Component {
 											dottedName,
 											input,
 											submit,
-											themeColours
+											themeColours,
+											setFormValue
 										}}
 									/>
 								</li>
@@ -121,7 +130,7 @@ let RadioLabel = props => (
 @HoverDecorator
 class RadioLabelContent extends Component {
 	render() {
-		let { value, label, input, submit, hover, themeColours } = this.props,
+		let { value, label, input, hover, themeColours, setFormValue } = this.props,
 			// value = when(is(Object), prop('value'))(choice),
 			labelStyle = Object.assign(
 				value === input.value || hover
@@ -136,7 +145,7 @@ class RadioLabelContent extends Component {
 				<input
 					type="radio"
 					{...input}
-					onClick={submit}
+					onClick={() => setFormValue(value)}
 					value={value}
 					checked={value === input.value ? 'checked' : ''}
 				/>

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -27,19 +27,23 @@ import SendButton from './SendButton'
 export default class Question extends Component {
 	render() {
 		let {
-			stepProps: { choices },
+			stepProps: { choices, submit },
 			themeColours,
-			stepProps: { submit }
+			meta: { pristine }
 		} = this.props
 		let choiceElements = is(Array)(choices)
 			? this.renderBinaryQuestion()
 			: this.renderChildren(choices)
-
 		return (
 			<>
 				{choiceElements}
 				<SendButton
-					{...{ disabled: false, themeColours, error: false, submit }}
+					{...{
+						disabled: pristine,
+						themeColours,
+						error: false,
+						submit
+					}}
 				/>
 			</>
 		)

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -133,13 +133,8 @@ let RadioLabel = props => (
 
 @HoverDecorator
 class RadioLabelContent extends Component {
-	state = {
-		active: null
-	}
 	click = value => () => {
-		this.props.setFormValue(value)
-		if (this.state.active !== value) this.setState({ active: value })
-		else this.props.submit('dblClick')
+		if (this.props.input.value == value) this.props.submit('dblClick')
 	}
 	render() {
 		let { value, label, input, hover, themeColours } = this.props,

--- a/source/components/conversation/SendButton.js
+++ b/source/components/conversation/SendButton.js
@@ -21,7 +21,7 @@ export default class SendButton extends Component {
 					onClick={this.getAction()}
 				>
 					<span className="text">valider</span>
-					<span className="icon">&#10003;</span>
+					<i className="fa fa-check" aria-hidden="true" />
 				</button>
 				<span
 					className="keyIcon"

--- a/source/components/conversation/SendButton.js
+++ b/source/components/conversation/SendButton.js
@@ -7,6 +7,19 @@ export default class SendButton extends Component {
 		let { disabled, submit } = this.props
 		return () => (!disabled ? submit() : null)
 	}
+	componentDidMount() {
+		// removeEventListener will need the exact same function instance
+		this.boundHandleKeyDown = this.handleKeyDown.bind(this)
+
+		window.addEventListener('keydown', this.boundHandleKeyDown)
+	}
+	componentWillUnmount() {
+		window.removeEventListener('keydown', this.boundHandleKeyDown)
+	}
+	handleKeyDown({ key }) {
+		if (key !== 'Enter') return
+		this.getAction()()
+	}
 	render() {
 		let { disabled, themeColours, hover } = this.props
 		return (

--- a/source/components/conversation/SendButton.js
+++ b/source/components/conversation/SendButton.js
@@ -5,7 +5,7 @@ import HoverDecorator from 'Components/HoverDecorator'
 export default class SendButton extends Component {
 	getAction() {
 		let { disabled, submit } = this.props
-		return () => (!disabled ? submit() : null)
+		return (cause) => (!disabled ? submit(cause) : null)
 	}
 	componentDidMount() {
 		// removeEventListener will need the exact same function instance
@@ -18,7 +18,7 @@ export default class SendButton extends Component {
 	}
 	handleKeyDown({ key }) {
 		if (key !== 'Enter') return
-		this.getAction()()
+		this.getAction()('enter')
 	}
 	render() {
 		let { disabled, themeColours, hover } = this.props
@@ -31,7 +31,7 @@ export default class SendButton extends Component {
 						color: themeColours.textColour,
 						background: themeColours.colour
 					}}
-					onClick={this.getAction()}
+					onClick={(event) => this.getAction()('accept')}
 				>
 					<span className="text">valider</span>
 					<i className="fa fa-check" aria-hidden="true" />

--- a/source/components/conversation/conversation.css
+++ b/source/components/conversation/conversation.css
@@ -315,7 +315,7 @@
 	font-style: italic;
 	float: right;
 	clear: right;
-	font-size: 70%;
+	font-size: 75%;
 	color: #222;
 }
 .step .inputSuggestions ul {
@@ -326,11 +326,12 @@
 }
 .step .inputSuggestions li {
 }
-.step .inputSuggestions a {
+.step .inputSuggestions span {
 	padding: 0.1em 0.9em;
 	font-weight: 600;
+	cursor: pointer;
 }
-.step .inputSuggestions a:hover {
+.step .inputSuggestions span:hover {
 	text-decoration: none;
 }
 

--- a/source/components/conversation/conversation.css
+++ b/source/components/conversation/conversation.css
@@ -214,6 +214,10 @@
 .step.question .variantLeaf.aucun label {
 	font-weight: bold;
 }
+
+.step.question .sendWrapper {
+	float: right;
+}
 .step label.radio,
 /* A resume of what's been answered */ .resume {
 	text-align: center;
@@ -371,11 +375,11 @@
 }
 
 .step .send {
-	padding: 0 0.1em 0 0.5em;
+	padding: 0.1em 0.4em 0em 1em;
 	background: none;
 	cursor: pointer;
 	border: 1px solid;
-	border-radius: 0.2em;
+	border-radius: 0.4em;
 	line-height: 0em;
 }
 
@@ -383,19 +387,24 @@
 	opacity: 0.2;
 }
 
-.step .send .icon {
-	margin-left: 0.3em;
-	font-size: 135%;
-	vertical-align: middle;
+.step .send i {
+	margin: 0 0.3em;
+	font-size: 160%;
 }
 
 .step .send .text {
 	text-transform: uppercase;
-	font-size: 115%;
+	font-size: 135%;
 	line-height: 2em;
 }
 
 .answer {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+}
+
+.foldedQuestion .answer {
 	float: right;
 }
 

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { encodeRuleName } from 'Engine/rules'
 import classNames from 'classnames'
-import { capitalise0 } from '../../utils'
 let fmt = new Intl.NumberFormat('fr-FR').format
 export let humanFigure = decimalDigits => value =>
 	fmt(value.toFixed(decimalDigits))
@@ -45,7 +44,7 @@ let RuleValue = ({ unsatisfied, irrelevant, conversationStarted, ruleValue }) =>
 			? ['irrelevant', "Vous n'êtes pas concerné"]
 			: unsatisfied
 				? ['unsatisfied', 'En attente de vos réponses...']
-				: ['figure', humanFigure(2)(ruleValue) + ' €']
+				: ['figure', humanFigure(0)(ruleValue) + ' €']
 
 		{
 			/*<p><i className="fa fa-lightbulb-o" aria-hidden="true"></i><em>Pourquoi ?</em></p> */

--- a/source/debounceFormChangeActions.js
+++ b/source/debounceFormChangeActions.js
@@ -10,11 +10,14 @@ export default () => {
 
 		let key = type
 
-		const shouldDebounce = key === '@@redux-form/CHANGE'
+		let shouldDebounce = key === '@@redux-form/CHANGE'
 
-		if (!shouldDebounce) {
-			return dispatch(action)
+		if (key === '@@redux-form/UPDATE_SYNC_ERRORS') {
+			dispatch(action)
+			return clearTimeout(timers['@@redux-form/CHANGE'])
 		}
+
+		if (!shouldDebounce) return dispatch(action)
 
 		if (timers[key]) {
 			clearTimeout(timers[key])

--- a/source/debounceFormChangeActions.js
+++ b/source/debounceFormChangeActions.js
@@ -1,0 +1,34 @@
+// Thank you, github.com/ryanseddon/redux-debounced
+
+export default () => {
+	let timers = {}
+
+	let time = 500
+
+	let middleware = () => dispatch => action => {
+		let { type } = action
+
+		let key = type
+
+		const shouldDebounce = key === '@@redux-form/CHANGE'
+
+		if (!shouldDebounce) {
+			return dispatch(action)
+		}
+
+		if (timers[key]) {
+			clearTimeout(timers[key])
+		}
+
+		dispatch(action)
+		return new Promise(resolve => {
+			timers[key] = setTimeout(() => {
+				resolve(dispatch({ type: 'USER_INPUT_UPDATE' }))
+			}, time)
+		})
+	}
+
+	middleware._timers = timers
+
+	return middleware
+}

--- a/source/entry.js
+++ b/source/entry.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import { render } from 'react-dom'
-import { compose, createStore } from 'redux'
+import { compose, createStore, applyMiddleware } from 'redux'
 import App from './containers/App'
 import reducers from './reducers'
 import DevTools from './DevTools'
 import { AppContainer } from 'react-hot-loader'
+import debounceFormChangeActions from './debounceFormChangeActions'
 import computeThemeColours from './components/themeColours'
 import { getIframeOption, getUrl } from './utils'
 
@@ -13,7 +14,15 @@ let initialStore = {
 	themeColours: computeThemeColours(getIframeOption('couleur'))
 }
 
-let store = createStore(reducers, initialStore, compose(DevTools.instrument()))
+let createStoreWithMiddleware = applyMiddleware(debounceFormChangeActions())(
+	createStore
+)
+
+let store = createStoreWithMiddleware(
+	reducers,
+	initialStore,
+	compose(DevTools.instrument())
+)
 let anchor = document.querySelector('#js')
 
 render(<App store={store} />, anchor)

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -1,4 +1,4 @@
-import { head, isEmpty, pathOr, reject, contains, without, concat } from 'ramda'
+import { head, isEmpty, pathOr, reject, contains, without, concat, length } from 'ramda'
 import { combineReducers } from 'redux'
 import reduceReducers from 'reduce-reducers'
 import { reducer as formReducer, formValueSelector } from 'redux-form'
@@ -116,9 +116,17 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 	if (action.type == STEP_ACTION && action.name == 'fold') {
 		tracker.push([
 			'trackEvent',
-			'answer',
+			'answer:'+action.source,
 			action.step + ': ' + situationWithDefaults(state)(action.step)
 		])
+
+		if (!newState.currentQuestion) {
+			tracker.push([
+				'trackEvent',
+				'done',
+				'after'+length(newState.foldedSteps)+'questions'
+			])
+		}
 
 		return {
 			...newState,

--- a/source/reducers.js
+++ b/source/reducers.js
@@ -51,7 +51,7 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 	if (!state.parsedRules) state.parsedRules = parseAll(flatRules)
 
 	if (
-		![START_CONVERSATION, STEP_ACTION, '@@redux-form/CHANGE'].includes(
+		![START_CONVERSATION, STEP_ACTION, 'USER_INPUT_UPDATE'].includes(
 			action.type
 		)
 	)
@@ -76,7 +76,7 @@ export let reduceSteps = (tracker, flatRules, answerSource) => (
 		situationWithDefaults(state)
 	)
 
-	if (action.type === '@@redux-form/CHANGE') {
+	if (action.type === 'USER_INPUT_UPDATE') {
 		return { ...state, analysis, situationGate: situationWithDefaults(state) }
 	}
 


### PR DESCRIPTION
Avant de cliquer sur `valider`, toute saisie entraîne un recalcul du résultat. 

C'est la dernière modification pour toute tranche de temps de 500ms qui est prise en compte. Ce délai est plutôt agréable dans l'expérience, je trouve. 

Fait pour les saisies numériques.
- [x] styler le bouton 'valider' pour les questions à choix multiple.
- [ ] le faire pour les autres types de question (ex. menu déroulant) ?

Ça demande de réintroduire un bouton pour les questions à choix multiple. Est-ce un problème ?

Le besoin nous été retourné : je ne me rappelle plus exactement du commentaire, mais essentiellement : "dans le nouveau simulateur, il me faut plusieurs clics pour modifier mon salaire et voir l'impact". Cette PR ramène le nombre de clic à 0, comme dans l'ancien. 
@georges-bayard @Morendil 
