### PR TITLE
Navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"react-color": "^2.13.8",
 		"react-dom": "^16.2.0",
 		"react-helmet": "^5.2.0",
+		"react-highlight-words": "^0.10.0",
 		"react-redux": "^5.0.6",
 		"react-router": "^4.2.0",
 		"react-router-dom": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"dedent-js": "^1.0.1",
 		"deep-assign": "^2.0.0",
 		"flow": "^0.2.3",
+		"fuse.js": "^3.2.0",
 		"global": "^4.3.2",
 		"ignore-loader": "^0.1.2",
 		"js-yaml": "^3.9.1",

--- a/source/components/AttachDictionary.js
+++ b/source/components/AttachDictionary.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import marked from 'Engine/marked'
 import './Dictionary.css'
+import Overlay from './Overlay'
 
 // On ajoute à la section la possibilité d'ouvrir un panneau d'explication des termes.
 // Il suffit à la section d'appeler une fonction fournie en lui donnant du JSX
@@ -26,28 +27,24 @@ export let AttachDictionary = dictionary => Decorated =>
 		render() {
 			let { explanation, term } = this.state
 			return (
-				<div style={{ display: 'inline-block' }} className="dictionaryWrapper">
+				<div style={{ display: 'inline-block' }}>
 					<Decorated
 						ref={decorated => (this.decorated = decorated)}
 						{...this.props}
-						explain={this.explain}
 					/>
 					{explanation && (
-						<div
-							id="dictionaryPanelWrapper"
-							onClick={() => this.setState({ term: null, explanation: null })}
+						<Overlay
+							onOuterClick={() =>
+								this.setState({ term: null, explanation: null })
+							}
 						>
 							<div
 								id="dictionaryPanel"
-								onClick={e => {
-									e.preventDefault()
-									e.stopPropagation()
-								}}
 								dangerouslySetInnerHTML={{
 									__html: this.renderExplanationMarkdown(explanation, term)
 								}}
 							/>
-						</div>
+						</Overlay>
 					)}
 				</div>
 			)

--- a/source/components/Contact.js
+++ b/source/components/Contact.js
@@ -1,14 +1,7 @@
 import React from 'react'
 
 export default () => (
-	<div
-		style={{
-			color: '#333350',
-			margin: '15% auto',
-			width: '20em',
-			textAlign: 'center'
-		}}
-	>
+	<div className="centeredMessage">
 		<p>
 			Pour nous écrire :{' '}
 			<span style={{ fontWeight: 'bold' }}>contact@embauche.beta.gouv.fr</span>

--- a/source/components/Dictionary.css
+++ b/source/components/Dictionary.css
@@ -1,27 +1,3 @@
-
-#dictionaryPanelWrapper {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	background: rgba(255, 255, 255, 0.86);
-	z-index: 1;
-}
-#dictionaryPanel {
-	background: white;
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translateX(-50%) translateY(-50%);
-	width: 70%;
-	max-width: 40em;
-	border: 2px solid #333350;
-	margin: 1em;
-	padding: 0em 1.5em;
-	min-height: 6em;
-	border-radius: .3em;
-}
 #dictionaryPanel h3 {
 	color: #333350;
 	font-weight: bold;
@@ -38,6 +14,6 @@
 }
 #dictionaryPanel code {
 	border: 1px solid #aaa;
-	padding: .05em .3em;
-	border-radius: .3em;
+	padding: 0.05em 0.3em;
+	border-radius: 0.3em;
 }

--- a/source/components/Overlay.css
+++ b/source/components/Overlay.css
@@ -1,0 +1,23 @@
+#overlayWrapper {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: rgba(255, 255, 255, 0.86);
+	z-index: 1;
+}
+#overlayContent {
+	background: white;
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translateX(-50%) translateY(-50%);
+	width: 70%;
+	max-width: 40em;
+	border: 2px solid #333350;
+	margin: 1em;
+	padding: 0em 1.5em;
+	min-height: 6em;
+	border-radius: 0.3em;
+}

--- a/source/components/Overlay.js
+++ b/source/components/Overlay.js
@@ -1,0 +1,23 @@
+import React, { Component } from 'react'
+import './Overlay.css'
+
+export default class Overlay extends Component {
+	state = {
+		visible: false
+	}
+	render() {
+		return (
+			<div id="overlayWrapper" onClick={this.props.onOuterClick}>
+				<div
+					id="overlayContent"
+					onClick={e => {
+						e.preventDefault()
+						e.stopPropagation()
+					}}
+				>
+					{this.props.children}
+				</div>
+			</div>
+		)
+	}
+}

