### PR TITLE
Refstate

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
 	"engines": {
 		"node": ">=8.10.0 <10.0.0"
 	},
-	"browserslist": ["> 1% in FR", "not ie < 11"],
+	"browserslist": [
+		"> 1% in FR",
+		"not ie < 11"
+	],
 	"dependencies": {
 		"@babel/core": "=7.0.0-beta.46",
 		"@babel/plugin-proposal-decorators": "=7.0.0-beta.46",
@@ -72,6 +75,9 @@
 		"react-virtualized-select": "^3.1.3",
 		"reduce-reducers": "^0.1.2",
 		"redux": "^3.7.2",
+		"redux-devtools": "^3.4.1",
+		"redux-devtools-dock-monitor": "^1.1.3",
+		"redux-devtools-log-monitor": "^1.4.0",
 		"redux-form": "^7.3.0",
 		"redux-persist": "^5.9.1",
 		"reselect": "^3.0.1",
@@ -86,29 +92,20 @@
 		"yaml-loader": "^0.5.0"
 	},
 	"scripts": {
-		"pretest":
-			"LIST=`git diff --name-only HEAD..HEAD^ | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi && flow check",
+		"pretest": "LIST=`git diff --name-only HEAD..HEAD^ | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi && flow check",
 		"start": "node source/server.js",
 		"externalize": "node source/externalize.js",
 		"prepare": "flow-typed install",
 		"compile": "webpack --config source/webpack.prod.js",
-		"test":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require test/helpers/browser.js  \"./{,!(node_modules)/**/}!(webpack).test.js\"",
-		"test-watch":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js \"test/**/*.test.js\" --watch",
-		"test-meca":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js test/mecanisms.test.js --watch",
-		"test-rules":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js test/real-rules.test.js --watch",
-		"test-inversions":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js \"test/inversion.test.js\" --watch",
-		"test-components":
-			"mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require test/helpers/browser.js \"source/components/**/*.test.js\" --watch",
+		"test": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require test/helpers/browser.js  \"./{,!(node_modules)/**/}!(webpack).test.js\"",
+		"test-watch": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js \"test/**/*.test.js\" --watch",
+		"test-meca": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js test/mecanisms.test.js --watch",
+		"test-rules": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js test/real-rules.test.js --watch",
+		"test-inversions": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --require test/helpers/browser.js \"test/inversion.test.js\" --watch",
+		"test-components": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require test/helpers/browser.js \"source/components/**/*.test.js\" --watch",
 		"heroku-postbuild": "yarn install --production=false && yarn compile",
-		"eslint":
-			"LIST=`git diff --cached --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
-		"eslint-check":
-			"eslint --print-config .eslintrc | eslint-config-prettier-check"
+		"eslint": "LIST=`git diff --cached --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
+		"eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check"
 	},
 	"devDependencies": {
 		"@babel/preset-flow": "^7.0.0-beta.47",

--- a/source/DevTools.js
+++ b/source/DevTools.js
@@ -1,0 +1,25 @@
+import React from 'react'
+
+// Exported from redux-devtools
+import { createDevTools } from 'redux-devtools'
+
+// Monitors are separate packages, and you can make a custom one
+import LogMonitor from 'redux-devtools-log-monitor'
+import DockMonitor from 'redux-devtools-dock-monitor'
+
+// createDevTools takes a monitor and produces a DevTools component
+const DevTools = createDevTools(
+	// Monitors are individually adjustable with props.
+	// Consult their repositories to learn about those props.
+	// Here, we put LogMonitor inside a DockMonitor.
+	// Note: DockMonitor is visible by default.
+	<DockMonitor
+		toggleVisibilityKey="ctrl-h"
+		changePositionKey="ctrl-q"
+		defaultPosition="right"
+		defaultIsVisible={false}>
+		<LogMonitor theme="tomorrow" />
+	</DockMonitor>
+)
+
+export default DevTools

--- a/source/components/conversation/Conversation.js
+++ b/source/components/conversation/Conversation.js
@@ -13,18 +13,7 @@ import './conversation.css'
 })
 @translate()
 @connect(
-	pick([
-		'currentQuestion',
-		'foldedSteps',
-		'themeColours',
-		'situationGate',
-		'targetNames',
-		'done',
-		'nextSteps',
-		'analysis',
-		'flatRules',
-		'conversationStarted'
-	])
+	pick(['currentQuestion', 'flatRules', 'targetNames', 'conversationStarted'])
 )
 export default class Conversation extends Component {
 	render() {

--- a/source/components/conversation/FoldedSteps.js
+++ b/source/components/conversation/FoldedSteps.js
@@ -11,22 +11,10 @@ import withColours from '../withColours'
 import { scroller, Element, animateScroll } from 'react-scroll'
 
 @withColours
-@connect(
-	pick([
-		'currentQuestion',
-		'foldedSteps',
-		'themeColours',
-		'situationGate',
-		'targetNames',
-		'nextSteps',
-		'analysis',
-		'flatRules'
-	]),
-	{
-		resetSimulation,
-		resetForm: () => reset('conversation')
-	}
-)
+@connect(pick(['foldedSteps', 'themeColours', 'targetNames', 'flatRules']), {
+	resetSimulation,
+	resetForm: () => reset('conversation')
+})
 @translate()
 export default class FoldedSteps extends Component {
 	handleSimulationReset = () => {

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -612,19 +612,6 @@ let evolveCond = (name, rule, rules) => value => {
 	}
 }
 
-export let getTargets = (target, rules) => {
-	let multiSimulation = path(['simulateur', 'objectifs'])(target)
-	let targets = multiSimulation
-		? // On a un simulateur qui définit une liste d'objectifs
-		  multiSimulation
-				.map(n => disambiguateRuleReference(rules, target, n))
-				.map(n => findRuleByDottedName(rules, n))
-		: // Sinon on est dans le cas d'une simple variable d'objectif
-		  [target]
-
-	return targets
-}
-
 export let parseAll = flatRules => {
 	let treatOne = rule => treatRuleRoot(flatRules, rule)
 	return map(treatOne, flatRules)
@@ -636,7 +623,7 @@ export let analyseMany = (parsedRules, targetNames) => situationGate => {
 	let cache = { parseLevel: 0 }
 
 	let parsedTargets = targetNames.map(t => findRule(parsedRules, t)),
-		targets = chain(pt => getTargets(pt, parsedRules), parsedTargets).map(t =>
+		targets = parsedTargets.map(t =>
 			evaluateNode(cache, situationGate, parsedRules, t)
 		)
 

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -160,7 +160,7 @@ let fillVariableNode = (rules, rule, filter) => parseResult => {
 			explanation,
 			missingVariables
 		)
-		return cache[cacheName]
+		return cacheName
 	}
 
 	let { fragments } = parseResult,

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -617,20 +617,21 @@ export let parseAll = flatRules => {
 	return map(treatOne, flatRules)
 }
 
-export let analyseMany = (parsedRules, targetNames) => situationGate => {
+// This function traverses the target rules evaluating them and they dependencies
+// it populates the values { dottedName => value } hash table return object
+// so that we have the AST (parsedRules) and the current variable values
+export let evaluateMany = (parsedRules, targetNames) => situationGate => {
 	// TODO: we should really make use of namespaces at this level, in particular
 	// setRule in Rule.js needs to get smarter and pass dottedName
-	let cache = { parseLevel: 0 }
+	let values = { parseLevel: 0 }
 
-	let parsedTargets = targetNames.map(t => findRule(parsedRules, t)),
-		targets = parsedTargets.map(t =>
-			evaluateNode(cache, situationGate, parsedRules, t)
-		)
+	let parsedTargets = targetNames.map(t => findRule(parsedRules, t))
 
-	// Don't use 'dict' for anything else than ResultsGrid
-	return { targets, cache }
+	parsedTargets.map(t => evaluateNode(values, situationGate, parsedRules, t))
+
+	return values
 }
 
-export let analyse = (parsedRules, target) => {
-	return analyseMany(parsedRules, [target])
+export let evaluate = (parsedRules, target) => {
+	return evaluateMany(parsedRules, [target])
 }

--- a/source/entry.js
+++ b/source/entry.js
@@ -13,6 +13,8 @@ import lang from './i18n'
 import debounceFormChangeActions from './middlewares/debounceFormChangeActions'
 import trackDomainActions from './middlewares/trackDomainActions'
 import reducers from './reducers/reducers'
+import DevTools from './DevTools'
+
 import {
 	persistSimulation,
 	retrievePersistedSimulation
@@ -49,7 +51,10 @@ let initialStore = {
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 let enhancer = composeEnhancers(
-	applyMiddleware(debounceFormChangeActions(), trackDomainActions(tracker))
+	applyMiddleware(debounceFormChangeActions(), trackDomainActions(tracker)),
+	process.env.NODE_ENV !== 'production'
+		? DevTools.instrument({ maxAge: 10 })
+		: x => x
 )
 
 let initialRules = lang == 'en' ? rules : rulesFr
@@ -59,7 +64,10 @@ persistSimulation(store)
 
 let App = ({ store }) => (
 	<Provider store={store}>
-		<Layout tracker={tracker} />
+		<>
+			<Layout tracker={tracker} />
+			{process.env.NODE_ENV !== 'production' && <DevTools />}
+		</>
 	</Provider>
 )
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -604,27 +604,6 @@
         compensation pour congés non pris: 39.6
       valeur attendue: 290
 
-# Cette variable est le point de départ du simulateur "surcout CDD" :-D
-- espace: contrat salarié . CDD
-  nom: surcoût CDD
-  simulateur:
-    objectifs:
-      - salaire net
-      - coût du travail
-      - CDD . surcoût
-    titre: Simulateur CDD
-    sous-titre: Découvrir le surcoût employeur du CDD par rapport au CDI
-    introduction:
-      notes:
-        - icône: fa-handshake-o
-          texte: Vous avez embauché ou vous réfléchissez à l'embauche d'un salarié en CDD.
-          titre: Votre situation
-        - icône: fa-balance-scale
-          texte: Votre contrat ne peut donc avoir ni pour objet ni pour effet de pourvoir durablement un emploi lié à l'activité normale et permanente de l'entreprise.
-          titre: Votre obligation
-        # CIF, majoration chômage, indemnité de fin de contrat, indemnité compensatrice des congés payés
-    hypothèses:
-      contrat salarié . type de contrat: CDD
 - nom: contrat salarié
   description: |
     Le contrat qui lie une entreprise (via son établissement) à un individu, qui est alors son salarié.
@@ -854,15 +833,6 @@
     somme:
       - CICE
       - CITS
-
-- espace: contrat salarié
-  nom: salaire
-  simulateur:
-    objectifs:
-      - salaire net
-      - coût du travail
-    titre: Simulateur de coût d'embauche
-    sous-titre: Découvrir le coût d'embauche et le salaire réel
 
 - espace: contrat salarié
   nom: jours de congés légaux

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,7 +1750,7 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+babel-runtime@6.x, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -1809,6 +1809,10 @@ balanced-match@^0.4.2:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base16@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
 
 base64-js@^1.0.2:
   version "1.3.0"
@@ -5411,6 +5415,10 @@ lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
+lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -5423,9 +5431,27 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.curry@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+
+lodash.debounce@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
+  dependencies:
+    lodash._getnative "^3.0.0"
+
+lodash.debounce@^4.0.4:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+
+lodash.flow@^3.3.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -6428,6 +6454,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-key@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/parse-key/-/parse-key-0.2.1.tgz#7bcf76595536e36075664be4d687e4bdd910208f"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -6912,7 +6942,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
   dependencies:
@@ -6975,6 +7005,10 @@ punycode@^1.2.4, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
+pure-color@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
 
 q@^1.1.2:
   version "1.5.1"
@@ -7101,6 +7135,15 @@ react-addons-css-transition-group@^15.6.2:
   dependencies:
     react-transition-group "^1.2.0"
 
+react-base16-styling@^0.5.1:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.5.3.tgz#3858f24e9c4dd8cbd3f702f3f74d581ca2917269"
+  dependencies:
+    base16 "^1.0.0"
+    lodash.curry "^4.0.1"
+    lodash.flow "^3.3.0"
+    pure-color "^1.2.0"
+
 react-color@^2.14.0:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.14.1.tgz#db8ad4f45d81e74896fc2e1c99508927c6d084e0"
@@ -7110,6 +7153,13 @@ react-color@^2.14.0:
     prop-types "^15.5.10"
     reactcss "^1.2.0"
     tinycolor2 "^1.4.1"
+
+react-dock@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/react-dock/-/react-dock-0.2.4.tgz#e727dc7550b3b73116635dcb9c0e04d0b7afe17c"
+  dependencies:
+    lodash.debounce "^3.1.1"
+    prop-types "^15.5.8"
 
 react-dom@^16.3.1:
   version "16.3.2"
@@ -7165,9 +7215,21 @@ react-is@^16.3.2:
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
 
+react-json-tree@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-json-tree/-/react-json-tree-0.11.0.tgz#f5b17e83329a9c76ae38be5c04fda3a7fd684a35"
+  dependencies:
+    babel-runtime "^6.6.1"
+    prop-types "^15.5.8"
+    react-base16-styling "^0.5.1"
+
 react-lifecycles-compat@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.2.tgz#7279047275bd727a912e25f734c0559527e84eff"
+
+react-pure-render@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-pure-render/-/react-pure-render-1.0.2.tgz#9d8a928c7f2c37513c2d064e57b3e3c356e9fabb"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -7429,6 +7491,47 @@ reduce-function-call@^1.0.1:
 reduce-reducers@^0.1.2:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.5.tgz#ff77ca8068ff41007319b8b4b91533c7e0e54576"
+
+redux-devtools-dock-monitor@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/redux-devtools-dock-monitor/-/redux-devtools-dock-monitor-1.1.3.tgz#1205e823c82536570aac8551a1c4b70972cba6aa"
+  dependencies:
+    babel-runtime "^6.2.0"
+    parse-key "^0.2.1"
+    prop-types "^15.5.8"
+    react-dock "^0.2.4"
+    react-pure-render "^1.0.2"
+
+redux-devtools-instrument@^1.0.1:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.3.tgz#c510d67ab4e5e4525acd6e410c25ab46b85aca7c"
+  dependencies:
+    lodash "^4.2.0"
+    symbol-observable "^1.0.2"
+
+redux-devtools-log-monitor@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/redux-devtools-log-monitor/-/redux-devtools-log-monitor-1.4.0.tgz#716b9580eda2a331cd359a36aa09e3a1602a854b"
+  dependencies:
+    lodash.debounce "^4.0.4"
+    prop-types "^15.0.0"
+    react-json-tree "^0.11.0"
+    react-pure-render "^1.0.2"
+    redux-devtools-themes "^1.0.0"
+
+redux-devtools-themes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redux-devtools-themes/-/redux-devtools-themes-1.0.0.tgz#c482dce3c5373976045f40134907d9dcb3ae3d5d"
+  dependencies:
+    base16 "^1.0.0"
+
+redux-devtools@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/redux-devtools/-/redux-devtools-3.4.1.tgz#09d342ce0ab6087be679e953a1d7c530efa1138e"
+  dependencies:
+    lodash "^4.2.0"
+    prop-types "^15.5.7"
+    redux-devtools-instrument "^1.0.1"
 
 redux-form@^7.3.0:
   version "7.3.0"
@@ -8367,7 +8470,7 @@ symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
 
-symbol-observable@^1.0.3:
+symbol-observable@^1.0.2, symbol-observable@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
Je continue l'idée de #196 : réduire notre state qui est beaaucoup trop gros.

Seul l'objet parsedRules a besoin d'être un arbre. Analysis.targets est inutile. Chaque élément du cache n'a besoin de contenir que l'arbre de ses mécanismes, pas l'arbre des variables dont il dépend mais une simple référence.

Dans ma compréhension, là où pour le moteur JS ce n'est pas vraiment un problème de performance car les objets ne sont pas copiés mais partagés, ça l'est clairement pour React / Redux / DevTools.

- [ ] Enlever aussi les fonctions d'évaluation du cache, elles n'ont rien à y faire
- [ ] Faire en sorte que ce soit l'évaluation de la variable qui cache sa valeur, pas l'évaluation de la variable dans le contexte de l'expression. Donc probablement nécessaire de réimplémenter le système de filtre, par exemple pour qu'un nouveau noeud "filteredExpressionVariable" aille chercher dans une variable cachée sa bonne composante
- [ ] Réduire le state au minimum : où on en est dans la simulation et les données du formulaire. Tous les calculs sont faits dans un sélecteur qui va cacher lui-même les calculs (recalculer seulement si une partie designée du state a changé).
- [ ] Supprimer ResultsGrid qui sera réécrite dans une nouvelle PR
- [ ] Adapter Rule.js, qui doivent maintenant potentiellement puiser dans le cache quand elles parcourent des variables
- [ ] Vérifier que les habituels ne sont pas cassés : inversion, missingVaribables
 