### PR TITLE
:bug: répare la supression de la sauvegarde

### DIFF
--- a/source/actions/actions.js
+++ b/source/actions/actions.js
@@ -5,6 +5,7 @@ import type {
 	DeletePreviousSimulationAction,
 	StartConversationAction
 } from 'Types/ActionsTypes'
+import { deletePersistedSimulation } from '../storage/persistSimulation'
 
 export function resetSimulation(): ResetSimulationAction {
 	return {
@@ -12,10 +13,13 @@ export function resetSimulation(): ResetSimulationAction {
 	}
 }
 
-export function deletePreviousSimulation(): DeletePreviousSimulationAction {
-	return {
+export const deletePreviousSimulation = () => (
+	dispatch: DeletePreviousSimulationAction => void
+) => {
+	dispatch({
 		type: 'DELETE_PREVIOUS_SIMULATION'
-	}
+	})
+	deletePersistedSimulation()
 }
 
 export function startConversation(question: ?string): StartConversationAction {

--- a/source/storage/persistSimulation.js
+++ b/source/storage/persistSimulation.js
@@ -25,3 +25,7 @@ export function retrievePersistedSimulation(): ?SavedSimulation {
 	const serializedState = window.localStorage.getItem(LOCAL_STORAGE_KEY)
 	return serializedState ? deserialize(serializedState) : null
 }
+
+export function deletePersistedSimulation(): void {
+	window.localStorage.removeItem(LOCAL_STORAGE_KEY)
+}


### PR DESCRIPTION
Lorsque l'on cliquait sur `supprimer` puis que l'on rechargeait la page, notre précédente simulation était toujours proposée. Dorénavant, elle est definitivement supprimée.
