### PR TITLE
Simplification des contrôles WIP

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,6 +43,8 @@ jobs:
         environment:
           ## this enables colors in the output
           TERM: xterm
+          EN_SITE: '${path}'
+          FR_SITE: '${path}'
           CYPRESS_baseUrl: http://localhost:5000
 
     steps:

--- a/cypress/.eslintrc.yaml
+++ b/cypress/.eslintrc.yaml
@@ -1,5 +1,4 @@
 globals:
   cy: false
   Cypress: false
-ecmaFeatures:
-  requireConfigFile: false
+parser: esprima

--- a/cypress/integration/mon-entreprise/navigation.js
+++ b/cypress/integration/mon-entreprise/navigation.js
@@ -1,0 +1,17 @@
+describe('Navigation', function() {
+	const fr = Cypress.env('language') === 'fr'
+	it('should enable switching site language', () => {
+		cy.visit(
+			fr
+				? '/entreprise/devenir-auto-entrepreneur'
+				: '/company/become-auto-entrepreneur'
+		)
+		cy.contains(fr ? 'Switch to English' : 'Passer en français').click()
+		cy.url().should(
+			'include',
+			fr
+				? '/company/become-auto-entrepreneur'
+				: '/entreprise/devenir-auto-entrepreneur'
+		)
+	})
+})

--- a/netlify.toml
+++ b/netlify.toml
@@ -133,3 +133,7 @@ status = 200
 [context.production.environment]
   EN_SITE = "https://mycompanyinfrance.fr${path}"
   FR_SITE = "https://mon-entreprise.fr${path}"
+
+[context.demo]
+  EN_SITE = "https://demo.mon-entreprise.fr${path}?s=m"
+  FR_SITE = "https://demo.mon-entreprise.fr${path}"

--- a/source/components/ComparativeTargets.js
+++ b/source/components/ComparativeTargets.js
@@ -18,7 +18,7 @@ import {
 } from 'Selectors/regleSelectors'
 import Animate from 'Ui/animate'
 import Montant from 'Ui/Montant'
