### PR TITLE
:art: Alignement des saisies a droite

### DIFF
--- a/source/components/conversation/FormDecorator.js
+++ b/source/components/conversation/FormDecorator.js
@@ -123,30 +123,30 @@ export var FormDecorator = formType => RenderField =>
 							/>
 						)}
 					</div>
-					<fieldset>
+					<div className="fieldset">
 						<Field
 							component={RenderField}
 							name={fieldName}
 							{...stepProps}
 							themeColours={themeColours}
 						/>
-					</fieldset>
+					</div>
 				</div>
 			)
 		}
 
 		renderFolded() {
 			let {
-				stepAction,
-				situationGate,
-				themeColours,
-				title,
-				dottedName,
-				fieldName,
-				fieldTitle,
-				flatRules
-			} = this.props,
-			{ i18n } = this.context
+					stepAction,
+					situationGate,
+					themeColours,
+					title,
+					dottedName,
+					fieldName,
+					fieldTitle,
+					flatRules
+				} = this.props,
+				{ i18n } = this.context
 
 			let answer = situationGate(fieldName),
 				rule = findRuleByDottedName(flatRules, dottedName + ' . ' + answer),
@@ -156,9 +156,7 @@ export var FormDecorator = formType => RenderField =>
 				<div className="foldedQuestion">
 					<span className="borderWrapper">
 						<span className="title">{capitalise0(fieldTitle || title)}</span>
-						<span className="answer">
-						{translatedAnswer}
-						</span>
+						<span className="answer">{translatedAnswer}</span>
 					</span>
 					<button
 						className="edit"

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -64,10 +64,12 @@ export default class Question extends Component {
 		return (
 			<ul className="binaryQuestionList">
 				{choices.map(({ value, label }) => (
-					<RadioLabel
-						key={value}
-						{...{ value, label, input, submit, themeColours, setFormValue }}
-					/>
+					<li key={value}>
+						<RadioLabel
+							key={value}
+							{...{ value, label, input, submit, themeColours, setFormValue }}
+						/>
+					</li>
 				))}
 			</ul>
 		)

--- a/source/components/conversation/SendButton.js
+++ b/source/components/conversation/SendButton.js
@@ -7,7 +7,7 @@ import HoverDecorator from 'Components/HoverDecorator'
 export default class SendButton extends Component {
 	getAction() {
 		let { disabled, submit } = this.props
-		return (cause) => (!disabled ? submit(cause) : null)
+		return cause => (!disabled ? submit(cause) : null)
 	}
 	componentDidMount() {
 		// removeEventListener will need the exact same function instance
@@ -33,15 +33,15 @@ export default class SendButton extends Component {
 						color: themeColours.textColour,
 						background: themeColours.colour
 					}}
-					onClick={(event) => this.getAction()('accept')}
-				>
-					<span className="text"><Trans>valider</Trans></span>
+					onClick={event => this.getAction()('accept')}>
+					<span className="text">
+						<Trans>valider</Trans>
+					</span>
 					<i className="fa fa-check" aria-hidden="true" />
 				</button>
 				<span
 					className="keyIcon"
-					style={{ opacity: hover && !disabled ? 1 : 0 }}
-				>
+					style={{ opacity: hover && !disabled ? 1 : 0 }}>
 					<Trans>Entrée</Trans> ↵
 				</span>
 			</span>

--- a/source/components/conversation/conversation.css
+++ b/source/components/conversation/conversation.css
@@ -114,13 +114,19 @@
 	border: 1px solid #333;
 }
 
-.step fieldset {
+.step .fieldset {
 	margin: 0.8em 0;
+	display: flex;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	align-items: center;
 }
 
-.step fieldset ul {
+.step .fieldset ul {
 	list-style-type: none;
 	padding-left: 2em;
+	margin-right: 2em;
+	min-width: 20%;
 }
 
 .step.question .variant {
@@ -152,8 +158,6 @@
 	white-space: nowrap;
 }
 .step.question .variantLeaf {
-	display: flex;
-	justify-content: flex-end;
 	margin-bottom: 0.6em;
 }
 


### PR DESCRIPTION
Les radio qui n'ont pas de bouton de documentation (`<Explicable>`)
restent sur la même ligne, je ne sais pas pourquoi.

@johangirod je n'ai pas réussi à réaligner à gauche les radio d'un groupe comme "motifs classiques"