--- a/source/components/ResultsGrid.js
+++ b/source/components/ResultsGrid.js
@@ -214,7 +214,7 @@ class Row extends Component {
 			: keys(detail).map(subCellName => (
 					<tr key={'detailsRow' + subCellName} className="detailsRow">
 						<td className="element name">
-							<Link to={'/regle/' + encodeRuleName(nameLeaf(subCellName))}>
+							<Link to={'/règle/' + encodeRuleName(nameLeaf(subCellName))}>
 								{title(subCellName)}
 							</Link>
 						</td>
@@ -298,7 +298,7 @@ class ReductionRow extends Component {
 		let detailRow = this.state.folded ? null : (
 			<tr key="detailsRowRéductions" className="detailsRow">
 				<td className="element name">
-					<Link to={'/regle/' + encodeRuleName('réductions de cotisations')}>
+					<Link to={'/règle/' + encodeRuleName('réductions de cotisations')}>
 						Réductions de cotisations
 					</Link>
 				</td>

--- a/source/components/SearchButton.css
+++ b/source/components/SearchButton.css
@@ -1,0 +1,11 @@
+#searchButton button {
+	margin-top: 0.6em;
+	border: none;
+}
+#searchButton i {
+	font-size: 180%;
+}
+#searchButton {
+	display: flex;
+	justify-content: flex-end;
+}

--- a/source/components/SearchButton.css
+++ b/source/components/SearchButton.css
@@ -9,3 +9,7 @@
 	display: flex;
 	justify-content: flex-end;
 }
+
+#searchButton #overlayContent {
+	height: 26em;
+}