-import { validInputEnteredSelector } from '../selectors/analyseSelectors'
+import { noUserInputSelector } from '../selectors/analyseSelectors'
 import './ComparativeTargets.css'
 import SchemeCard from './ui/SchemeCard'
 import type {
@@ -33,12 +33,12 @@ const connectRègles = (situationBranchName: string) =>
 		state => {
 			return ({
 				revenuDisponible:
-					validInputEnteredSelector(state) &&
+					!noUserInputSelector(state) &&
 					règleAvecMontantSelector(state, {
 						situationBranchName
 					})('revenu disponible'),
 				prélèvements:
-					validInputEnteredSelector(state) &&
+					!noUserInputSelector(state) &&
 					règleAvecValeurSelector(state, {
 						situationBranchName
 					})('ratio de prélèvements')

--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -1,32 +1,32 @@
 /* @flow */
-import { startConversation } from 'Actions/actions';
-import withLanguage from 'Components/utils/withLanguage';
-import { compose, toPairs } from 'ramda';
-import React from 'react';
-import { Trans } from 'react-i18next';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
-import { animated, Spring } from 'react-spring';
-import { validInputEnteredSelector } from 'Selectors/analyseSelectors';
+import { startConversation } from 'Actions/actions'
+import withLanguage from 'Components/utils/withLanguage'
+import { compose, toPairs } from 'ramda'
+import React from 'react'
+import { Trans } from 'react-i18next'
+import { connect } from 'react-redux'
+import { withRouter } from 'react-router'
+import { animated, Spring } from 'react-spring'
+import { noUserInputSelector } from 'Selectors/analyseSelectors'
 import type { Location } from 'react-router'
 
 type OwnProps = {
-	quickLinks: {[string]: string},
+	quickLinks: { [string]: string }
 }
 type Props = OwnProps & {
 	startConversation: (?string) => void,
 	location: Location,
-	validInputEntered: boolean,
+	userInput: boolean,
 	conversationStarted: boolean
 }
 
 const QuickLinks = ({
 	startConversation,
-	validInputEntered,
+	userInput,
 	quickLinks,
 	conversationStarted
 }: Props) => {
-	const show = validInputEntered && !conversationStarted
+	const show = userInput && !conversationStarted
 	return (
 		<Spring
 			to={{
@@ -67,7 +67,7 @@ export default (compose(
 	connect(
 		(state, props) => ({
 			key: props.language,
-			validInputEntered: validInputEnteredSelector(state),
+			userInput: !noUserInputSelector(state),
 			conversationStarted: state.conversationStarted,
 			quickLinks: state.simulation?.config["questions à l'affiche"]
 		}),

--- a/source/components/SalaryExplanation.js
+++ b/source/components/SalaryExplanation.js
@@ -1,14 +1,14 @@
-import { startConversation } from 'Actions/actions';
-import withTracker from 'Components/utils/withTracker';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { formValueSelector } from 'redux-form';
-import ficheDePaieSelectors from 'Selectors/ficheDePaieSelectors';
-import * as Animate from 'Ui/animate';
-import SalaryCompactExplanation from './SalaryCompactExplanation';
-import './SalaryCompactExplanation.css';
-import SalaryFirstExplanation from './SalaryFirstExplanation';
+import { startConversation } from 'Actions/actions'
+import withTracker from 'Components/utils/withTracker'
+import { compose } from 'ramda'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { formValueSelector } from 'redux-form'
+import ficheDePaieSelectors from 'Selectors/ficheDePaieSelectors'
+import * as Animate from 'Ui/animate'
+import SalaryCompactExplanation from './SalaryCompactExplanation'
+import './SalaryCompactExplanation.css'
+import SalaryFirstExplanation from './SalaryFirstExplanation'
 
 export default compose(
 	withTracker,

--- a/source/components/Simulation.js
+++ b/source/components/Simulation.js
@@ -1,12 +1,16 @@
-import { resetSimulation } from 'Actions/actions';
-import { React, T } from 'Components';
-import Answers from 'Components/AnswerList';
-import Conversation from 'Components/conversation/Conversation';
-import withColours from 'Components/utils/withColours';
-import { compose } from 'ramda';
-import { connect } from 'react-redux';
-import { blockingInputControlsSelector, nextStepsSelector, noUserInputSelector, validInputEnteredSelector } from 'Selectors/analyseSelectors';
-import Animate from 'Ui/animate';
+import { resetSimulation } from 'Actions/actions'
+import { React, T } from 'Components'
+import Answers from 'Components/AnswerList'
+import Conversation from 'Components/conversation/Conversation'
+import withColours from 'Components/utils/withColours'
+import { compose } from 'ramda'
+import { connect } from 'react-redux'
+import {
+	nextStepsSelector,
+	noUserInputSelector,
+	noUserInputSelector
+} from 'Selectors/analyseSelectors'
+import Animate from 'Ui/animate'
 
 export default compose(
 	withColours,
@@ -15,12 +19,9 @@ export default compose(
 			conversationStarted: state.conversationStarted,
 			previousAnswers: state.conversationSteps.foldedSteps,
 			noNextSteps:
-				state.conversationStarted &&
-				!blockingInputControlsSelector(state) &&
-				nextStepsSelector(state).length == 0,
+				state.conversationStarted && nextStepsSelector(state).length == 0,
 			noUserInput: noUserInputSelector(state),
-			blockingInputControls: blockingInputControlsSelector(state),
-			validInputEntered: validInputEnteredSelector(state)
+			userInput: !noUserInputSelector(state)
 		}),
 		{ resetSimulation }
 	)
@@ -36,14 +37,12 @@ export default compose(
 				noUserInput,
 				conversationStarted,
 				resetSimulation,
-				blockingInputControls,
 				showTargetsAnyway,
 				targetsTriggerConversation
 			} = this.props
 			let arePreviousAnswers = previousAnswers.length > 0,
 				displayConversation =
-					(!targetsTriggerConversation || conversationStarted) &&
-					!blockingInputControls,
+					!targetsTriggerConversation || conversationStarted,
 				showTargets =
 					targetsTriggerConversation || !noUserInput || showTargetsAnyway
 			return (

--- a/source/components/Simulation.js
+++ b/source/components/Simulation.js
@@ -7,7 +7,6 @@ import { compose } from 'ramda'
 import { connect } from 'react-redux'
 import {
 	nextStepsSelector,
-	noUserInputSelector,
 	noUserInputSelector
 } from 'Selectors/analyseSelectors'
 import Animate from 'Ui/animate'
@@ -20,8 +19,7 @@ export default compose(
 			previousAnswers: state.conversationSteps.foldedSteps,
 			noNextSteps:
 				state.conversationStarted && nextStepsSelector(state).length == 0,
-			noUserInput: noUserInputSelector(state),
-			userInput: !noUserInputSelector(state)
+			noUserInput: noUserInputSelector(state)
 		}),
 		{ resetSimulation }
 	)

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -15,7 +15,6 @@ import { Link } from 'react-router-dom'
 import { change, Field, formValueSelector, reduxForm } from 'redux-form'
 import {
 	analysisWithDefaultsSelector,
-	blockingInputControlsSelector,
 	flatRulesSelector,
 	nextStepsSelector,
 	noUserInputSelector
@@ -41,7 +40,6 @@ export default compose(
 			getTargetValue: dottedName =>
 				formValueSelector('conversation')(state, dottedName),
 			analysis: analysisWithDefaultsSelector(state),
-			blockingInputControls: blockingInputControlsSelector(state),
 			flatRules: flatRulesSelector(state),
 			progress:
 				(100 * (MAX_NUMBER_QUESTION - nextStepsSelector(state))) /
@@ -67,7 +65,9 @@ export default compose(
 				<div id="targetSelection">
 					<QuickLinks />
 					<Controls controls={analysis.controls} />
-					<div style={{height: '10px'}}><Progress percent={progress}/></div>
+					<div style={{ height: '10px' }}>
+						<Progress percent={progress} />
+					</div>
 					<section
 						className="ui__ plain card"
 						style={{
@@ -95,7 +95,6 @@ export default compose(
 					setActiveInput,
 					analysis,
 					noUserInput,
-					blockingInputControls,
 					match
 				} = this.props,
 				targets = analysis ? analysis.targets : []
@@ -111,8 +110,7 @@ export default compose(
 											match,
 											target,
 											conversationStarted,
-											isActiveInput: activeInput === target.dottedName,
-											blockingInputControls
+											isActiveInput: activeInput === target.dottedName
 										}}
 									/>
 									<TargetInputOrValue
@@ -122,8 +120,7 @@ export default compose(
 											activeInput,
 											setActiveInput,
 											setFormValue: this.props.setFormValue,
-											noUserInput,
-											blockingInputControls
+											noUserInput
 										}}
 									/>
 								</div>
@@ -179,15 +176,7 @@ let CurrencyField = withColours(props => {
 })
 
 let TargetInputOrValue = withLanguage(
-	({
-		target,
-		targets,
-		activeInput,
-		setActiveInput,
-		language,
-		noUserInput,
-		blockingInputControls
-	}) => (
+	({ target, targets, activeInput, setActiveInput, language, noUserInput }) => (
 		<span className="targetInputOrValue">
 			{activeInput === target.dottedName ? (
 				<Field
@@ -202,8 +191,7 @@ let TargetInputOrValue = withLanguage(
 						target,
 						activeInput,
 						setActiveInput,
-						noUserInput,
-						blockingInputControls
+						noUserInput
 					}}
 				/>
 			)}
@@ -219,7 +207,7 @@ const TargetValue = connect(
 )(
 	class TargetValue extends Component {
 		render() {
-			let { targets, target, noUserInput, blockingInputControls } = this.props
+			let { targets, target, noUserInput } = this.props
 
 			let targetWithValue =
 					targets && targets.find(propEq('dottedName', target.dottedName)),
@@ -229,8 +217,7 @@ const TargetValue = connect(
 				<div
 					className={classNames({
 						editable: target.question,
-						attractClick:
-							target.question && (noUserInput || blockingInputControls)
+						attractClick: target.question && noUserInput
 					})}
 					tabIndex="0"
 					onClick={this.showField(value)}

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -6,7 +6,7 @@ import withColours from 'Components/utils/withColours'
 import withLanguage from 'Components/utils/withLanguage'
 import withSitePaths from 'Components/utils/withSitePaths'
 import { encodeRuleName, findRuleByDottedName } from 'Engine/rules'
-import { compose, propEq } from 'ramda'
+import { compose, propEq, chain } from 'ramda'
 import React, { Component } from 'react'
 import { withTranslation } from 'react-i18next'
 import { connect } from 'react-redux'
@@ -64,7 +64,9 @@ export default compose(
 			return (
 				<div id="targetSelection">
 					<QuickLinks />
-					<Controls controls={analysis.controls} />
+					<Controls
+						controls={chain(({ contrôles }) => contrôles, analysis.cache)}
+					/>
 					<div style={{ height: '10px' }}>
 						<Progress percent={progress} />
 					</div>

--- a/source/components/utils/withSitePaths.js
+++ b/source/components/utils/withSitePaths.js
@@ -1,6 +1,6 @@
 /* @flow */
-
 import React, { Component, createContext } from 'react'
+import i18n from '../../i18n'
 
 const SitePathsContext: React$Context<SitePaths> = createContext({})
 
@@ -12,6 +12,13 @@ export default function withSitePaths<Props: { sitePaths: SitePaths }>(
 		$Diff<Props, { sitePaths: SitePaths }>
 	> {
 		displayName = `withSitePaths(${WrappedComponent.displayName || ''})`
+		constructor(props) {
+			super(props)
+			i18n.on('languageChanged', () => {
+				console.log('zop')
+				this.forceUpdate()
+			})
+		}
 		render() {
 			return (
 				<SitePathsContext.Consumer>

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -238,6 +238,10 @@ export let treatRuleRoot = (rules, rule) => {
 		contrôles: list =>
 			list.map(control => {
 				let testExpression = treat(rules, rule)(control.si)
+				if (!testExpression.explanation)
+					throw new Error(
+						'Ce contrôle ne semble pas être compris :' + control['si']
+					)
 
 				return {
 					dottedName: rule.dottedName,
@@ -249,42 +253,6 @@ export let treatRuleRoot = (rules, rule) => {
 				}
 			})
 	})(root)
-
-	let controls =
-		rule['contrôles'] &&
-		rule['contrôles'].map(control => {
-			let testExpression = treat(rules, rule)(control.si)
-			if (!testExpression.explanation)
-				throw new Error(
-					'Ce contrôle ne semble pas être compris :' + control['si']
-				)
-
-			let otherVariables = testExpression.explanation.filter(
-				node =>
-					node.category === 'variable' && node.dottedName !== rule.dottedName
-			)
-			let isInputControl = !otherVariables.length,
-				level = control['niveau']
-
-			if (level === 'bloquant' && !isInputControl) {
-				throw new Error(
-					`Un contrôle ne peut être bloquant et invoquer des calculs de variables :
-						${control['si']}
-						${level}
-						`
-				)
-			}
-
-			return {
-				dottedName: rule.dottedName,
-				level: control['niveau'],
-				test: control['si'],
-				message: control['message'],
-				testExpression,
-				solution: control['solution'],
-				isInputControl
-			}
-		})
 
 	return {
 		// Pas de propriété explanation et jsx ici car on est parti du (mauvais) principe que 'non applicable si' et 'formule' sont particuliers, alors qu'ils pourraient être rangé avec les autres mécanismes

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -166,6 +166,17 @@ export let treatRuleRoot = (rules, rule) => {
 			...node,
 			...evaluatedAttributes,
 			...{ formule: evaluatedFormula },
+			...{
+				contrôles: node.contrôles.map(control => ({
+					...control,
+					evaluated: evaluateNode(
+						cache,
+						situationGate,
+						parsedRules,
+						control.testExpression
+					)
+				}))
+			},
 			nodeValue,
 			isApplicable,
 			missingVariables

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -138,6 +138,11 @@ export let treatRuleRoot = (rules, rule) => {
 				nodeValue
 			} = evaluatedFormula
 
+		// if isApplicable === true
+		// evaluateControls
+		// attache them to the node for further usage
+		// do not output missingVariables for now
+
 		let condMissing =
 				isApplicable === false
 					? {}

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -217,15 +217,6 @@ let analysisValidatedOnlySelector = makeAnalysisSelector(
 	validatedSituationBranchesSelector
 )
 
-export let blockingInputControlsSelector = state => {
-	let analysis = analysisWithDefaultsSelector(state)
-	return analysis && analysis.blockingInputControls
-}
-
-export let validInputEnteredSelector = createSelector(
-	[noUserInputSelector, blockingInputControlsSelector],
-	(noUserInput, blockingInputControls) => !noUserInput && !blockingInputControls
-)
 // TODO this should really not be fired twice in a user session...
 //
 // TODO the just input salary should be in the situation so that it is not a missing variable

--- a/source/selectors/progressSelectors.js
+++ b/source/selectors/progressSelectors.js
@@ -1,7 +1,6 @@
 /* @flow */
 import { createSelector, createStructuredSelector } from 'reselect'
 import {
-	blockingInputControlsSelector,
 	nextStepsSelector,
 	noUserInputSelector
 } from 'Selectors/analyseSelectors'
@@ -45,10 +44,7 @@ const NUMBER_MAX_QUESTION_SIMULATION = 18
 const START_SIMULATION_COEFFICIENT = 0.15
 const QUESTIONS_COEFFICIENT = 0.85
 export const estimationProgressSelector = (state: any) => {
-	const userInputProgress = +(
-		!noUserInputSelector(state) &&
-		!softCatch(blockingInputControlsSelector)(state)
-	)
+	const userInputProgress = !noUserInputSelector(state)
 	const questionsProgress =
 		(state.conversationStarted &&
 			NUMBER_MAX_QUESTION_SIMULATION - nextStepsSelector(state).length) /

--- a/source/selectors/regleSelectors.js
+++ b/source/selectors/regleSelectors.js
@@ -72,6 +72,8 @@ export const règleValeurSelector: InputSelector<
 			(analysis.cache[dottedName] ||
 				analysis.targets.find(target => target.dottedName === dottedName))
 
+		if (rule == undefined) return null
+
 		let valeur =
 			rule && !isNil(rule.nodeValue)
 				? rule.nodeValue
@@ -103,6 +105,7 @@ export const règleValeurSelector: InputSelector<
 			(!Number.isNaN(valeur) && Number.isNaN(Number.parseFloat(valeur))
 				? 'string'
 				: 'number')
+
 		return {
 			type,
 			valeur:

--- a/source/sites/mycompanyinfrance.fr/layout/Footer/Footer.js
+++ b/source/sites/mycompanyinfrance.fr/layout/Footer/Footer.js
@@ -6,6 +6,7 @@ import withColours from 'Components/utils/withColours'
 import urssafSvg from 'Images/urssaf.svg'
 import { compose } from 'ramda'
 import React from 'react'
+import emoji from 'react-easy-emoji'
 import Helmet from 'react-helmet'
 import i18n from '../../../../i18n'
 import { feedbackBlacklist } from '../../config'
@@ -62,7 +63,7 @@ const Footer = ({ colours: { colour } }) => {
 						<LegalNotice />
 						{'  •  '}
 						<Privacy />
-						{/* {!!hrefLink.length && '  •  '}
+						{!!hrefLink.length && '  •  '}
 						{hrefLink.map(({ hrefLang, href }) => (
 							<a
 								href={href}
@@ -76,13 +77,11 @@ const Footer = ({ colours: { colour } }) => {
 									hrefLang
 								)}
 							</a>
-						))} */}
+						))}
 					</p>
 				</div>
 			</footer>
 		</div>
 	)
 }
-export default compose(
-	withColours,
-)(Footer)
+export default compose(withColours)(Footer)

--- a/source/sites/mycompanyinfrance.fr/layout/Footer/Footer.js
+++ b/source/sites/mycompanyinfrance.fr/layout/Footer/Footer.js
@@ -72,7 +72,7 @@ const Footer = ({ colours: { colour } }) => {
 								{hrefLang === 'fr' ? (
 									<> Passer en français {emoji('🇫🇷')}</>
 								) : hrefLang === 'en' ? (
-									<> Switch to english {emoji('🇬🇧')}</>
+									<> Switch to English {emoji('🇬🇧')}</>
 								) : (
 									hrefLang
 								)}

--- a/test/contrôles.test.js
+++ b/test/contrôles.test.js
@@ -49,31 +49,6 @@ describe('controls', function() {
 		rules = rawRules.map(enrichRule),
 		parsedRules = parseAll(rules)
 
-	it('Should parse blocking controls', function() {
-		let controls = parsedRules.find(r => r.controls).controls
-		expect(
-			controls.filter(
-				({ level, isInputControl }) => level == 'bloquant' && isInputControl
-			)
-		).to.have.lengthOf(2)
-	})
-
-	it('Should block the engine evaluation if blocking input controls trigger', function() {
-		let situationGate = dottedName => ({ brut: 400 }[dottedName]),
-			{ blockingInputControls } = analyseMany(parsedRules, ['net'])(
-				situationGate
-			)
-
-		expect(blockingInputControls).to.have.lengthOf(1)
-	})
-	it('Should not block the engine evaluation if no blocking input controls trigger', function() {
-		let situationGate = dottedName => ({ brut: 1200 }[dottedName]),
-			{ blockingInputControls } = analyseMany(parsedRules, ['net'])(
-				situationGate
-			)
-
-		expect(blockingInputControls).to.be.undefined
-	})
 	it('Should allow imbricated conditions', function() {
 		let situationGate = dottedName => ({ brut: 2000000 }[dottedName]),
 			{ controls } = analyseMany(parsedRules, ['net'])(situationGate)


### PR DESCRIPTION
Sur cette branche j'ai supprimé la notion de contrôle bloquant.

J'intègre l'évaluation des contrôles dans treatRuleRoot pour ne pas les évaluer si les variables sont désactivées car leur parent est un booléen faux, et éviter au passage des calculs inutiles en dehors de l'évaluation principale.


A rétablir : un if null return null dans règleSélector.

