### PR TITLE
Change la valeur par défaut du département et de la commune

### DIFF
--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1443,9 +1443,9 @@
   API: géo
   par défaut: 
     code: 29019
-    nom: Brest
+    nom: Non renseignée
     departement: 
-      nom: Finistère
+      nom: Non renseigné
 
 - espace: établissement . localisation
   nom: code commune


### PR DESCRIPTION
Pour éviter un défaut qui pourrait être incompréhensible pour les utilisateurs, on choisit d'avoir un département et une commune avec un nom par défaut "Non renseigné", tout en gardant le versement transport de Brest (ville de taille moyenne).

Pour le futur, on peut imaginer ajouter la prise en compte de la valeur "nulle" comme "Non renseignée", et modifier le moteur en conséquence