### PR TITLE
Alsace moselle

### DIFF
--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -63,7 +63,7 @@ Variable -> VariableFragment (_ Dot _ VariableFragment {% d => d[3] %}):*  {% d 
 	type: 'numeric | boolean'
 }) %}
 
-Constant -> "'" [ .'a-zA-Z\u00C0-\u017F ]:+ "'" {% d => ({
+Constant -> "'" [ .'a-zA-Z\-\u00C0-\u017F ]:+ "'" {% d => ({
 	category: 'value',
 	type: 'string',
 	nodeValue: d[1].join('')

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2431,10 +2431,10 @@
     multiplication:
       assiette: assiette cotisations sociales
       taux:
-        0.68%
-        # exception:
-        #   si: régime géographique = Alsace-Moselle
-        #   2016: 0.44%
+        variations: 
+          - si: régime alsace moselle
+            alors: 0.44%
+          - sinon: 0.68%
 
 - espace: contrat salarié
   nom: contribution supplémentaire à l'apprentissage

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2137,6 +2137,10 @@
 - espace: contrat salarié
   nom: régime alsace moselle
   titre: Régime Alsace-Moselle
+  description: |
+    Nous considérons qu'un salarié est affilié au régime Alsace-Moselle quand l'établissement dans lequel il travaille est situé dans ces départements. 
+    
+    Attention, c'est une **simplification** : l'affiliation est plus compliquée que celà, voir les conditions exactes [sur le site du régime](http://regime-local.fr/salaries/).
   applicable si: 
     une de ces conditions:
       - établissement . localisation . département = 'Bas-Rhin'

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -851,6 +851,7 @@
   formule:
     somme:
       - vieillesse (salarié)
+      - maladie (salarié)
       - ARRCO (salarié)
       - AGIRC (salarié)
       - GMP (salarié)
@@ -2316,7 +2317,6 @@
   nom: maladie
   cotisation:
     branche: santé
-    dû par: employeur
   description: Cotisations de la branche maladie
   références:
     fiche: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-maladie---maternit.html
@@ -2325,13 +2325,23 @@
     multiplication:
       assiette: assiette cotisations sociales
       composantes:
-        - attributs: # On va ici surcharger la Cotisation incomplète définie plus haut
+        - attributs:
             composante: maladie, maternité, invalidité, décès
+            dû par: employeur
           taux: 13%
+        - attributs: 
+            composante: maladie, maternité, invalidité, décès
+            dû par: salarié
+          taux:
+            variations: 
+              - si: régime alsace moselle
+                alors: 1.5%
+              - sinon: 0% 
 
         - attributs:
             composante: Contribution Solidarité Autonomie
             abbréviation: CSA
+            dû par: employeur
           références:
             - https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-contribution-solidarite-auton.html
             - https://www.service-public.fr/professionnels-entreprises/vosdroits/F32872

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1377,10 +1377,6 @@
   références:
     fiche: https://www.service-public.fr/particuliers/vosdroits/F2258
 
-- espace: contrat salarié
-  nom: régime alsace moselle
-  par défaut: non
-
 - nom: entreprise
   description: |
     Le contrat lie une entreprise, identifiée par un code SIREN, et un employé.
@@ -2107,21 +2103,56 @@
 - espace: contrat salarié
   nom: forfait complémentaire santé
   titre: Forfait de complémentaire santé entreprise
-  question: Quel est le montant mensuel total (salarié et employeur) de la complémentaire santé entreprise ?
   description: |
     L'employeur a l'obligation de proposer une offre de complémentaire santé. Il doit prendre en charge la moitié du montant,
     ce que nous avons retenu pour cette simulation, ou davantage. Le montant est libre, tant qu'elle couvre un panier légal de soins.
   références:
     les obligations de l'employeur: https://www.service-public.fr/professionnels-entreprises/vosdroits/F33754
+  formule: 
+    variations: 
+      - si: régime alsace moselle
+        alors: en alsace moselle
+      - sinon: en france
+  contrôles: 
+    - si: forfait complémentaire santé < 15
+      niveau: avertissement
+      message: Vérifiez bien qu'une complémentaire santé si peu chère couvre le panier de soin minimal défini dans la loi.
+
+- espace: contrat salarié . forfait complémentaire santé
+  nom: en alsace moselle
+  titre: forfait complémentaire santé en Alsace-Moselle
+  question: Quel est le montant mensuel total (salarié et employeur) de la complémentaire santé entreprise ?
+  description: |
+    Pour des raisons historiques, la couverture sociale santé des salariés d'Alsace-Moselle est plus forte. En conséquence, le prix des forfaits de complémentaire santé qui leur sont proposés sont inférieurs. 
+    Une étude de Meilleureassurance.com nous permet de supposer qu'il vaut en moyenne ~ 70% du prix moyen en France.
+  références: 
+    étude Meilleureassurance.com: http://www.lefigaro.fr/conjoncture/2018/10/16/20002-20181016ARTFIG00248-les-tarifs-des-complementaires-sante-font-le-grand-ecart-d-un-departement-a-l-autre.php
+  format: euros
+  par défaut: 30
+  suggestions:
+    basique: 30
+    élevé: 70
+
+- espace: contrat salarié
+  nom: régime alsace moselle
+  titre: Régime Alsace-Moselle
+  applicable si: 
+    une de ces conditions:
+      - établissement . localisation . département = 'Bas-Rhin'
+      - établissement . localisation . département = 'Haut-Rhin'
+      - établissement . localisation . département = 'Moselle'
+
+
+
+- espace: contrat salarié . forfait complémentaire santé
+  nom: en france
+  titre: forfait complémentaire santé en France
+  question: Quel est le montant mensuel total (salarié et employeur) de la complémentaire santé entreprise ?
   format: euros
   par défaut: 40
   suggestions:
     basique: 40
     élevé: 100
-  contrôles: 
-    - si: forfait complémentaire santé < 15
-      niveau: avertissement
-      message: Vérifiez bien qu'une complémentaire santé si peu chère couvre le panier de soin minimal défini dans la loi.
 
 - espace: contrat salarié
   nom: contribution au dialogue social

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2122,7 +2122,7 @@
 - espace: contrat salarié . forfait complémentaire santé
   nom: en alsace moselle
   titre: forfait complémentaire santé en Alsace-Moselle
-  question: Quel est le montant mensuel total (salarié et employeur) de la complémentaire santé entreprise ?
+  question: Quel est le montant mensuel total (salarié et employeur) de la complémentaire santé entreprise (régime Alsace-Moselle) ?
   description: |
     Pour des raisons historiques, la couverture sociale santé des salariés d'Alsace-Moselle est plus forte. En conséquence, le prix des forfaits de complémentaire santé qui leur sont proposés sont inférieurs. 
     Une étude de Meilleureassurance.com nous permet de supposer qu'il vaut en moyenne ~ 70% du prix moyen en France.

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -1077,32 +1077,32 @@ contrat salarié . chômage:
 contrat salarié . complémentaire santé:
   titre.en: Complementary health insurance
   titre.fr: complémentaire santé
-contrat salarié . forfait complémentaire santé:
+contrat salarié . forfait complémentaire santé . en alsace moselle:
   titre.en: Complementary health insurance plan
-  titre.fr: Forfait de complémentaire santé entreprise
   question.en: >-
     What is the total monthly amount (employee and employer) of the company's
     complementary health insurance ?
-  question.fr: >-
-    Quel est le montant mensuel total (salarié et employeur) de la
-    complémentaire santé entreprise ?
   description.en: >-
     The employer has the obligation to propose a complementary health insurance
     plan. More importantly, he has to take in charge at least half of the
     amount, which is the repartition we chose for this simulation, or more. The
     plan is free as long as it covers a legal care basket.
-  description.fr: >
-    L'employeur a l'obligation de proposer une offre de complémentaire santé. Il
-    doit prendre en charge la moitié du montant,
-
-    ce que nous avons retenu pour cette simulation, ou davantage. Le montant est
-    libre, tant qu'elle couvre un panier légal de soins.
   suggestions.en:
     basique: low
     élevé: high
-  suggestions.fr:
-    basique: 40
-    élevé: 100
+contrat salarié . forfait complémentaire santé . en france moselle:
+  titre.en: Complementary health insurance plan
+  question.en: >-
+    What is the total monthly amount (employee and employer) of the company's
+    complementary health insurance ?
+  description.en: >-
+    The employer has the obligation to propose a complementary health insurance
+    plan. More importantly, he has to take in charge at least half of the
+    amount, which is the repartition we chose for this simulation, or more. The
+    plan is free as long as it covers a legal care basket.
+  suggestions.en:
+    basique: low
+    élevé: high
 contrat salarié . contribution au dialogue social:
   description.en: >-
     Employers' contribution intended to supplement a joint fund dedicated to the

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -1077,29 +1077,30 @@ contrat salarié . chômage:
 contrat salarié . complémentaire santé:
   titre.en: Complementary health insurance
   titre.fr: complémentaire santé
-contrat salarié . forfait complémentaire santé . en alsace moselle:
-  titre.en: Complementary health insurance plan
-  question.en: >-
-    What is the total monthly amount (employee and employer) of the company's
-    complementary health insurance ?
+contrat salarié . forfait complémentaire santé: 
+  titre.en: Complementary health insurance package
   description.en: >-
     The employer has the obligation to propose a complementary health insurance
     plan. More importantly, he has to take in charge at least half of the
     amount, which is the repartition we chose for this simulation, or more. The
     plan is free as long as it covers a legal care basket.
+contrat salarié . forfait complémentaire santé . en alsace moselle:
+  titre.en: Complementary health insurance plan (Alsace-Moselle)
+  question.en: >-
+    What is the total monthly amount (employee and employer) of the company's
+    complementary health insurance (Alsace-Moselle) ?
+  description.en: |
+    For historical reasons, the social health coverage of the employees of the Alsace and Moselle historical regions is higher. As a result, the price of the complementary health insurance packages that private companies offer to them is lower.
+
+    A study by Meilleureassurance.com allows us to assume that it is worth on average ~ 70% of the average price in France. 
   suggestions.en:
     basique: low
     élevé: high
-contrat salarié . forfait complémentaire santé . en france moselle:
-  titre.en: Complementary health insurance plan
+contrat salarié . forfait complémentaire santé . en france:
+  titre.en: Complementary health insurance plan (France)
   question.en: >-
     What is the total monthly amount (employee and employer) of the company's
     complementary health insurance ?
-  description.en: >-
-    The employer has the obligation to propose a complementary health insurance
-    plan. More importantly, he has to take in charge at least half of the
-    amount, which is the repartition we chose for this simulation, or more. The
-    plan is free as long as it covers a legal care basket.
   suggestions.en:
     basique: low
     élevé: high


### PR DESCRIPTION
- [x] Il faudrait rendre les suggestions dynamiques en fonction de `régime alsace-moselle`. On résoud ça en dupliquant la question, c'est pas propre (mais ça marche).
- [x] Reste à bien traduire les 2 questions de la compl santé

Fixes #66 