### PR TITLE
Simplification des contrôles 

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"test-watch": "yarn test-common --watch",
 		"test-common": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require mock-local-storage --require test/helpers/browser.js \"./{,!(node_modules)/**/}!(webpack).test.js\"",
 		"test": "yarn test-common",
+		"test-one": "yarn mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require mock-local-storage --require test/helpers/browser.js",
 		"test-components": "mocha-webpack --webpack-config source/webpack.test.js --require source-map-support/register --include componentTestSetup.js --require mock-local-storage ---require test/helpers/browser.js \"source/components/**/*.test.js\" --watch",
 		"test-lib": "yarn test-common --grep 'library'",
 		"compile-lib": "yarn webpack --config source/webpack.lib.js",

--- a/source/components/ComparativeTargets.js
+++ b/source/components/ComparativeTargets.js
@@ -27,7 +27,7 @@ const connectRègles = (situationBranchName: string) =>
 						situationBranchName
 					})('revenu net')
 			}: {
-				revenuDisponible: RègleAvecMontant
+				revenuDisponible: boolean | RègleAvecMontant
 			})
 		},
 		{

--- a/source/components/ComparativeTargets.js
+++ b/source/components/ComparativeTargets.js
@@ -11,7 +11,7 @@ import { config } from 'react-spring'
 import { branchAnalyseSelector } from 'Selectors/analyseSelectors'
 import { règleAvecMontantSelector } from 'Selectors/regleSelectors'
 import Animate from 'Ui/animate'
-import { validInputEnteredSelector } from '../selectors/analyseSelectors'
+import { noUserInputSelector } from '../selectors/analyseSelectors'
 import './ComparativeTargets.css'
 import SchemeCard from './ui/SchemeCard'
 
@@ -22,7 +22,7 @@ const connectRègles = (situationBranchName: string) =>
 		state => {
 			return ({
 				revenuDisponible:
-					validInputEnteredSelector(state) &&
+					!noUserInputSelector(state) &&
 					règleAvecMontantSelector(state, {
 						situationBranchName
 					})('revenu net')

--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -7,7 +7,7 @@ import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import { animated, Spring } from 'react-spring'
-import { validInputEnteredSelector } from 'Selectors/analyseSelectors'
+import { noUserInputSelector } from 'Selectors/analyseSelectors'
 import type { Location } from 'react-router'
 
 type OwnProps = {
@@ -16,17 +16,17 @@ type OwnProps = {
 type Props = OwnProps & {
 	startConversation: (?string) => void,
 	location: Location,
-	validInputEntered: boolean,
+	userInput: boolean,
 	conversationStarted: boolean
 }
 
 const QuickLinks = ({
 	startConversation,
-	validInputEntered,
+	userInput,
 	quickLinks,
 	conversationStarted
 }: Props) => {
-	const show = validInputEntered && !conversationStarted
+	const show = userInput && !conversationStarted
 	return (
 		<Spring
 			to={{
@@ -67,7 +67,7 @@ export default (compose(
 	connect(
 		(state, props) => ({
 			key: props.language,
-			validInputEntered: validInputEnteredSelector(state),
+			userInput: !noUserInputSelector(state),
 			conversationStarted: state.conversationStarted,
 			quickLinks: state.simulation?.config["questions à l'affiche"]
 		}),

--- a/source/components/SalaryExplanation.js
+++ b/source/components/SalaryExplanation.js
@@ -1,14 +1,14 @@
-import { startConversation } from 'Actions/actions';
-import withTracker from 'Components/utils/withTracker';
-import { compose } from 'ramda';
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { formValueSelector } from 'redux-form';
-import ficheDePaieSelectors from 'Selectors/ficheDePaieSelectors';
-import * as Animate from 'Ui/animate';
-import SalaryCompactExplanation from './SalaryCompactExplanation';
-import './SalaryCompactExplanation.css';
-import SalaryFirstExplanation from './SalaryFirstExplanation';
+import { startConversation } from 'Actions/actions'
+import withTracker from 'Components/utils/withTracker'
+import { compose } from 'ramda'
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { formValueSelector } from 'redux-form'
+import ficheDePaieSelectors from 'Selectors/ficheDePaieSelectors'
+import * as Animate from 'Ui/animate'
+import SalaryCompactExplanation from './SalaryCompactExplanation'
+import './SalaryCompactExplanation.css'
+import SalaryFirstExplanation from './SalaryFirstExplanation'
 
 export default compose(
 	withTracker,

--- a/source/components/Simulation.js
+++ b/source/components/Simulation.js
@@ -10,10 +10,8 @@ import withColours from 'Components/utils/withColours'
 import { compose } from 'ramda'
 import { connect } from 'react-redux'
 import {
-	blockingInputControlsSelector,
 	nextStepsSelector,
-	noUserInputSelector,
-	validInputEnteredSelector
+	noUserInputSelector
 } from 'Selectors/analyseSelectors'
 import Animate from 'Ui/animate'
 
@@ -24,12 +22,8 @@ export default compose(
 			conversationStarted: state.conversationStarted,
 			previousAnswers: state.conversationSteps.foldedSteps,
 			noNextSteps:
-				state.conversationStarted &&
-				!blockingInputControlsSelector(state) &&
-				nextStepsSelector(state).length == 0,
-			noUserInput: noUserInputSelector(state),
-			blockingInputControls: blockingInputControlsSelector(state),
-			validInputEntered: validInputEnteredSelector(state)
+				state.conversationStarted && nextStepsSelector(state).length == 0,
+			noUserInput: noUserInputSelector(state)
 		}),
 		{ resetSimulation }
 	)
@@ -46,14 +40,12 @@ export default compose(
 				conversationStarted,
 				resetSimulation,
 				noFeedback,
-				blockingInputControls,
 				showTargetsAnyway,
 				targetsTriggerConversation
 			} = this.props
 			let arePreviousAnswers = previousAnswers.length > 0,
 				displayConversation =
-					(!targetsTriggerConversation || conversationStarted) &&
-					!blockingInputControls,
+					!targetsTriggerConversation || conversationStarted,
 				showTargets =
 					targetsTriggerConversation || !noUserInput || showTargetsAnyway
 			return (

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -58,14 +58,12 @@ export default compose(
 )(
 	class TargetSelection extends Component {
 		render() {
-			let { colours, analysis, progress } = this.props
+			let { colours, noUserInput, analysis, progress } = this.props
 
 			return (
 				<div id="targetSelection">
 					<QuickLinks />
-					<Controls
-						controls={chain(({ contrôles }) => contrôles, analysis.cache)}
-					/>
+					{!noUserInput && <Controls controls={analysis.controls} />}
 					<div style={{ height: '10px' }}>
 						<Progress percent={progress} />
 					</div>

--- a/source/engine/controls.js
+++ b/source/engine/controls.js
@@ -1,0 +1,25 @@
+import { evaluateNode } from 'Engine/evaluation'
+import { values, unnest, filter, map, pipe, path } from 'ramda'
+
+let getControls = path(['explanation', 'contrôles'])
+export let evaluateControls = (cache, situationGate, parsedRules) =>
+	pipe(
+		values,
+		filter(getControls),
+		map(rule =>
+			getControls(rule).map(
+				control =>
+					!rule.inactiveParent && {
+						...control,
+						evaluated: evaluateNode(
+							cache,
+							situationGate,
+							parsedRules,
+							control.testExpression
+						)
+					}
+			)
+		),
+		unnest,
+		filter(control => control.evaluated.nodeValue === true)
+	)(cache)

--- a/source/engine/traverse.js
+++ b/source/engine/traverse.js
@@ -244,7 +244,10 @@ export let treatRuleRoot = (rules, rule) => {
 		},
 		contrôles: map(control => {
 			let testExpression = treat(rules, rule)(control.si)
-			if (!testExpression.explanation)
+			if (
+				!testExpression.explanation &&
+				!(testExpression.category === 'variable')
+			)
 				throw new Error(
 					'Ce contrôle ne semble pas être compris :' + control['si']
 				)

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -127,6 +127,7 @@ export let treatVariableTransforms = (rules, rule) => parseResult => {
 		let nodeValue = filteredNode.nodeValue
 
 		// Temporal transformation
+		let supportedPeriods = ['mois', 'année', 'flexible']
 		if (nodeValue == null) return filteredNode
 		let ruleToTransform = findRuleByDottedName(
 			rules,
@@ -139,13 +140,15 @@ export let treatVariableTransforms = (rules, rule) => parseResult => {
 
 		// Exceptions
 		if (!rule.période && !inlinePeriodTransform) {
-			if (ruleToTransform.période)
+			if (supportedPeriods.includes(ruleToTransform.période))
 				throw new Error(
 					`Attention, une variable sans période, ${
 						rule.dottedName
 					}, qui appelle une variable à période, ${
 						ruleToTransform.dottedName
 					}, c'est suspect !
+
+					Si la période de la variable appelée est neutralisée dans la formule de calcul, par exemple un montant mensuel divisé par 30 (comprendre 30 jours), utilisez "période: aucune" pour taire cette erreur et rassurer tout le monde.
 				`
 				)
 

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -25,10 +25,11 @@ export let treatVariable = (rules, rule, filter) => parseResult => {
 				variable['non applicable si'] != null,
 			situationValue = getSituationValue(situation, dottedName, variable),
 			needsEvaluation =
-				situationValue == null &&
-				(variableHasCond ||
-					variableHasFormula ||
-					findParentDependency(rules, variable))
+				variable['contrôles'] ||
+				(situationValue == null &&
+					(variableHasCond ||
+						variableHasFormula ||
+						findParentDependency(rules, variable)))
 
 		//		if (dottedName.includes('jeune va')) debugger
 
@@ -160,6 +161,7 @@ export let treatVariableTransforms = (rules, rule) => parseResult => {
 			ruleToTransform.période === 'flexible'
 				? environmentPeriod
 				: ruleToTransform.période
+
 		let transformedNodeValue =
 				callingPeriod === 'mois' && calledPeriod === 'année'
 					? nodeValue / 12

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -25,11 +25,10 @@ export let treatVariable = (rules, rule, filter) => parseResult => {
 				variable['non applicable si'] != null,
 			situationValue = getSituationValue(situation, dottedName, variable),
 			needsEvaluation =
-				variable['contrôles'] ||
-				(situationValue == null &&
-					(variableHasCond ||
-						variableHasFormula ||
-						findParentDependency(rules, variable)))
+				situationValue == null &&
+				(variableHasCond ||
+					variableHasFormula ||
+					findParentDependency(rules, variable))
 
 		//		if (dottedName.includes('jeune va')) debugger
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -731,8 +731,6 @@
     salaire médian: 2300
     SMIC: 1522
   contrôles:
-    - si: brut de base [mensuel] < 50
-      niveau: bloquant
     - si:
         toutes ces conditions:
           - brut de base [mensuel] < SMIC [mensuel]
@@ -968,9 +966,6 @@
     Cette somme peut varier en fonction de décisions politiques (augmentation ou diminution des cotisations) alors que le salaire brut est contractuel (pour le changer, il faut signer un avenant au contrat).
   période: flexible
   formule: rémunération . net de cotisations - avantages en nature . montant
-  contrôles:
-    - si: net [mensuel] < 30
-      niveau: bloquant
 
 - espace: contrat salarié . salaire
   nom: net après impôt
@@ -992,9 +987,6 @@
     Explication de l'impôt à la source: https://www.economie.gouv.fr/prelevement-a-la-source
 
   formule: net - impôt . neutre
-  contrôles:
-    - si: net après impôt [mensuel] < 20
-      niveau: bloquant
 
 - espace: impôt . neutre
   nom: barème Guadeloupe Réunion Martinique
@@ -1332,9 +1324,6 @@
     Des [aides différées](/documentation/aides-employeur) peuvent venir diminuer ce montant.
 
   formule: rémunération . total sans réduction - réductions de cotisations
-  contrôles:
-    - si: total [mensuel] < 100
-      niveau: bloquant
 
 - espace: contrat salarié
   nom: réductions de cotisations
@@ -1409,9 +1398,6 @@
   période: flexible
   type: salaire
   formule: rémunération . total - aides employeur
-  contrôles:
-    - si: coût d'embauche [mensuel] < 100
-      niveau: bloquant
 
 - espace: contrat salarié
   nom: aides employeur

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -212,6 +212,7 @@
 - espace: contrat salarié . CDD . compensation pour congés non pris
   nom: salaire journalier
   unité: jour ouvré
+  période: aucune
   formule: assiette mensuelle / 21
   note: On retient 21 comme nombre de jours ouvrés moyens par mois
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -683,7 +683,7 @@
   question: Est-ce un contrat à durée déterminée (CDD) ?
   description: |
     Par défaut, faire travailler quelqu'un en France établit auutomatiquement un CDI à temps plein.
-    Certaines situations exceptionnelles permettent aux employeurs de prévoir une date de fin. Le contrat, qui est alors nécessaire, mentionne cette date d fin.
+    Certaines situations exceptionnelles permettent aux employeurs de prévoir une date de fin. Le contrat, qui est alors nécessaire, mentionne cette date de fin.
 
   par défaut: non
   # TODO: règle de type : il faut q'un motif et une durée soient sélectionnés pour qu'un contrat soit un CDD. Cela revient à dire que les variables CDD et motif sont obligatoires *dans le contexte* de leur attache
@@ -698,7 +698,7 @@
   #     Code du travail - Article L1242-1
   #
   contrôles:
-    - si: CDD = 'oui'
+    - si: CDD
       niveau: information
       message: |
         Rappelez-vous qu'un CDD doit toujours correspondre à un besoin temporaire de l'entreprise.
@@ -1968,9 +1968,10 @@
       - si: régime alsace moselle
         alors: en alsace moselle
       - sinon: en france
-        #  contrôles:
-        #    - si: complémentaire santé . forfait [mensuel] < 15
-        #      niveau: avertissement
+  contrôles:
+    - si: complémentaire santé . forfait [mensuel] < 15
+      message: Vérifiez bien qu'une complémentaire santé si peu chère couvre le panier de soin minimal défini dans la loi.
+      niveau: avertissement
 
 - espace: contrat salarié . complémentaire santé . forfait
   nom: en alsace moselle

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -217,15 +217,6 @@ let analysisValidatedOnlySelector = makeAnalysisSelector(
 	validatedSituationBranchesSelector
 )
 
-export let blockingInputControlsSelector = state => {
-	let analysis = analysisWithDefaultsSelector(state)
-	return analysis && analysis.blockingInputControls
-}
-
-export let validInputEnteredSelector = createSelector(
-	[noUserInputSelector, blockingInputControlsSelector],
-	(noUserInput, blockingInputControls) => !noUserInput && !blockingInputControls
-)
 // TODO this should really not be fired twice in a user session...
 //
 // TODO the just input salary should be in the situation so that it is not a missing variable

--- a/source/selectors/progressSelectors.js
+++ b/source/selectors/progressSelectors.js
@@ -1,7 +1,6 @@
 /* @flow */
 import { createSelector, createStructuredSelector } from 'reselect'
 import {
-	blockingInputControlsSelector,
 	nextStepsSelector,
 	noUserInputSelector
 } from 'Selectors/analyseSelectors'
@@ -45,10 +44,7 @@ const NUMBER_MAX_QUESTION_SIMULATION = 18
 const START_SIMULATION_COEFFICIENT = 0.15
 const QUESTIONS_COEFFICIENT = 0.85
 export const estimationProgressSelector = (state: any) => {
-	const userInputProgress = +(
-		!noUserInputSelector(state) &&
-		!softCatch(blockingInputControlsSelector)(state)
-	)
+	const userInputProgress = !noUserInputSelector(state)
 	const questionsProgress =
 		(state.conversationStarted &&
 			NUMBER_MAX_QUESTION_SIMULATION - nextStepsSelector(state).length) /

--- a/source/selectors/regleSelectors.js
+++ b/source/selectors/regleSelectors.js
@@ -7,7 +7,7 @@ import { createSelector } from 'reselect'
 import {
 	branchAnalyseSelector,
 	flatRulesSelector,
-	validatedSituationBranchesSelector
+	situationsWithDefaultsSelector
 } from './analyseSelectors'
 import type { FlatRules } from 'Types/State'
 import type {
@@ -57,7 +57,7 @@ export const règleValeurSelector: InputSelector<
 	(dottedName: string) => RègleValeur
 > = createSelector(
 	branchAnalyseSelector,
-	validatedSituationBranchesSelector,
+	situationsWithDefaultsSelector,
 	règleLocaliséeSelector,
 	(analysis: Analysis, situation, règleLocalisée: string => Règle) => (
 		dottedName: string
@@ -71,8 +71,6 @@ export const règleValeurSelector: InputSelector<
 			!Array.isArray(analysis) && // It's an array if we're in a comparative simulation.
 			(analysis.cache[dottedName] ||
 				analysis.targets.find(target => target.dottedName === dottedName))
-
-		if (rule == undefined) return null
 
 		let valeur =
 			rule && !isNil(rule.nodeValue)

--- a/source/selectors/regleSelectors.js
+++ b/source/selectors/regleSelectors.js
@@ -72,6 +72,8 @@ export const règleValeurSelector: InputSelector<
 			(analysis.cache[dottedName] ||
 				analysis.targets.find(target => target.dottedName === dottedName))
 
+		if (rule == undefined) return null
+
 		let valeur =
 			rule && !isNil(rule.nodeValue)
 				? rule.nodeValue
@@ -103,6 +105,7 @@ export const règleValeurSelector: InputSelector<
 			(!Number.isNaN(valeur) && Number.isNaN(Number.parseFloat(valeur))
 				? 'string'
 				: 'number')
+
 		return {
 			type,
 			valeur:

--- a/test/contrôles.test.js
+++ b/test/contrôles.test.js
@@ -58,13 +58,29 @@ describe('controls', function() {
 	})
 
 	it('Should allow imbricated conditions', function() {
-		let situationGate = dottedName => ({ brut: 2000000 }[dottedName]),
-			cache = analyseMany(parsedRules, ['net'])(situationGate).cache,
-			controls = chain(prop('contrôles'), values(cache))
-
+		let controls = analyseMany(parsedRules, ['net'])(
+			dottedName => ({ brut: 2000000 }[dottedName])
+		).controls
 		expect(
 			controls.find(
 				({ message }) => message === 'Vous êtes un contribuable hors-pair !'
+			)
+		).to.exist
+
+		let controls2 = analyseMany(parsedRules, ['net'])(
+			dottedName => ({ brut: 100001 }[dottedName])
+		).controls
+		expect(controls2.find(({ message }) => message === 'Oulah ! Oulah !')).to
+			.exist
+
+		let controls3 = analyseMany(parsedRules, ['net'])(
+			dottedName => ({ brut: 100 }[dottedName])
+		).controls
+		expect(
+			controls3.find(
+				({ message }) =>
+					message ===
+					'Malheureux, je crois que vous vous êtes trompé dans votre saisie.'
 			)
 		).to.exist
 	})

--- a/test/contrôles.test.js
+++ b/test/contrôles.test.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { enrichRule } from '../source/engine/rules'
 import { analyseMany, parseAll } from '../source/engine/traverse'
+import { chain, values, prop } from 'ramda'
 
 describe('controls', function() {
 	let rawRules = [
@@ -50,33 +51,16 @@ describe('controls', function() {
 		parsedRules = parseAll(rules)
 
 	it('Should parse blocking controls', function() {
-		let controls = parsedRules.find(r => r.controls).controls
+		let controls = parsedRules.find(r => r.contrôles).contrôles
 		expect(
-			controls.filter(
-				({ level, isInputControl }) => level == 'bloquant' && isInputControl
-			)
+			controls.filter(({ level }) => level == 'bloquant')
 		).to.have.lengthOf(2)
 	})
 
-	it('Should block the engine evaluation if blocking input controls trigger', function() {
-		let situationGate = dottedName => ({ brut: 400 }[dottedName]),
-			{ blockingInputControls } = analyseMany(parsedRules, ['net'])(
-				situationGate
-			)
-
-		expect(blockingInputControls).to.have.lengthOf(1)
-	})
-	it('Should not block the engine evaluation if no blocking input controls trigger', function() {
-		let situationGate = dottedName => ({ brut: 1200 }[dottedName]),
-			{ blockingInputControls } = analyseMany(parsedRules, ['net'])(
-				situationGate
-			)
-
-		expect(blockingInputControls).to.be.undefined
-	})
 	it('Should allow imbricated conditions', function() {
 		let situationGate = dottedName => ({ brut: 2000000 }[dottedName]),
-			{ controls } = analyseMany(parsedRules, ['net'])(situationGate)
+			cache = analyseMany(parsedRules, ['net'])(situationGate).cache,
+			controls = chain(prop('contrôles'), values(cache))
 
 		expect(
 			controls.find(


### PR DESCRIPTION
Sur cette branche j'ai supprimé la notion de contrôle bloquant.
On évite ainsi de devoir faire des calculs en amont de l'évaluation principale. 
S'il faut réintroduire les des bloquants, ce sera dans l'UI.

A rétablir : un if null return null dans règleSélector.

