### PR TITLE
Améliore la pertinence des résultats pour l'auto-complétion des noms de commune

### DIFF
--- a/source/components/conversation/select/SelectGéo.js
+++ b/source/components/conversation/select/SelectGéo.js
@@ -9,7 +9,7 @@ let getOptions = input =>
 	input.length < 3
 		? Promise.resolve({ options: [] })
 		: fetch(
-				`https://geo.api.gouv.fr/communes?nom=${input}&fields=nom,code,departement,region&`
+				`https://geo.api.gouv.fr/communes?nom=${input}&fields=nom,code,departement,region&boost=population`
 		  )
 				.then(response => {
 					if (!response.ok)


### PR DESCRIPTION
L'ajout de l'option `boost=population` permet d'obtenir la pertinence naturel d'une auto-complétion de nom de commune, pondérée par population.