### PR TITLE
Des assiettes pouvaient passer à travers le barème linéaire

### DIFF
--- a/source/engine/mecanismViews/BarèmeLinéaire.js
+++ b/source/engine/mecanismViews/BarèmeLinéaire.js
@@ -39,8 +39,9 @@ export default function BarèmeLinéaire(nodeValue, explanation) {
 										key={min || minOnly || 0}
 										style={{
 											fontWeight:
-												explanation.assiette.nodeValue > min &&
-												(!max || explanation.assiette.nodeValue < max)
+												Math.round(explanation.assiette.nodeValue) >= min &&
+												(!max ||
+													Math.round(explanation.assiette.nodeValue) <= max)
 													? ' bold'
 													: ''
 										}}>

--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -710,11 +710,12 @@ export let mecanismLinearScale = (recurse, k, v) => {
 	let effect = ({ assiette, tranches }) => {
 		if (val(assiette) === null) return null
 
+		let roundedAssiette = Math.round(val(assiette))
+
 		let matchedTranche = tranches.find(
-			({ de: min, à: max }) => val(assiette) >= min && val(assiette) < max
+			({ de: min, à: max }) => roundedAssiette >= min && roundedAssiette <= max
 		)
 
-		if (!matchedTranche) return 0
 		return matchedTranche.taux.nodeValue * val(assiette)
 	}
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -977,7 +977,8 @@
     barème linéaire:
       assiette: contrat salarié . rémunération . net imposable
       tranches:
-        - en-dessous de: 1568
+        - de: 0
+          à: 1568
           taux: 0%
 
         - de: 1569
@@ -1062,7 +1063,8 @@
     barème linéaire:
       assiette: contrat salarié . rémunération . net imposable
       tranches:
-        - en-dessous de: 1679
+        - de: 0
+          à: 1679
           taux: 0%
 
         - de: 1680
@@ -1146,7 +1148,8 @@
     barème linéaire:
       assiette: contrat salarié . rémunération . net imposable
       tranches:
-        - en-dessous de: 1367
+        - de: 0
+          à: 1367
           taux: 0%
 
         - de: 1368

--- a/test/mécanismes/barème-linéaire.yaml
+++ b/test/mécanismes/barème-linéaire.yaml
@@ -6,10 +6,11 @@
     barème linéaire:
       assiette: assiette
       tranches:
-      - en-dessous de: 1000
+      - de: 0
+        à: 999
         taux: 5%
       - de: 1000
-        à: 2000
+        à: 1999
         taux: 10%
       - au-dessus de: 2000
         taux: 15%
@@ -27,5 +28,12 @@
       situation:
         assiette: 10000
       valeur attendue: 1500
-
+    - nom: "pour choisir la tranche, l'assiette est arrondie au préalable"
+      situation:
+        assiette: 999.3
+      valeur attendue: 49.965
+    - nom: "pour choisir la tranche, l'assiette est arrondie au préalable (2)"
+      situation:
+        assiette: 999.6
+      valeur attendue: 99.96
 


### PR DESCRIPTION
:plate_with_cutlery: 
Ces problèmes de seuil sont indolores pour les barèmes marginaux, mais ne le sont pas du tout pour les barèmes linéaires, comme nous l'a fait remarquer un utilisateur. 