### PR TITLE
:bug: répare l'autocomplete de selection de commune

### DIFF
--- a/source/components/conversation/select/SelectGéo.js
+++ b/source/components/conversation/select/SelectGéo.js
@@ -45,6 +45,10 @@ class Select extends Component {
 					optionRenderer={({ nom, departement }) =>
 						nom + ` (${departement?.nom})`
 					}
+					filterOptions={options => {
+						// Do no filtering, just return all options
+						return options
+					}}
 					placeholder="Entrez le nom de commune"
 					noResultsText="Nous n'avons trouvé aucune commune"
 					searchPromptText={null}


### PR DESCRIPTION
Dorénavant, on affiche directement les résultats de l'api, sans filtre. Ca permet d'avoir une recherche moins restrictive, notamment au niveau des noms de communes avec tiret (e.g. saint-denis)

Will fix #403 