### PR TITLE
Salaire après impôts

### DIFF
--- a/source/components/BlueButton.css
+++ b/source/components/BlueButton.css
@@ -16,6 +16,18 @@
 
 	transition: background 0.3s;
 }
+@keyframes AnimatedGradient {
+	0% {
+		background-position: 0% 50%;
+	}
+	50% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0% 50%;
+	}
+}
+
 .blueButton:hover {
 	box-shadow: none;
 	opacity: 1;

--- a/source/components/BlueButton.js
+++ b/source/components/BlueButton.js
@@ -9,8 +9,14 @@ export default connect(state => ({
 		disabled={disabled}
 		onClick={onClick}
 		className="blueButton"
-		style={{ ...style, background: themeColours.colour }}
-	>
+		style={{
+			...style,
+			background: `linear-gradient(45deg, ${themeColours.darkerColour}, ${
+				themeColours.colour
+			})`,
+			animation: 'AnimatedGradient 6s ease infinite',
+			backgroundSize: '400% 400%'
+		}}>
 		{children}
 	</button>
 ))

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -97,11 +97,10 @@
 	font-weight: 700;
 	padding: 0;
 	padding: 0em 0.5em;
-	background: white;
+	background: rgba(255, 255, 255, 0);
 	border-radius: 0.2em;
-	border: none;
-	box-shadow: 0px 1px 9px 0px rgba(0, 0, 0, 0.45);
-	color: #333;
+	border: 2px solid white;
+	color: white;
 	font-size: inherit;
 }
 

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -1,5 +1,4 @@
 #targetsContainer {
-	padding: 0.5em;
 	border-radius: 0.6em;
 	box-shadow: 0px 0px 13px 3px rgba(0, 0, 0, 0.25);
 }
@@ -23,20 +22,17 @@
 }
 
 #targetSelection #targets {
-	margin: 0;
 	list-style: none;
-	/* For the checkbox that will appear */
-	padding: 0;
+	background: rgba(0, 0, 0, 0.1);
+	padding: 0 0.5em;
 }
 #targetSelection #targets > li:last-child {
 	margin-bottom: 0;
 }
 
 #targetSelection #targets > li {
-	margin-bottom: 0.5em;
-	background: rgba(0, 0, 0, 0.25);
-	padding: 0.4em 0.6em 0.4em;
-	border-radius: 0.3em;
+	padding: 0.6em;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.5);
 }
 #targetSelection #targets > li .main {
 	display: flex;

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -19,13 +19,13 @@ import { RuleValue } from './rule/RuleValueVignette'
 import './TargetSelection.css'
 import withLanguage from './withLanguage'
 
-let salaries = [
+export let displayedTargetNames = [
 	'contrat salarié . salaire . total',
 	'contrat salarié . salaire . brut de base',
-	'contrat salarié . salaire . net à payer'
+	'contrat salarié . salaire . net à payer',
+	'contrat salarié . salaire . net après impôts'
 ]
 
-let displayedTargetNames = [...salaries, 'contrat salarié . aides employeur']
 export let popularTargetNames = [
 	...displayedTargetNames,
 	'contrat salarié . salaire . net imposable'
@@ -224,7 +224,7 @@ class TargetValue extends Component {
 					}
 					setActiveInput(target.dottedName)
 				}}>
-				<RuleValue value={value} />
+				<RuleValue target={target} value={value} />
 			</span>
 		)
 	}

--- a/source/components/rule/RuleValueVignette.js
+++ b/source/components/rule/RuleValueVignette.js
@@ -43,7 +43,13 @@ export class RuleValue extends Component {
 				transitionLeaveTimeout={100}>
 				<span key={text} className="Rule-value">
 					{' '}
-					<span className={className}>{text}</span>
+					<span className={className}>
+						{this.props.target.title === 'Salaire chargé' ? (
+							<span>3542€ - 🎁 200€ </span>
+						) : (
+							<span>{text}</span>
+						)}
+					</span>
 				</span>
 			</ReactCSSTransitionGroup>
 		)

--- a/source/components/themeColours.js
+++ b/source/components/themeColours.js
@@ -10,6 +10,7 @@ export default forcedThemeColour => {
 		colour = forcedThemeColour || defaultColour,
 		lightColour = lightenColour(colour, 10),
 		darkColour = lightenColour(colour, -10),
+		darkerColour = lightenColour(colour, -20),
 		lightestColour = lightenColour(colour, 100),
 		darkestColour = lightenColour(colour, -100),
 		textColour = findContrastedTextColour(colour, true), // the 'simple' version feels better...
@@ -29,6 +30,7 @@ export default forcedThemeColour => {
 		textColourOnWhite,
 		lightColour,
 		darkColour,
+		darkerColour,
 		lightestColour,
 		darkestColour
 	}

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -685,6 +685,7 @@
       avec:
         - salaire . net à payer
         - salaire . total
+        - salaire . net après impôts
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
@@ -855,6 +856,17 @@
     C'est le montant que le salarié touche à la fin du mois.
   formule: salaire . net - avantages en nature . montant
 
+- espace: contrat salarié . salaire
+  nom: net après impôts
+  titre: Salaire net après impôts
+  résumé: Revenu disponible du salarié
+  question: Quel est le revenu net après impôts du salarié ?
+  type: salaire
+  format: euros
+  description: | 
+          Le salaire net après déduction de l'impôt neutre. C'est une bonne estimation du revenu disponible d'une personne en l'absence d'information sur sa famille et son patrimoine.
+  formule: net à payer - 500
+
 - espace: contrat salarié
   nom: coût du travail
   description: |
@@ -868,7 +880,7 @@
   nom: total
   titre: Salaire chargé
   question: Quel est le salaire mensuel chargé ?
-  résumé: Versé par l'employeur tous les mois
+  résumé: Versé par l'employeur 
   type: salaire
   description: |
     C'est le salaire brut, plus les cotisations patronales, moins les réductions de cotisations sociales.

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1,4 +1,5 @@
 - espace: contrat salarié . CDD
+  # yo
   nom: CIF
   description: Contribution au financement du congé individuel de formation spécifique aux CDD.
   cotisation:
@@ -867,7 +868,7 @@
   nom: total
   titre: Salaire chargé
   question: Quel est le salaire mensuel chargé ?
-  résumé: À verser par l'employeur tous les mois
+  résumé: Versé par l'employeur tous les mois
   type: salaire
   description: |
     C'est le salaire brut, plus les cotisations patronales, moins les réductions de cotisations sociales.


### PR DESCRIPTION
+ tentatives d'amélioration graphique de targetSelection 

- [ ] Implémenter correctement cette nouvelle vue du salaire chargé, ex. grâce à une nouvelle vue jsx "résumé" qui integrerait les emoji d'une formule
- [ ] mettre en deuxième plan les aides par rapport au montant sans aides
- [ ] vraiment implémenter l'impôt et bien documenter ses pages
- [ ] revoir le texte "net à payer" qui ne correspond plus
- [ ] expliquer la différence entre salaire à sortir tous les mois et salaire après réductions long terme
- [ ] Adapter la fiche de paie
