### PR TITLE
Différentiation de la base [réflexion]

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -1,0 +1,19 @@
+deep = require('deep-diff').diff
+
+yaml = require('js-yaml')
+fs = require('fs')
+
+var base1 = './source/règles/base.yaml'
+var base2 = './source/règles/base-originale.yaml'
+
+// Get document, or throw exception on error
+try {
+	var o1 = yaml.safeLoad(fs.readFileSync(base1, 'utf8'))
+	var o2 = yaml.safeLoad(fs.readFileSync(base2, 'utf8'))
+
+	var differences = deep(o1, o2)
+
+	console.log(differences)
+} catch (e) {
+	console.log(e)
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"classnames": "^2.2.5",
 		"dedent-js": "^1.0.1",
 		"deep-assign": "^2.0.0",
+		"deep-diff": "^0.3.8",
 		"flow": "^0.2.3",
 		"fuse.js": "^3.2.0",
 		"global": "^4.3.2",

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -9,6 +9,7 @@ main ->
 		| FilteredVariable {% id %}
 		| percentage {% id %}
 		| Comparison {% id %}
+		| Constant {% id %}
 
 Comparison -> Comparable _ ComparisonOperator _ Comparable {% d => ({
 	category: 'comparison',

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -264,7 +264,8 @@ let treat = (rules, rule) => rawNode => {
 					'filteredVariable',
 					'comparison',
 					'negatedVariable',
-					'percentage'
+					'percentage',
+					'value'
 				])
 			)
 				throw "Attention ! Erreur de traitement de l'expression : " + rawNode
@@ -282,8 +283,6 @@ let treat = (rules, rule) => rawNode => {
 					fillVariableNode(rules, rule)(parseResult.variable)
 				)
 
-			// We don't need to handle category == 'value' because YAML then returns it as
-			// numerical value, not a String: it goes to treatNumber
 			if (parseResult.category == 'percentage') {
 				return {
 					nodeValue: parseResult.nodeValue,
@@ -291,6 +290,14 @@ let treat = (rules, rule) => rawNode => {
 				}
 			}
 
+			// We don't need to handle a category == 'number' because YAML then returns it as
+			// numerical value, not a String: it goes to treatNumber
+			if (parseResult.category == 'value') {
+				return {
+					nodeValue: parseResult.nodeValue,
+					jsx: () => <span className="string">{parseResult.nodeValue}</span>
+				}
+			}
 			if (
 				parseResult.category == 'calcExpression' ||
 				parseResult.category == 'comparison'
@@ -483,7 +490,7 @@ export let treatRuleRoot = (rules, rule) => {
 						: anyNull([e['non applicable si'], e['applicable si']])
 							? null
 							: !val(e['non applicable si']) &&
-								undefOrTrue(val(e['applicable si']))
+							  undefOrTrue(val(e['applicable si']))
 			},
 			nodeValue = computeRuleValue(formuleValue, isApplicable)
 
@@ -506,7 +513,7 @@ export let treatRuleRoot = (rules, rule) => {
 						: [
 								...applyOrEmpty(collectNodeMissing)(notApplicable),
 								...applyOrEmpty(collectNodeMissing)(applicable)
-							],
+						  ],
 			collectInFormule = isApplicable !== false,
 			formMissing = applyOrEmpty(() =>
 				applyOrEmpty(collectNodeMissing)(formule)
@@ -605,11 +612,11 @@ export let getTargets = (target, rules) => {
 	let multiSimulation = path(['simulateur', 'objectifs'])(target)
 	let targets = multiSimulation
 		? // On a un simulateur qui définit une liste d'objectifs
-			multiSimulation
+		  multiSimulation
 				.map(n => disambiguateRuleReference(rules, target, n))
 				.map(n => findRuleByDottedName(rules, n))
 		: // Sinon on est dans le cas d'une simple variable d'objectif
-			[target]
+		  [target]
 
 	return targets
 }

--- a/source/règles/base-originale.yaml
+++ b/source/règles/base-originale.yaml
@@ -639,7 +639,12 @@
   nom: type de contrat
   titre: Type de contrat
   question: Quelle est la nature du contrat de travail ?
-  formule: CDI
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+      - CDI
+      - CDD
   par défaut: CDI
 
 - espace: contrat salarié . type de contrat
@@ -710,7 +715,6 @@
   question: Le salarié a-t-il le statut cadre ?
   description: Notion mal définie mais reconnue par les conventions collectives et déterminant l'appartenance à une caise de retraite de base spécifique
   par défaut: non
-  formule: oui
 
 - espace: contrat salarié
   nom: plafond sécurité sociale temps plein
@@ -967,7 +971,10 @@
       - assiette cotisations sociales > plafond cice
       - entreprise . association non lucrative
 
-  formule: 0
+  formule:
+    multiplication:
+      assiette: assiette cotisations sociales
+      taux: 6%
 
   exemples:
     - nom: SMIC
@@ -1116,7 +1123,11 @@
       - assiette cotisations sociales > plafond réduction générale
       - statut JEI
 
-  formule: 0
+  formule:
+    le minimum de:
+      - assiette réduction générale
+      # TODO - cette expression correspond algébriquement mais n'a pas de sens métier, que faire ?
+      - réduction générale constante - réduction générale variable
   exemples:
     - nom: "Maximale dans le cas d'un SMIC"
       situation:
@@ -1351,10 +1362,13 @@
   references:
     calcul: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31409
 
+#  non applicable si: assimilé salarié
 
-  formule: 0
-
-
+  formule:
+    multiplication:
+      assiette: assiette cotisations sociales
+      plafond: 4 * plafond sécurité sociale
+      taux: 0.15%
 - espace: contrat salarié
   nom: allocations familiales
   cotisation:
@@ -1379,7 +1393,10 @@
       - assiette cotisations sociales < plafond réduction allocations familiales
       - ≠ statut JEI
 
-  formule: 0
+  formule:
+    multiplication:
+      assiette: assiette cotisations sociales
+      taux: 1.8%
 
 - espace: contrat salarié
   nom: plafond réduction allocations familiales
@@ -1486,7 +1503,27 @@
     urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/lassurance-chomage-et-lags/les-taux.html
     changements 2017: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/contributions-patronales-dassura.html
 
-  formule: 0  
+  formule:
+    multiplication:
+      assiette: assiette cotisations sociales
+      plafond: 4 * plafond sécurité sociale
+
+      composantes:
+        - attributs:
+            dû par: employeur
+          taux: 4%
+
+        - attributs:
+            dû par: employeur
+            composante: contribution exceptionnelle temporaire
+          description: |
+            Instaurée le 1er octobre 2017, applicable jusqu’au 30 septembre 2020 au plus tard.
+          taux: 0.05%
+
+        - attributs:
+            dû par: salarié
+          taux: 0.95%
+
   exemples:
     - nom: SMIC
       situation:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -639,7 +639,7 @@
   nom: type de contrat
   titre: Type de contrat
   question: Quelle est la nature du contrat de travail ?
-  formule: CDI
+  formule: "'CDI'"
   par défaut: CDI
 
 - espace: contrat salarié . type de contrat
@@ -710,7 +710,7 @@
   question: Le salarié a-t-il le statut cadre ?
   description: Notion mal définie mais reconnue par les conventions collectives et déterminant l'appartenance à une caise de retraite de base spécifique
   par défaut: non
-  formule: oui
+  formule: "'oui'"
 
 - espace: contrat salarié
   nom: plafond sécurité sociale temps plein


### PR DESCRIPTION
POC de l'extension de la base par différenciation sur le sujet de l'assimilé salarié.

- [x] écraser la base avec les règles de l'assimilé salarié
- [x] tester `deep-diff`
- [ ] stocker non pas la base écrasée mais le diff + le cas d'application du diff (variable: valeur) dans github à la main
- [ ] recharger une version de la base dans l'UI en cliquant sur un bouton ou avec un paramètre dans l'URL

Questions ouvertes : 
- en termes d'UI, où proposer quelque chose comme l'interrupteur salarié / assimilé salarié, sur une nouvelle URL ?
- est-ce envisageable de générer des PR et d'y ajouter des commits ?
- de quoi doit-on discuter sur une PR, du diff ou de la base différenciée ?
- comment gérer l'extension d'extension ?

Exemples d'extensions intéressantes : 
- assimilé salarié
- traduction de la base 
- droit conventionnel
- temporelle (plus compliqué, car le date n'est ni un booléen ni un ensemble fini de catégories...)