--- a/source/components/SearchButton.js
+++ b/source/components/SearchButton.js
@@ -6,16 +6,33 @@ import withColours from 'Components/withColours'
 
 @withColours
 export default class SearchButton extends Component {
+	componentDidMount() {
+		// removeEventListener will need the exact same function instance
+		this.boundHandleKeyDown = this.handleKeyDown.bind(this)
+
+		window.addEventListener('keydown', this.boundHandleKeyDown)
+	}
+	handleKeyDown(e) {
+		if (!(e.ctrlKey && e.key === 'p')) return
+		this.setState({ visible: true })
+		e.preventDefault()
+		e.stopPropagation()
+		return false
+	}
+	componentWillUnmount() {
+		window.removeEventListener('keydown', this.boundHandleKeyDown)
+	}
 	state = {
 		visible: false
 	}
+	close = () => this.setState({ visible: false })
 	render() {
 		return (
 			<div id="searchButton">
 				{this.state.visible ? (
-					<Overlay onOuterClick={() => this.setState({ visible: false })}>
+					<Overlay onOuterClick={this.close}>
 						<h2>Chercher une règle</h2>
-						<SearchBar showDefaultList={false} />
+						<SearchBar showDefaultList={false} finally={this.close} />
 					</Overlay>
 				) : (
 					<button onClick={() => this.setState({ visible: true })}>

--- a/source/components/SearchButton.js
+++ b/source/components/SearchButton.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import './SearchButton.css'
+import Overlay from './Overlay'
+import { SearchBar } from './pages/RulesList'
+import withColours from 'Components/withColours'
+
+@withColours
+export default class SearchButton extends Component {
+	state = {
+		visible: false
+	}
+	render() {
+		return (
+			<div id="searchButton">
+				{this.state.visible ? (
+					<Overlay onOuterClick={() => this.setState({ visible: false })}>
+						<h2>Chercher une règle</h2>
+						<SearchBar showDefaultList={false} />
+					</Overlay>
+				) : (
+					<button onClick={() => this.setState({ visible: true })}>
+						<i
+							style={{ color: this.props.colours.colour }}
+							className="fa fa-search"
+							aria-hidden="true"
+						/>
+					</button>
+				)}
+			</div>
+		)
+	}
+}

--- a/source/components/pages/Header.js
+++ b/source/components/pages/Header.js
@@ -19,7 +19,7 @@ export class Header extends Component {
 
 	render() {
 		let { location } = this.props
-		let appMode = ['/simu', '/regle'].find(t => location.pathname.includes(t))
+		let appMode = ['/simu', '/règle'].find(t => location.pathname.includes(t))
 		if (this.props.iframe)
 			return screenfull.enabled ? (
 				<div
@@ -88,7 +88,7 @@ let Links = ({ toggle }) => (
 		<Link className="menu-item" to="/contribuer">
 			Contribuer
 		</Link>
-		<Link className="menu-item" to="/regles">
+		<Link className="menu-item" to="/règles">
 			Toutes nos règles
 		</Link>
 		<Link className="menu-item" to="/à-propos">

--- a/source/components/pages/RulesList.css
+++ b/source/components/pages/RulesList.css
@@ -1,4 +1,8 @@
 #RulesList ul {
-	margin: 0 auto;
+	margin: 1em auto;
 	max-width: 860px;
+	padding: 0;
+}
+#RulesList li {
+	list-style: none;
 }

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -8,6 +8,7 @@ import Select from 'react-select'
 import 'react-select/dist/react-select.css'
 import Fuse from 'fuse.js'
 import { Redirect } from 'react-router-dom'
+import Highlighter from 'react-highlight-words'
 
 export default class RulesList extends Component {
 	render() {
@@ -41,37 +42,51 @@ class SearchBar extends React.Component {
 		this.fuse = new Fuse(rules, options)
 	}
 	state = {
-		selectedOption: null
+		selectedOption: null,
+		inputValue: null
 	}
 	handleChange = selectedOption => {
 		this.setState({ selectedOption })
 	}
-
+	renderOption = option => (
+		<Highlighter
+			searchWords={[this.state.inputValue]}
+			textToHighlight={option.title}
+		/>
+	)
 	filterOptions = (options, filter) => this.fuse.search(filter)
 	render() {
 		let { selectedOption } = this.state
 
 		if (selectedOption != null)
 			return <Redirect to={'règle/' + selectedOption.dottedName} />
+
 		return (
-			<Select
-				name="form-field-name"
-				value={selectedOption && selectedOption.dottedName}
-				onChange={this.handleChange}
-				valueKey="dottedName"
-				labelKey="title"
-				filterOptions={this.filterOptions}
-			/>
+			<>
+				<Select
+					value={selectedOption && selectedOption.dottedName}
+					onChange={this.handleChange}
+					onInputChange={inputValue => this.setState({ inputValue })}
+					valueKey="dottedName"
+					labelKey="title"
+					options={rules}
+					filterOptions={this.filterOptions}
+					optionRenderer={this.renderOption}
+					searchPromptText="Entrez des mots clefs ici"
+					noResultsText="Nous n'avons rien trouvé..."
+				/>
+				{!this.state.inputValue && (
+					<ul>
+						{rules.map(rule => (
+							<li key={rule.dottedName}>
+								<Link to={'/règle/' + encodeRuleName(rule.name)}>
+									{capitalise0(rule.name)}
+								</Link>
+							</li>
+						))}
+					</ul>
+				)}
+			</>
 		)
 	}
 }
-
-// <ul>
-// 	{rules.map(rule => (
-// 		<li key={rule.name}>
-// 			<Link to={'/règle/' + encodeRuleName(rule.name)}>
-// 				{capitalise0(rule.name)}
-// 			</Link>
-// 		</li>
-// 	))}
-// </ul>

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -15,13 +15,13 @@ export default class RulesList extends Component {
 		return (
 			<div id="RulesList" className="page">
 				<h1>Explorez notre base de règles</h1>
-				<SearchBar rules={rules} />
+				<SearchBar showDefaultList={true} rules={rules} />
 			</div>
 		)
 	}
 }
 
-class SearchBar extends React.Component {
+export class SearchBar extends React.Component {
 	componentWillMount() {
 		var options = {
 			keys: [
@@ -60,7 +60,6 @@ class SearchBar extends React.Component {
 
 		if (selectedOption != null)
 			return <Redirect to={'règle/' + selectedOption.dottedName} />
-
 		return (
 			<>
 				<Select
@@ -72,20 +71,21 @@ class SearchBar extends React.Component {
 					options={rules}
 					filterOptions={this.filterOptions}
 					optionRenderer={this.renderOption}
-					searchPromptText="Entrez des mots clefs ici"
+					placeholder="Entrez des mots clefs ici"
 					noResultsText="Nous n'avons rien trouvé..."
 				/>
-				{!this.state.inputValue && (
-					<ul>
-						{rules.map(rule => (
-							<li key={rule.dottedName}>
-								<Link to={'/règle/' + encodeRuleName(rule.name)}>
-									{capitalise0(rule.name)}
-								</Link>
-							</li>
-						))}
-					</ul>
-				)}
+				{this.props.showDefaultList &&
+					!this.state.inputValue && (
+						<ul>
+							{rules.map(rule => (
+								<li key={rule.dottedName}>
+									<Link to={'/règle/' + encodeRuleName(rule.name)}>
+										{capitalise0(rule.name)}
+									</Link>
+								</li>
+							))}
+						</ul>
+					)}
 			</>
 		)
 	}

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -22,6 +22,9 @@ export default class RulesList extends Component {
 }
 
 export class SearchBar extends React.Component {
+	componentDidMount() {
+		this.inputElement.focus()
+	}
 	componentWillMount() {
 		var options = {
 			keys: [
@@ -58,8 +61,10 @@ export class SearchBar extends React.Component {
 	render() {
 		let { selectedOption } = this.state
 
-		if (selectedOption != null)
-			return <Redirect to={'règle/' + selectedOption.dottedName} />
+		if (selectedOption != null) {
+			this.props.finally()
+			return <Redirect to={'/règle/' + selectedOption.dottedName} />
+		}
 		return (
 			<>
 				<Select
@@ -73,6 +78,9 @@ export class SearchBar extends React.Component {
 					optionRenderer={this.renderOption}
 					placeholder="Entrez des mots clefs ici"
 					noResultsText="Nous n'avons rien trouvé..."
+					ref={el => {
+						this.inputElement = el
+					}}
 				/>
 				{this.props.showDefaultList &&
 					!this.state.inputValue && (

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -62,8 +62,10 @@ export class SearchBar extends React.Component {
 		let { selectedOption } = this.state
 
 		if (selectedOption != null) {
-			this.props.finally()
-			return <Redirect to={'/règle/' + selectedOption.dottedName} />
+			this.props.finally && this.props.finally()
+			return (
+				<Redirect to={'/règle/' + encodeRuleName(selectedOption.dottedName)} />
+			)
 		}
 		return (
 			<>

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -1,25 +1,77 @@
 import React, { Component } from 'react'
-import { rules, encodeRuleName, nameLeaf } from 'Engine/rules.js'
+import { rules, encodeRuleName } from 'Engine/rules.js'
 import { Link } from 'react-router-dom'
 import './RulesList.css'
 import './Pages.css'
 import { capitalise0 } from '../../utils'
+import Select from 'react-select'
+import 'react-select/dist/react-select.css'
+import Fuse from 'fuse.js'
+import { Redirect } from 'react-router-dom'
 
 export default class RulesList extends Component {
 	render() {
 		return (
 			<div id="RulesList" className="page">
-				<h1>Les règles aujourd'hui implémentées</h1>
-				<ul>
-					{rules.map(rule => (
-						<li key={rule.name}>
-							<Link to={'/règle/' + encodeRuleName(rule.name)}>
-								{capitalise0(rule.name)}
-							</Link>
-						</li>
-					))}
-				</ul>
+				<h1>Explorez notre base de règles</h1>
+				<SearchBar rules={rules} />
 			</div>
 		)
 	}
 }
+
+class SearchBar extends React.Component {
+	componentWillMount() {
+		var options = {
+			keys: [
+				{
+					name: 'title',
+					weight: 0.5
+				},
+				{
+					name: 'espace',
+					weight: 0.3
+				},
+				{
+					name: 'description',
+					weight: 0.2
+				}
+			]
+		}
+		this.fuse = new Fuse(rules, options)
+	}
+	state = {
+		selectedOption: null
+	}
+	handleChange = selectedOption => {
+		this.setState({ selectedOption })
+	}
+
+	filterOptions = (options, filter) => this.fuse.search(filter)
+	render() {
+		let { selectedOption } = this.state
+
+		if (selectedOption != null)
+			return <Redirect to={'règle/' + selectedOption.dottedName} />
+		return (
+			<Select
+				name="form-field-name"
+				value={selectedOption && selectedOption.dottedName}
+				onChange={this.handleChange}
+				valueKey="dottedName"
+				labelKey="title"
+				filterOptions={this.filterOptions}
+			/>
+		)
+	}
+}
+
+// <ul>
+// 	{rules.map(rule => (
+// 		<li key={rule.name}>
+// 			<Link to={'/règle/' + encodeRuleName(rule.name)}>
+// 				{capitalise0(rule.name)}
+// 			</Link>
+// 		</li>
+// 	))}
+// </ul>

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -13,7 +13,7 @@ export default class RulesList extends Component {
 				<ul>
 					{rules.map(rule => (
 						<li key={rule.name}>
-							<Link to={'/regle/' + encodeRuleName(rule.name)}>
+							<Link to={'/règle/' + encodeRuleName(rule.name)}>
 								{capitalise0(rule.name)}
 							</Link>
 						</li>

--- a/source/components/pages/RulesList.js
+++ b/source/components/pages/RulesList.js
@@ -9,6 +9,7 @@ import 'react-select/dist/react-select.css'
 import Fuse from 'fuse.js'
 import { Redirect } from 'react-router-dom'
 import Highlighter from 'react-highlight-words'
+import { pick } from 'ramda'
 
 export default class RulesList extends Component {
 	render() {
@@ -42,7 +43,10 @@ export class SearchBar extends React.Component {
 				}
 			]
 		}
-		this.fuse = new Fuse(rules, options)
+		this.fuse = new Fuse(
+			rules.map(pick(['title', 'espace', 'description', 'name', 'dottedName'])),
+			options
+		)
 	}
 	state = {
 		selectedOption: null,

--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -7,13 +7,12 @@ import { makeJsx } from 'Engine/evaluation'
 import './Algorithm.css'
 import { humanFigure } from '../../utils'
 
-let RuleWithoutFormula = () => [
+let RuleWithoutFormula = () => (
 	<p>
-		Cette règle n'a pas de formule de calcul pour l'instant (elle n'en aura même
-		peut-être jamais !)
-	</p>,
-	<p>Sa valeur doit donc être renseignée directement.</p>
-]
+		Cette règle n'a pas de formule de calcul pour l'instant. Sa valeur doit donc
+		être renseignée directement.
+	</p>
+)
 
 @AttachDictionary(knownMecanisms)
 export default class Algorithm extends React.Component {

--- a/source/components/rule/Rule.css
+++ b/source/components/rule/Rule.css
@@ -70,7 +70,7 @@
 	background: rgba(51, 51, 80, 0.03);
 	padding: 1em;
 	display: flex;
-	justify-content: center;
+	justify-content: flex-start;
 }
 #meta-content p {
 	/*border-left: 3px solid #333350;*/

--- a/source/components/rule/Rule.css
+++ b/source/components/rule/Rule.css
@@ -10,37 +10,48 @@
 	margin-top: 1.6em;
 }
 
+#meta-header {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+}
+#meta-header {
+	line-height: 3em;
+}
+
+#namespace {
+	padding: 0;
+}
+
+#namespace li {
+	display: inline;
+}
 
 #rule pre {
 	padding: 1em 2em;
 }
 
-.rule-type {
-	padding: 0 .5em;
-	margin: 0 auto;
-	width: 7em;
+.rule-type span {
+	padding: 0 1em;
+	margin: 0 1em;
 	text-align: center;
-	color: #4B4B66;
-	border: 2px solid #4B4B66;
+	color: #4b4b66;
+	border: 2px solid #4b4b66;
 	border-radius: 3px;
 	font-weight: 600;
 	text-transform: uppercase;
 }
 
 #rule h1 {
-	color: #4B4B66;
-	width: 100%;
-	text-align: center;
-	margin: 0;
-	padding: .2em 0;
-	border-bottom: 1px solid rgba(51, 51, 80, 0.2);
+	color: #4b4b66;
+	font-size: 200%;
 }
 
 #rule h2 {
 	font-size: 150%;
 	font-weight: 400;
 	border-bottom: 1px solid rgba(51, 51, 80, 0.15);
-	padding: 0.3em 0 .1em;
+	padding: 0.3em 0 0.1em;
 }
 
 #rule h2 small {
@@ -54,15 +65,14 @@
 	margin: 0;
 }
 
-
-
-#meta-paragraph {
+#meta-content {
+	border-top: 1px solid rgba(51, 51, 80, 0.2);
 	background: rgba(51, 51, 80, 0.03);
 	padding: 1em;
 	display: flex;
 	justify-content: center;
 }
-#meta-paragraph p {
+#meta-content p {
 	/*border-left: 3px solid #333350;*/
 	padding-left: 1em;
 	color: #444;
@@ -72,7 +82,7 @@
 #rule h3 {
 	font-size: 100%;
 	font-weight: 400;
-	margin: .4em 0;
+	margin: 0.4em 0;
 }
 
 #destinataire {
@@ -89,19 +99,19 @@
 }
 #destinataire img {
 	width: 100%;
-	opacity: .8;
+	opacity: 0.8;
 	display: block;
 }
 #destinataireName {
 	text-align: center;
 	font-size: 70%;
 	line-height: 1em;
-	margin-top: .3em;
+	margin-top: 0.3em;
 }
 #destinataire #calligraphy {
-	color: #5B5B73;
-	border: 2px solid #5B5B73;
-	border-radius: .4em;
+	color: #5b5b73;
+	border: 2px solid #5b5b73;
+	border-radius: 0.4em;
 	width: 130px;
 	line-height: 2em;
 	font-size: 130%;
@@ -114,7 +124,7 @@
 	color: white;
 	border: none;
 	font-size: 100%;
-	padding: .3em .6em;
+	padding: 0.3em 0.6em;
 	margin: 3em auto 0;
 	display: block;
 }

--- a/source/components/rule/Rule.css
+++ b/source/components/rule/Rule.css
@@ -7,7 +7,6 @@
 }
 
 #rule-meta {
-	margin-top: 1.6em;
 }
 
 #meta-header {

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -13,6 +13,8 @@ import { Link } from 'react-router-dom'
 import { findRuleByNamespace } from 'Engine/rules'
 import withColours from '../withColours'
 
+import SearchButton from 'Components/SearchButton'
+
 @connect(state => ({
 	form: state.form,
 	textColourOnWhite: state.themeColours.textColourOnWhite,
@@ -38,7 +40,7 @@ export default class Rule extends Component {
 					<title>{title}</title>
 					<meta name="description" content={description} />
 				</Helmet>
-
+				<SearchButton />
 				<RuleMeta
 					{...{
 						textColourOnWhite,

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -10,9 +10,11 @@ import Examples from './Examples'
 import Helmet from 'react-helmet'
 import { createMarkdownDiv } from 'Engine/marked'
 import Destinataire from './Destinataire'
+import { Link } from 'react-router-dom'
 
 @connect(state => ({
-	form: state.form
+	form: state.form,
+	textColourOnWhite: state.themeColours.textColourOnWhite
 }))
 export default class Rule extends Component {
 	state = {
@@ -20,11 +22,11 @@ export default class Rule extends Component {
 		showValues: true
 	}
 	render() {
-		let { form, rule } = this.props,
+		let { form, rule, textColourOnWhite } = this.props,
 			conversationStarted = !isEmpty(form),
 			situationExists = conversationStarted || this.state.example != null
 
-		let { type, name, title, description, question } = rule,
+		let { type, name, title, description, question, ns } = rule,
 			situationOrExampleRule = path(['example', 'rule'])(this.state) || rule
 
 		return (
@@ -35,10 +37,19 @@ export default class Rule extends Component {
 				</Helmet>
 
 				<section id="rule-meta">
-					<div className="rule-type">{type || 'Règle'}</div>
-					<h1>{capitalise0(name)}</h1>
-					<div id="meta-paragraph">
-						{createMarkdownDiv(description || question)}
+					<div id="meta-header">
+						<Namespace {...{ textColourOnWhite, ns }} />
+						<h1>{capitalise0(name)}</h1>
+					</div>
+					<div id="meta-content">
+						<div id="meta-paragraph">
+							{type && (
+								<span className="rule-type">
+									<span>{type}</span>
+								</span>
+							)}
+							{createMarkdownDiv(description || question)}
+						</div>
 						<Destinataire destinataire={path([type, 'destinataire'])(rule)} />
 					</div>
 				</section>
@@ -87,3 +98,26 @@ export default class Rule extends Component {
 			</div>
 		) : null
 }
+
+let Namespace = ({ ns, textColourOnWhite }) => (
+	<ul id="namespace">
+		{ns.split(' . ').map(fragment => (
+			<li key={fragment}>
+				<Link
+					style={{
+						color: textColourOnWhite,
+						textDecoration: 'underline'
+					}}
+					to={'/regle/' + fragment}
+				>
+					{capitalise0(fragment)}
+				</Link>
+				<i
+					style={{ margin: '0 .6em', fontSize: '85%' }}
+					className="fa fa-chevron-right"
+					aria-hidden="true"
+				/>
+			</li>
+		))}
+	</ul>
+)

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -10,14 +10,13 @@ import Helmet from 'react-helmet'
 import { createMarkdownDiv } from 'Engine/marked'
 import Destinataire from './Destinataire'
 import { Link } from 'react-router-dom'
-import { findRuleByNamespace } from 'Engine/rules'
+import { findRuleByNamespace, encodeRuleName } from 'Engine/rules'
 import withColours from '../withColours'
 
 import SearchButton from 'Components/SearchButton'
 
 @connect(state => ({
 	form: state.form,
-	textColourOnWhite: state.themeColours.textColourOnWhite,
 	rules: state.parsedRules
 }))
 export default class Rule extends Component {
@@ -26,7 +25,7 @@ export default class Rule extends Component {
 		showValues: true
 	}
 	render() {
-		let { form, rule, textColourOnWhite } = this.props,
+		let { form, rule } = this.props,
 			conversationStarted = !isEmpty(form),
 			situationExists = conversationStarted || this.state.example != null
 
@@ -43,7 +42,6 @@ export default class Rule extends Component {
 				<SearchButton />
 				<RuleMeta
 					{...{
-						textColourOnWhite,
 						ns,
 						type,
 						description,
@@ -103,7 +101,7 @@ let NamespaceRules = withColours(({ namespaceRules, rule, colours }) => (
 							color: colours.textColourOnWhite,
 							textDecoration: 'underline'
 						}}
-						to={'/règle/' + r.name}
+						to={'/règle/' + encodeRuleName(r.name)}
 					>
 						{r.name}
 					</Link>
@@ -113,18 +111,10 @@ let NamespaceRules = withColours(({ namespaceRules, rule, colours }) => (
 	</section>
 ))
 
-let RuleMeta = ({
-	textColourOnWhite,
-	ns,
-	type,
-	description,
-	question,
-	rule,
-	name
-}) => (
+let RuleMeta = ({ ns, type, description, question, rule, name }) => (
 	<section id="rule-meta">
 		<div id="meta-header">
-			{ns && <Namespace {...{ textColourOnWhite, ns }} />}
+			{ns && <Namespace {...{ ns }} />}
 			<h1>{capitalise0(name)}</h1>
 		</div>
 		<div id="meta-content">
@@ -141,16 +131,16 @@ let RuleMeta = ({
 	</section>
 )
 
-let Namespace = ({ ns, textColourOnWhite }) => (
+export let Namespace = withColours(({ ns, colours }) => (
 	<ul id="namespace">
 		{ns.split(' . ').map(fragment => (
 			<li key={fragment}>
 				<Link
 					style={{
-						color: textColourOnWhite,
+						color: colours.textColourOnWhite,
 						textDecoration: 'underline'
 					}}
-					to={'/règle/' + fragment}
+					to={'/règle/' + encodeRuleName(fragment)}
 				>
 					{capitalise0(fragment)}
 				</Link>
@@ -162,7 +152,7 @@ let Namespace = ({ ns, textColourOnWhite }) => (
 			</li>
 		))}
 	</ul>
-)
+))
 
 let ReportError = () => (
 	<button id="reportError">

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -26,7 +26,7 @@ export default ({
 				number
 			})}
 		>
-			<Link to={'/regle/' + encodeRuleName(name)}>
+			<Link to={'/règle/' + encodeRuleName(name)}>
 				<div className="rule-box">
 					<span className="rule-name">{title}</span>
 					<RuleValue

--- a/source/components/withColours.js
+++ b/source/components/withColours.js
@@ -1,0 +1,3 @@
+import { connect } from 'react-redux'
+export default component =>
+	connect(state => ({ colours: state.themeColours }))(component)

--- a/source/containers/Layout.css
+++ b/source/containers/Layout.css
@@ -39,3 +39,10 @@ h1 {
 	font-size: 100%;
 	font-weight: bold;
 }
+
+.centeredMessage {
+	color: #333350;
+	margin: 10% auto;
+	width: 20em;
+	textalign: center;
+}

--- a/source/containers/Layout.js
+++ b/source/containers/Layout.js
@@ -45,8 +45,15 @@ export default class Layout extends Component {
 					<Switch>
 						<Route exact path="/" component={Home} />
 						<Route path="/contact" component={Contact} />
-						<Route path="/regle/:name" component={RulePage} />
-						<Route path="/regles" component={RulesList} />
+						<Route path="/règle/:name" component={RulePage} />
+						{/* Redirect to be removed in March (Google should have understood...)*/}
+						<Route
+							path="/regle/:name"
+							render={({ match }) => (
+								<Redirect to={`/règle/${match.params.name}`} />
+							)}
+						/>
+						<Route path="/règles" component={RulesList} />
 						<Route path="/mecanismes" component={Mecanisms} />
 						<Redirect from="/simu/surcoût-CDD/intro" to="/" />
 						<Redirect from="/simu/surcoût-CDD" to="/" />

--- a/source/engine/mecanismViews/common.js
+++ b/source/engine/mecanismViews/common.js
@@ -49,7 +49,7 @@ export let Leaf = ({ classes, name, value }) => (
 	<span className={classNames(classes, 'leaf')}>
 		{name && (
 			<span className="nodeHead">
-				<Link to={'/regle/' + encodeRuleName(name)}>
+				<Link to={'/règle/' + encodeRuleName(name)}>
 					<span className="name">
 						{capitalise0(name)}
 						<NodeValuePointer data={value} />

--- a/source/engine/mecanismViews/common.js
+++ b/source/engine/mecanismViews/common.js
@@ -45,11 +45,11 @@ export class Node extends React.Component {
 }
 
 // Un élément du graphe de calcul qui a une valeur interprétée (à afficher)
-export let Leaf = ({ classes, name, value }) => (
+export let Leaf = ({ classes, dottedName, name, value }) => (
 	<span className={classNames(classes, 'leaf')}>
-		{name && (
+		{dottedName && (
 			<span className="nodeHead">
-				<Link to={'/règle/' + encodeRuleName(name)}>
+				<Link to={'/règle/' + encodeRuleName(dottedName)}>
 					<span className="name">
 						{capitalise0(name)}
 						<NodeValuePointer data={value} />

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -74,8 +74,10 @@ export let splitName = split(' . '),
 export let parentName = pipe(splitName, dropLast(1), joinName)
 export let nameLeaf = pipe(splitName, last)
 
-export let encodeRuleName = name => name.replace(/\s/g, '-')
-export let decodeRuleName = name => name.replace(/-/g, ' ')
+export let encodeRuleName = name =>
+	name.replace(/\s\.\s/g, '--').replace(/\s/g, '-')
+export let decodeRuleName = name =>
+	name.replace(/--/g, ' . ').replace(/-/g, ' ')
 
 /* Les variables peuvent être exprimées dans la formule d'une règle relativement à son propre espace de nom, pour une plus grande lisibilité. Cette fonction résoud cette ambiguité.
 */
@@ -120,8 +122,11 @@ export let rules = rawRules.map(rule =>
 /****************************************
  Méthodes de recherche d'une règle */
 
-export let findRuleByName = (allRules, search) =>
-	allRules.find(({ name }) => name === search)
+export let findRuleByName = (allRules, query) =>
+	allRules.find(({ name }) => name === query)
+
+export let findRulesByName = (allRules, query) =>
+	allRules.filter(({ name }) => name === query)
 
 export let searchRules = searchInput =>
 	rules

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -10,6 +10,7 @@ import {
 	join,
 	dropLast,
 	take,
+	propEq,
 	reduce,
 	when,
 	is,
@@ -137,6 +138,9 @@ export let searchRules = searchInput =>
 export let findRuleByDottedName = (allRules, dottedName) => {
 	return allRules.find(rule => rule.dottedName == dottedName)
 }
+
+export let findRuleByNamespace = (allRules, ns) =>
+	allRules.filter(propEq('ns', ns))
 
 /*********************************
  Autres */

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -183,7 +183,12 @@ let fillVariableNode = (rules, rule, filter) => parseResult => {
 		dottedName = disambiguateRuleReference(rules, rule, variablePartialName)
 
 	let jsx = nodeValue => (
-		<Leaf classes="variable" name={fragments.join(' . ')} value={nodeValue} />
+		<Leaf
+			classes="variable"
+			name={fragments.join(' . ')}
+			dottedName={dottedName}
+			value={nodeValue}
+		/>
 	)
 
 	return {

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -616,7 +616,12 @@ export let analyseMany = (parsedRules, targetNames) => situationGate => {
 	// setRule in Rule.js needs to get smarter and pass dottedName
 	let cache = {}
 
-	let parsedTargets = targetNames.map(t => findRuleByName(parsedRules, t)),
+	let parsedTargets = targetNames.map(
+			t =>
+				t.includes(' . ')
+					? findRuleByDottedName(parsedRules, t)
+					: findRuleByName(parsedRules, t)
+		),
 		targets = chain(pt => getTargets(pt, parsedRules), parsedTargets).map(t =>
 			evaluateNode(cache, situationGate, parsedRules, t)
 		)

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1,3 +1,6 @@
+- nom: contrat salarié
+  description: Le contrat qui lie une entreprise (via son établissement) à un individu, qui est alors son salarié.
+
 - espace: contrat salarié . CDD
   nom: CIF
   description: Contribution au financement du congé individuel de formation spécifique aux CDD.
@@ -860,6 +863,7 @@
 - espace: contrat salarié
   nom: régime alsace moselle
   par défaut: non
+
 - nom : entreprise
   description: |
     Le contrat lie une entreprise et un employé

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1,4 +1,3 @@
-
 - espace: contrat salarié . CDD
   nom: CIF
   description: Contribution au financement du congé individuel de formation spécifique aux CDD.

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1,5 +1,3 @@
-- nom: contrat salarié
-  description: Le contrat qui lie une entreprise (via son établissement) à un individu, qui est alors son salarié.
 
 - espace: contrat salarié . CDD
   nom: CIF
@@ -631,7 +629,7 @@
       contrat salarié . type de contrat: CDD
 - nom: contrat salarié
   description: |
-    Activité encadrée par un contrat de travail de droit privé.
+    Le contrat qui lie une entreprise (via son établissement) à un individu, qui est alors son salarié.
 
     Le contrat n'est en fait pas nécessaire dans le droit français, il est possible d'employer quelqu'un sans contrat par exemple dans ces cas:
       - particuliers employeurs : plus de 8 heures par semaine ou de plus de 4 semaines consécutives dans l'année.

--- a/source/server.js
+++ b/source/server.js
@@ -8,6 +8,7 @@ new WebpackDevServer(webpack(config), {
 	disableHostCheck: true,
 	publicPath: config.output.publicPath,
 	hot: true,
+	headers: { 'Access-Control-Allow-Origin': '*' }, //for hot reloading
 	historyApiFallback: true,
 	// It suppress error shown in console, so it has to be set to false.
 	quiet: false,

--- a/source/webpack.config.js
+++ b/source/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 		bundle: prodEnv
 			? ['@babel/polyfill', 'whatwg-fetch', './source/entry.js']
 			: [
-					'webpack-dev-server/client?http://localhost:3000/',
+					'webpack-dev-server/client?http://0.0.0.0:3000/',
 					'webpack/hot/only-dev-server',
 					'@babel/polyfill',
 					'react-hot-loader/patch',


### PR DESCRIPTION
Notre page règle avec les valeurs d'une simulation, c'est super... Mais pour naviguer, il faut cliquer séquentiellement sur les variables. 

- [x] On peut naviguer via l'espace de nom en en-tête de /règle/
- [x] On peut chercher une règle via /règles
- [x] On peut faire une recherche de règle via CTRL-P partout sur l'app (usage avancé) 
- [x] On peut faire une recherche via un clic 🔍 `rechercher` sur /règle/
- [x] Réutiliser pour ça le code de AttachDictionary. Il est spécifique au dictionnaire, en faire un overlay
- [x] Accepter les espaces de noms dans les url /règle/XXX
- [x] Effacer la deuxième règle factice CIF
- [ ] Réutiliser ce code pour améliorer la recherche AT/MP et villes 