### PR TITLE
Corrections indeps semaine du 20 mars

### DIFF
--- a/source/components/Controls.css
+++ b/source/components/Controls.css
@@ -3,7 +3,7 @@
 	font-size: 150%;
 }
 
-#controlsBlock ul {
+#controlsBlock > ul {
 	list-style: none;
 	padding: 0;
 }
@@ -11,18 +11,22 @@
 	margin: 1em 0;
 	display: flex;
 	align-items: center;
-
-	border-radius: 0.3em;
-
+}
+#controlsBlock .controlText {
+	width: 100%;
+	padding: 1rem 2.6rem 1rem 1.6rem;
 	/*For the .hide element */
 	position: relative;
 }
-#controlsBlock .controlText {
-	display: flex;
-	padding: 0.4rem;
-}
 #controlsBlock .controlText p {
 	margin: 0;
+}
+
+.controlText .hide {
+	position: absolute;
+	top: 0rem;
+	right: -1.4rem;
+	font-size: 200%;
 }
 
 #controlExplanation {
@@ -42,20 +46,7 @@
 	display: inline-block;
 }
 #controlsBlock img {
-	margin: 0 0.6em 0 !important;
+	margin: 0 1em 0 !important;
 	width: 1.6em !important;
 	height: 1.6em !important;
-}
-
-#controlsBlock #solution {
-}
-
-#controlsBlock {
-}
-
-#controlsBlock .hide {
-	font-size: 200%;
-	padding: 0;
-	margin: 0;
-	right: 0em;
 }

--- a/source/components/Controls.js
+++ b/source/components/Controls.js
@@ -14,7 +14,6 @@ function Controls({
 	startConversation,
 	hideControl,
 	foldedSteps,
-	colours,
 	hiddenControls,
 	language
 }) {
@@ -26,33 +25,32 @@ function Controls({
 			<ul>
 				{controls.map(({ level, test, message, solution, evaluated }) =>
 					hiddenControls.includes(test) ? null : (
-						<li
-							key={test}
-							className="control"
-							style={{ background: colours.lighterColour }}>
+						<li key={test} className="control">
 							{emoji(level == 'avertissement' ? '⚠️' : 'ℹ️')}
-							<div className="controlText">
+							<div className="controlText ui__ card">
 								{message ? (
 									createMarkdownDiv(message)
 								) : (
 									<span id="controlExplanation">{makeJsx(evaluated)}</span>
 								)}
-								&nbsp;
+
 								{solution && !foldedSteps.includes(solution.cible) && (
-									<button
-										key={solution.cible}
-										className="ui__ link-button"
-										onClick={() => startConversation(solution.cible)}>
-										{solution.texte}
-									</button>
+									<div>
+										<button
+											key={solution.cible}
+											className="ui__ link-button"
+											onClick={() => startConversation(solution.cible)}>
+											{solution.texte}
+										</button>
+									</div>
 								)}
+								<button
+									className="hide"
+									aria-label="close"
+									onClick={() => hideControl(test)}>
+									×
+								</button>
 							</div>
-							<button
-								className="hide"
-								aria-label="close"
-								onClick={() => hideControl(test)}>
-								×
-							</button>
 						</li>
 					)
 				)}

--- a/source/components/SimulateurWarning.js
+++ b/source/components/SimulateurWarning.js
@@ -12,9 +12,14 @@ export default function SimulateurWarning({ simulateur, autoFolded }) {
 			<p>
 				{emoji('🚩 ')}
 				<strong>Outil en cours de développement </strong>
-				{folded && <a onClick={toggle}> (plus d'info)</a>}
+				{folded && (
+					<button className="ui__ button simple small" onClick={toggle}>
+						{' '}
+						(plus d'info)
+					</button>
+				)}
 			</p>
-			<div className="content">
+			<div className={`content ${folded ? '' : 'ui__ card'}`}>
 				{!folded && (
 					<ul style={{ marginLeft: '1em' }}>
 						<li>réservé aux entreprises créées en 2019</li>
@@ -40,7 +45,9 @@ export default function SimulateurWarning({ simulateur, autoFolded }) {
 
 				{!folded && (
 					<div style={{ textAlign: 'right', paddingRight: '1em' }}>
-						<a onClick={toggle}>J'ai compris</a>
+						<button className="ui__ button simple small" onClick={toggle}>
+							J'ai compris
+						</button>
 					</div>
 				)}
 			</div>

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -9,9 +9,9 @@ questions:
   - entreprise . catégorie d'activité
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
-  - entreprise . catégorie d'activité . libérale reglementée
+  - entreprise . catégorie d'activité . libérale règlementée
   # pour l'instant pas utilisées 
-  # - entreprise . catégorie d'activité . libérale reglementée . type d'activité libérale reglementée
+  # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
   - entreprise . charges
   - entreprise . année d'activité
 

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -9,9 +9,9 @@ questions:
   - entreprise . catégorie d'activité
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
-  - entreprise . catégorie d'activité . libérale reglementée
-  # pour l'instant pas utilisées
-  # - entreprise . catégorie d'activité . libérale reglementée . type d'activité libérale reglementée
+  - entreprise . catégorie d'activité . libérale règlementée
+  # pour l'instant pas utilisées 
+  # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
   - entreprise . année d'activité
   - situation personnelle . RSA
 

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -8,9 +8,9 @@ questions:
   - entreprise . catégorie d'activité
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
-  - entreprise . catégorie d'activité . libérale reglementée
+  - entreprise . catégorie d'activité . libérale règlementée
   # pour l'instant pas utilisées 
-  # - entreprise . catégorie d'activité . libérale reglementée . type d'activité libérale reglementée
+  # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale reglementée
   - entreprise . charges
 bloquant:
   - entreprise . chiffre d'affaires

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -46,7 +46,6 @@ aiguillage numérique:
 
     Si aucune condition n'est vraie, alors ce mécanisme renvoie implicitement `non applicable` (ce qui peut se traduire par la valeur `0` si nous sommes dans un contexte numérique).
 
-
 variations:
   type: numeric
   description: |
@@ -89,7 +88,6 @@ somme:
   description: |
     C'est tout simplement la somme de chaque terme de la liste.
 
-
 ##########################################
 # Ce qu'on appelle aujourd'hui des RuleProp
 # Et qui deviendront des mécanismes classiques normalement par la suite #TODO
@@ -99,7 +97,6 @@ formule:
     C'est la formule de calcul d'une variable. Elle renvoie une valeur numérique ou un 'non', exprimant le fait que la variable n'est pas applicable, ce qui vaut implicitement 0.
 
     Cette doit faire appel à fera appel à des mécanismes de calcul : par exemple `multiplication`, le plus commun pour les variables de type `Cotisation`.
-
 
 applicable si:
   description: |
@@ -130,7 +127,6 @@ barème:
 
     Les tranches sont souvent exprimées sous forme de facteurs d'une variable que l'on appelle `multiplicateur`, par exemple `1 x le plafond de la sécurité sociale`.
 
-
 barème linéaire:
   type: numeric
   description: |
@@ -149,6 +145,8 @@ barème continu:
 
     Dans ce type de barème, il y a souvent un multiplicateur de l'assiette, par exemple le plafond de la sécurité sociale : les seuils sont des petits nombres comme 1 ou 1.5, mais ils correspondent en réalité à `1 * 3311€` et `1.5 * 3311€`.
 
+    L'option `retourne seulement le taux: oui` permet d'obtenir un taux pour une assiette donnée, pour l'appliquer ensuite à une autre assiette.
+
 complément:
   type: numeric
   description: |
@@ -165,20 +163,19 @@ composantes:
 
     > L'exemple le plus courant de composantes, c'est la distinction part employeur, part salarié (ex. retraite AGIRC).
 
-allègement: 
+allègement:
   type: numeric
   description: |
     Permet de réduire le montant d'une variable. 
     Très utilisé dans le contexte des impôts. 
 
-synchronisation: 
+synchronisation:
   type: object
   description: |
     Pour éviter trop de saisies à l'utilisateur, certaines informations sont récupérées à partir de ce que l'on appelle des API. Ce sont des services auxquels ont fait appel pour obtenir des informations sur un sujet précis. Par exemple, l'État français fournit gratuitement l'API géo, qui permet à partir du nom d'une ville, d'obtenir son code postal, son département, la population etc.
     Ce mécanismes `synchronisation` permet de faire le lien entre les règles de notre système et les réponses de ces API.
 
-
-période: 
+période:
   description: |
     Une régle qui a une période `mois` ou `année`, c'est une règle qui ne peut être calculée que sur cette période. La période est `flexible` quand le calcul est valable quelle que soit la période choisie. D'autres règles ne changent pas de valeur en fonction de la période.
 

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -163,7 +163,7 @@ composantes:
 
     Il est même possible, pour les mécanismes `barème` et `multiplication` de garder en commun un paramètre comme l'assiette, puis de déclarer des composantes pour le taux.
 
-    > L'example le plus courant de composantes, c'est la distinction part employeur, part salarié (ex. retraite AGIRC).
+    > L'exemple le plus courant de composantes, c'est la distinction part employeur, part salarié (ex. retraite AGIRC).
 
 allègement: 
   type: numeric

--- a/source/engine/mecanismViews/Barème.js
+++ b/source/engine/mecanismViews/Barème.js
@@ -88,19 +88,23 @@ let Component = withLanguage(function Barème({
 									))}
 								</tbody>
 							</table>
-							{showValues && barèmeType === 'marginal' && (
-								<>
-									<b>
-										<Trans>Taux final</Trans> :{' '}
-									</b>
-									{formatNumber(
-										(nodeValue / lazyEval(explanation['assiette']).nodeValue) *
-											100,
-										language
-									)}{' '}
-									%
-								</>
-							)}
+							{/* nous avons remarqué que la notion de taux final pour un barème à 2 tranches est moins pertinent pour les règles de calcul des indépendants. Règle empirique à faire évoluer ! */}
+							{showValues &&
+								barèmeType === 'marginal' &&
+								explanation.tranches.length > 2 && (
+									<>
+										<b>
+											<Trans>Taux final</Trans> :{' '}
+										</b>
+										{formatNumber(
+											(nodeValue /
+												lazyEval(explanation['assiette']).nodeValue) *
+												100,
+											language
+										)}{' '}
+										%
+									</>
+								)}
 						</ul>
 					}
 				/>

--- a/source/engine/mecanismViews/BarèmeContinu.js
+++ b/source/engine/mecanismViews/BarèmeContinu.js
@@ -43,7 +43,7 @@ let Comp = withLanguage(function Barème({ nodeValue, explanation }) {
 									<b>
 										<Trans>Votre taux </Trans> :{' '}
 									</b>
-									{(100 * explanation.taux).toFixed(1)} %
+									{(100 * explanation.taux).toFixed(2)} %
 								</span>
 							)}
 							{explanation.returnRate && (

--- a/source/engine/mecanismViews/Product.js
+++ b/source/engine/mecanismViews/Product.js
@@ -29,7 +29,15 @@ export default function ProductView(nodeValue, explanation) {
 									alignItems: 'baseline',
 									flexWrap: 'wrap'
 								}}>
-								<Trans>Plafonnée à :</Trans>&nbsp;{makeJsx(explanation.plafond)}
+								<span
+									style={{
+										...(explanation.plafondActif
+											? { background: 'yellow' }
+											: {})
+									}}>
+									<Trans>Plafonnée à :</Trans>&nbsp;
+									{makeJsx(explanation.plafond)}
+								</span>
 							</div>
 						)}
 					</div>

--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -1,23 +1,68 @@
-import { desugarScale } from 'Engine/mecanisms/barème';
-import { decompose, devariateExplanation } from 'Engine/mecanisms/utils';
-import { add, any, aperture, curry, equals, evolve, filter, find, head, is, isEmpty, isNil, keys, last, map, max, mergeWith, min, path, pipe, pluck, prop, propEq, reduce, reduced, reject, sort, subtract, toPairs } from 'ramda';
-import React from 'react';
-import { Trans } from 'react-i18next';
-import 'react-virtualized/styles.css';
-import { bonus, collectNodeMissing, defaultNode, evaluateArray, evaluateNode, evaluateObject, makeJsx, mergeAllMissing, mergeMissing, parseObject, rewriteNode } from './evaluation';
-import Allègement from './mecanismViews/Allègement';
-import Barème from './mecanismViews/Barème';
-import BarèmeContinu from './mecanismViews/BarèmeContinu';
-import { Node, SimpleRuleLink } from './mecanismViews/common';
-import InversionNumérique from './mecanismViews/InversionNumérique';
-import Product from './mecanismViews/Product';
-import buildSelectionView from './mecanismViews/Selection';
-import Somme from './mecanismViews/Somme';
-import Variations from './mecanismViews/Variations';
-import { disambiguateRuleReference, findRuleByDottedName, findRuleByName } from './rules';
-import { anyNull, val } from './traverse-common-functions';
-import uniroot from './uniroot';
-
+import { desugarScale } from 'Engine/mecanisms/barème'
+import { decompose, devariateExplanation } from 'Engine/mecanisms/utils'
+import {
+	add,
+	any,
+	aperture,
+	curry,
+	equals,
+	evolve,
+	filter,
+	find,
+	head,
+	is,
+	isEmpty,
+	isNil,
+	keys,
+	last,
+	map,
+	max,
+	mergeWith,
+	min,
+	path,
+	pipe,
+	pluck,
+	prop,
+	propEq,
+	reduce,
+	reduced,
+	reject,
+	sort,
+	subtract,
+	toPairs
+} from 'ramda'
+import React from 'react'
+import { Trans } from 'react-i18next'
+import 'react-virtualized/styles.css'
+import {
+	bonus,
+	collectNodeMissing,
+	defaultNode,
+	evaluateArray,
+	evaluateNode,
+	evaluateObject,
+	makeJsx,
+	mergeAllMissing,
+	mergeMissing,
+	parseObject,
+	rewriteNode
+} from './evaluation'
+import Allègement from './mecanismViews/Allègement'
+import Barème from './mecanismViews/Barème'
+import BarèmeContinu from './mecanismViews/BarèmeContinu'
+import { Node, SimpleRuleLink } from './mecanismViews/common'
+import InversionNumérique from './mecanismViews/InversionNumérique'
+import Product from './mecanismViews/Product'
+import buildSelectionView from './mecanismViews/Selection'
+import Somme from './mecanismViews/Somme'
+import Variations from './mecanismViews/Variations'
+import {
+	disambiguateRuleReference,
+	findRuleByDottedName,
+	findRuleByName
+} from './rules'
+import { anyNull, val } from './traverse-common-functions'
+import uniroot from './uniroot'
 
 /* @devariate = true => This function will produce variations of a same mecanism (e.g. product) that share some common properties */
 export let mecanismVariations = (recurse, k, v, devariate) => {
@@ -557,14 +602,18 @@ export let mecanismProduct = (recurse, k, v) => {
 	let effect = ({ assiette, taux, facteur, plafond }) => {
 		let mult = (base, rate, facteur, plafond) =>
 			Math.min(base, plafond) * rate * facteur
-		return val(taux) === 0 ||
-			val(taux) === false ||
-			val(assiette) === 0 ||
-			val(facteur) === 0
-			? 0
-			: anyNull([taux, assiette, facteur, plafond])
-			? null
-			: mult(val(assiette), val(taux), val(facteur), val(plafond))
+		return {
+			nodeValue:
+				val(taux) === 0 ||
+				val(taux) === false ||
+				val(assiette) === 0 ||
+				val(facteur) === 0
+					? 0
+					: anyNull([taux, assiette, facteur, plafond])
+					? null
+					: mult(val(assiette), val(taux), val(facteur), val(plafond)),
+			additionalExplanation: { plafondActif: val(assiette) > val(plafond) }
+		}
 	}
 
 	let explanation = parseObject(recurse, objectShape, v),

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2907,10 +2907,10 @@
     Il s'agit des autres personnes qui pratiquent, une science ou un art et dont l'activité intellectuelle joue le principal rôle. Leurs recettes doivent représenter la rémunération d'un travail personnel, sans lien de subordination, tout en engageant leur responsabilité technique et morale.
 
     > Exemples de professions non-règlementées : développeur, historien, urbaniste...
-  contrôles: 
+  contrôles:
     - si: libérale règlementée
       niveau: avertissement
-      message: | 
+      message: |
         Attention, le simulateur n'est pas encore complet pour les professions libérales règlementées : 
 
         - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant. 
@@ -3051,7 +3051,7 @@
   nom: assiette minimale
   période: flexible
   formule:
-    variations: 
+    variations:
       - si: situation personnelle . RSA
         alors: revenu professionnel
       - sinon:
@@ -3084,8 +3084,8 @@
   formule:
     multiplication:
       assiette: assiette minimale
-      taux: 
-        variations: 
+      taux:
+        variations:
           - si: situation personnelle . RSA
             alors: taux RSA
           - sinon: taux
@@ -3093,9 +3093,9 @@
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
   nom: taux RSA
   période: flexible
-  formule: 
-    multiplication: 
-      assiette: taux RSA part variable + 1.35% 
+  formule:
+    multiplication:
+      assiette: taux RSA part variable + 1.35%
       plafond: 6.35%
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
@@ -3105,15 +3105,15 @@
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
   nom: taux RSA part variable
   période: flexible
-  formule: 
-    multiplication: 
+  formule:
+    multiplication:
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
   nom: seuil supérieur de réduction
   période: flexible
-  formule: 
+  formule:
     multiplication:
       assiette: plafond sécurité sociale temps plein
       taux: 110%
@@ -3141,16 +3141,15 @@
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
   nom: part revenus élevés
   période: flexible
-  applicable si: revenu professionnel > seuil
   formule:
-    multiplication:
+    barème:
       assiette: revenu professionnel
-      taux: 0.15%
-
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux . part revenus élevés
-  nom: seuil
-  période: flexible
-  formule: 5 * plafond sécurité sociale temps plein
+      multiplicateur: plafond sécurité sociale temps plein
+      tranches:
+        - en-dessous de: 5
+          taux: 0
+        - au-dessus de: 5
+          taux: 0.15%
 
 - espace: indépendant . cotisations
   nom: retraite de base

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2785,12 +2785,7 @@
 
 - espace: indépendant
   nom: revenu net de cotisations
-  formule: revenu professionnel - cotisations et contributions . non déductibles
-  période: flexible
-
-- espace: indépendant . cotisations et contributions
-  nom: non déductibles
-  formule: CSG et CRDS (non déductible) + formation professionnelle
+  formule: revenu professionnel - cotisations et contributions . CSG et CRDS (non déductible)
   période: flexible
 
 - espace: indépendant
@@ -3286,7 +3281,8 @@
     somme:
       - revenu professionnel
       - cotisations à payer
-      - cotisations et contributions . CSG et CRDS (déductible)
+      - cotisations et contributions . CSG et CRDS (déductible) 
+      - cotisations et contributions . formation professionnelle
 
 - nom: auto entrepreneur
   icônes: 🚶

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3030,7 +3030,7 @@
   période: flexible
   nom: libérale reglementée
   titre: maladie libérale reglementée
-  formule: 
+  formule:
     barème continu:
       assiette: revenu professionnel
       multiplicateur: plafond sécurité sociale temps plein
@@ -3074,8 +3074,17 @@
   nom: barème principal
   période: flexible
   formule:
-    barème continu:
+    multiplication:
       assiette: assiette
+      taux: taux du barème principal
+
+- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+  nom: taux du barème principal
+  période: flexible
+  formule:
+    barème continu:
+      retourne seulement le taux: oui
+      assiette: revenu professionnel
       multiplicateur: plafond sécurité sociale temps plein
       points:
         0: 0%
@@ -3288,7 +3297,7 @@
     somme:
       - revenu professionnel
       - cotisations à payer
-      - cotisations et contributions . CSG et CRDS (déductible) 
+      - cotisations et contributions . CSG et CRDS (déductible)
       - cotisations et contributions . formation professionnelle
 
 - nom: auto entrepreneur

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3088,8 +3088,15 @@
       multiplicateur: plafond sécurité sociale temps plein
       points:
         0: 0%
-        0.4: 3.16%
+        0.4: 3.168%
         1.1: 6.35%
+  note: |
+    Cette cotisation est à la base très simple : la cotisation maladie est de 7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà. Cependant : 
+    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs. 
+    - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
+
+  références:
+    décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
   nom: part revenus élevés
@@ -3261,7 +3268,6 @@
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
-
 
 - espace: indépendant . cotisations
   nom: allocations familiales

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3040,7 +3040,7 @@
 
 - espace: indépendant . cotisations . maladie
   nom: assiette
-  titre: assiette maladie
+  titre: assiette minimale maladie
   période: flexible
   formule:
     variations:
@@ -3135,7 +3135,7 @@
 - espace: indépendant . cotisations . retraite de base
   nom: assiette
   période: flexible
-  titre: assiette retraite de base
+  titre: assiette minimale retraite de base
   formule:
     variations:
       - si: ≠ situation personnelle . RSA
@@ -3207,7 +3207,7 @@
 - espace: indépendant . cotisations . invalidité et décès
   nom: assiette
   période: flexible
-  titre: assiette invalidité et décès
+  titre: assiette minimale invalidité et décès
   formule:
     variations:
       - si: ≠ situation personnelle . RSA
@@ -3266,7 +3266,7 @@
 - espace: indépendant . cotisations et contributions . formation professionnelle
   nom: assiette
   période: flexible
-  titre: assiette formation professionnelle
+  titre: assiette minimale formation professionnelle
   formule:
     variations:
       - si: ≠ situation personnelle . RSA

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2907,6 +2907,15 @@
     Il s'agit des autres personnes qui pratiquent, une science ou un art et dont l'activité intellectuelle joue le principal rôle. Leurs recettes doivent représenter la rémunération d'un travail personnel, sans lien de subordination, tout en engageant leur responsabilité technique et morale.
 
     > Exemples de professions non-règlementées : développeur, historien, urbaniste...
+  contrôles: 
+    - si: libérale règlementée
+      niveau: avertissement
+      message: | 
+        Attention, le simulateur n'est pas encore complet pour les professions libérales règlementées : 
+
+        - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant. 
+        - assurez-vous que le statut auto-entrepreneur est bien compatible avec votre profession règlementée
+        - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
 
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3039,11 +3039,10 @@
         1.1: 6.5%
 
 - espace: indépendant . cotisations . maladie
-  nom: assiette
-  titre: assiette minimale maladie
+  nom: assiette minimale
   période: flexible
   formule:
-    variations:
+    variations: 
       - si: situation personnelle . RSA
         alors: revenu professionnel
       - sinon:
@@ -3061,7 +3060,7 @@
   non applicable si: entreprise . catégorie d'activité . libérale reglementée
   formule:
     multiplication:
-      assiette: maladie . assiette
+      assiette: maladie . assiette minimale
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
@@ -3075,11 +3074,43 @@
   période: flexible
   formule:
     multiplication:
-      assiette: assiette
-      taux: taux du barème principal
+      assiette: assiette minimale
+      taux: 
+        variations: 
+          - si: situation personnelle . RSA
+            alors: taux RSA
+          - sinon: taux
 
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
-  nom: taux du barème principal
+  nom: taux RSA
+  période: flexible
+  formule: 
+    multiplication: 
+      assiette: taux RSA part variable + 1.35% 
+      plafond: 6.35%
+  note: |
+    Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
+
+    Cette formule n'est pas intuitive. Si vous en avez une meilleure représentation, n'hésitez pas à contribuer ! 
+
+- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+  nom: taux RSA part variable
+  période: flexible
+  formule: 
+    multiplication: 
+      assiette: 5%
+      taux: revenu professionnel / seuil supérieur de réduction
+
+- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+  nom: seuil supérieur de réduction
+  période: flexible
+  formule: 
+    multiplication:
+      assiette: plafond sécurité sociale temps plein
+      taux: 110%
+
+- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+  nom: taux
   période: flexible
   formule:
     barème continu:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3150,6 +3150,14 @@
           taux: 0
         - au-dessus de: 5
           taux: 0.15%
+  références:
+    décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
+  note: |
+    On retrouve dans le décret ci-dessous la phrase suivante : 
+
+    > I.-Par dérogation au premier alinéa, le taux de la cotisation est fixé à 6,5 % lorsque le revenu d'activité est supérieur à cinq fois la valeur annuelle du plafond de la sécurité sociale déterminée conformément à l'article D. 613-2.
+
+    Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nou avons retenue.
 
 - espace: indépendant . cotisations
   nom: retraite de base

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2895,24 +2895,24 @@
   par défaut: non
 
 - espace: entreprise . catégorie d'activité
-  nom: libérale reglementée
-  question: Est-ce une activité libérale reglementée ?
+  nom: libérale règlementée
+  question: Est-ce une activité libérale règlementée ?
   par défaut: non
   applicable si: catégorie d'activité = 'libérale'
   description: |
     Certaines professions libérales ont été classées dans le domaine libéral par la loi et leur titre est protégé. Leurs membres doivent respecter des règles déontologiques strictes et sont soumis au contrôle de leurs instances professionnelles (ordre, chambre, ou syndicat).
 
-    > Exemples de professions reglementées : architecte, avocat, infirmier, médecin...
+    > Exemples de professions règlementées : architecte, avocat, infirmier, médecin...
 
     Il s'agit des autres personnes qui pratiquent, une science ou un art et dont l'activité intellectuelle joue le principal rôle. Leurs recettes doivent représenter la rémunération d'un travail personnel, sans lien de subordination, tout en engageant leur responsabilité technique et morale.
 
-    > Exemples de professions non-reglementées : développeur, historien, urbaniste...
+    > Exemples de professions non-règlementées : développeur, historien, urbaniste...
 
   références:
     Liste des activités libérales: https://bpifrance-creation.fr/encyclopedie/trouver-proteger-tester-son-idee/verifiertester-son-idee/liste-professions-liberales
 
-- espace: entreprise . catégorie d'activité . libérale reglementée
-  nom: type d'activité libérale reglementée
+- espace: entreprise . catégorie d'activité . libérale règlementée
+  nom: type d'activité libérale règlementée
   formule:
     une possibilité:
       choix obligatoire: oui
@@ -2961,14 +2961,14 @@
   # TODO consolider la formule :
   # Nous avons deux listes possibles
   # A) Voilà la liste de l'URSSAF
-  question: La profession libérale reglementée est-elle rattachée à la CIPAV ?
+  question: La profession libérale règlementée est-elle rattachée à la CIPAV ?
   par défaut: non
   description: |
-    Les auto-entrepreneurs exerçant une activité de profession libérale réglementée sont affiliés pour leur assurance retraite à la Cipav. Ces professions libérales réglementées sont : architectes, architectes d’intérieur, économistes de la construction, géomètres, ingénieurs-conseils, maîtres d’oeuvre, psychologues, psychothérapeutes, ostéopathes, ergothérapeutes, chiropracteurs, diététiciens, artistes autres que les artistes-auteurs, experts devant les tribunaux, experts automobiles, mandataires judiciaires à la protection des majeurs, courtiers en valeur, guides-conférenciers, guides de haute montagne, accompagnateurs de moyenne montagne et moniteurs de ski.
+    Les auto-entrepreneurs exerçant une activité de profession libérale règlementée sont affiliés pour leur assurance retraite à la Cipav. Ces professions libérales règlementées sont : architectes, architectes d’intérieur, économistes de la construction, géomètres, ingénieurs-conseils, maîtres d’oeuvre, psychologues, psychothérapeutes, ostéopathes, ergothérapeutes, chiropracteurs, diététiciens, artistes autres que les artistes-auteurs, experts devant les tribunaux, experts automobiles, mandataires judiciaires à la protection des majeurs, courtiers en valeur, guides-conférenciers, guides de haute montagne, accompagnateurs de moyenne montagne et moniteurs de ski.
 
     formule:
       inclusion:
-        de: entreprise . catégorie d'activité . type d'activité libérale reglementée
+        de: entreprise . catégorie d'activité . type d'activité libérale règlementée
         dans: # B) voilà la liste obtenue sur https://www.afecreation.fr/pid14832/liste-des-activites-liberales.html
           - Architecte
           - Architecte d'intérieur
@@ -2986,7 +2986,7 @@
   nom: auto entreprise impossible
   formule:
     toutes ces conditions:
-      - entreprise . catégorie d'activité . libérale reglementée
+      - entreprise . catégorie d'activité . libérale règlementée
       - ≠ rattachée à la CIPAV
   note: D'autres conditions d'exclusions existent, il faudra les compléter, mais la question de la catégorie d'activité doit avant être complétée.
 
@@ -3021,15 +3021,15 @@
   nom: maladie
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale reglementée
-        alors: libérale reglementée
+      - si: entreprise . catégorie d'activité . libérale règlementée
+        alors: libérale règlementée
 
       - sinon: artisans commerçants libéraux
 
 - espace: indépendant . cotisations . maladie
   période: flexible
-  nom: libérale reglementée
-  titre: maladie libérale reglementée
+  nom: libérale règlementée
+  titre: maladie libérale règlementée
   formule:
     barème continu:
       assiette: revenu professionnel
@@ -3057,7 +3057,7 @@
   titre: Maladie 2
   description: Cotisations pour les indémnité journalière des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, ils peuvent bénéficier d’indemnités journalières.
   période: flexible
-  non applicable si: entreprise . catégorie d'activité . libérale reglementée
+  non applicable si: entreprise . catégorie d'activité . libérale règlementée
   formule:
     multiplication:
       assiette: maladie . assiette minimale
@@ -3148,7 +3148,7 @@
   période: année
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale reglementée
+      - si: entreprise . catégorie d'activité . libérale règlementée
         alors:
           multiplication:
             assiette: assiette
@@ -3192,7 +3192,7 @@
   note: Pour les professions libérales, nous avons retenu un des 8 régimes de retraite, celui de la CIPAV, la caisse interprofessionnelle.
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale reglementée
+      - si: entreprise . catégorie d'activité . libérale règlementée
         alors:
           barème linéaire:
             assiette: revenu professionnel
@@ -3399,7 +3399,7 @@
 
                 - entreprise . catégorie d'activité . restauration ou hébergement
             alors: 0.015%
-          - si: entreprise . catégorie d'activité . libérale reglementée
+          - si: entreprise . catégorie d'activité . libérale règlementée
             alors: 0.2%
           - sinon: 0.44%
 
@@ -3416,7 +3416,7 @@
         variations:
           - si: entreprise . catégorie d'activité = 'artisanale'
             alors: 0.3%
-          - si: entreprise . catégorie d'activité . libérale reglementée
+          - si: entreprise . catégorie d'activité . libérale règlementée
             alors: 0.2%
           - si:
               une de ces conditions:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3675,6 +3675,8 @@
   références:
     wikipedia: https://fr.wikipedia.org/wiki/Versement_transport
 
+- nom: situation personnelle
+
 - espace: situation personnelle
   nom: RSA
   titre: allocataire RSA

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3246,7 +3246,7 @@
           - si: entreprise . catégorie d'activité = 'artisanale'
             alors: 0.29%
           - sinon: 0.25%
-  note: Le taux passe à 0,34 % si votre conjoint a le statut de conjoint collaborateur.
+  note: Pour les commerçants et professions libérales, le taux passe à 0,34 % si votre conjoint a le statut de conjoint collaborateur.
   références:
     fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23459
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3022,14 +3022,21 @@
   formule:
     variations:
       - si: entreprise . catégorie d'activité . libérale reglementée
-        alors:
-          barème continu:
-            assiette: assiette
-            multiplicateur: plafond sécurité sociale temps plein
-            points:
-              0: 1.5%
-              1.1: 6.5%
+        alors: libérale reglementée
+
       - sinon: artisans commerçants libéraux
+
+- espace: indépendant . cotisations . maladie
+  période: flexible
+  nom: libérale reglementée
+  titre: maladie libérale reglementée
+  formule: 
+    barème continu:
+      assiette: revenu professionnel
+      multiplicateur: plafond sécurité sociale temps plein
+      points:
+        0: 1.5%
+        1.1: 6.5%
 
 - espace: indépendant . cotisations . maladie
   nom: assiette
@@ -3061,10 +3068,10 @@
 - espace: indépendant . cotisations . maladie
   nom: artisans commerçants libéraux
   période: flexible
-  formule: barème + part revenus élevés
+  formule: barème principal + part revenus élevés
 
 - espace: indépendant . cotisations . maladie . artisans commerçants libéraux
-  nom: barème
+  nom: barème principal
   période: flexible
   formule:
     barème continu:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3250,8 +3250,7 @@
   période: flexible
   formule:
     multiplication:
-      assiette: assiette
-      plafond: plafond sécurité sociale temps plein
+      assiette: plafond sécurité sociale temps plein
       taux:
         variations:
           - si: entreprise . catégorie d'activité = 'artisanale'
@@ -3263,20 +3262,6 @@
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
 
-- espace: indépendant . cotisations et contributions . formation professionnelle
-  nom: assiette
-  période: flexible
-  titre: assiette minimale formation professionnelle
-  formule:
-    variations:
-      - si: ≠ situation personnelle . RSA
-        alors:
-          le maximum de:
-            - plafond sécurité sociale temps plein
-            - revenu professionnel
-      - sinon: revenu professionnel
-  références:
-    secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
 - espace: indépendant . cotisations
   nom: allocations familiales

--- a/source/règles/brouillons/régimes-juridiques.yaml
+++ b/source/règles/brouillons/régimes-juridiques.yaml
@@ -53,7 +53,7 @@ Questions:
   - industriels ?
   - artisan (inscrit à la chambre des métiers)
   - libéral (inscrit à l'URSSAF)
-    - professions libérales reglementées
+    - professions libérales règlementées
     # Une profession libérale réglementée est celle exercée par des personnes ayant reçu un diplôme (généralement de l'enseignement supérieur) reconnu dans leur métier, qui sont tenues par un code de déontologie, et qui sont soumises au contrôle d'instances professionnelles.
       - santé
         - médicales
@@ -70,7 +70,7 @@ Questions:
         - architecte
         ...
       ...
-    - non reglementées
+    - non règlementées
     # https://travailleur-independant.ooreka.fr/comprendre/profession-liberale-non-reglementee
 
   - artiste (inscrit à la maison des artistes)

--- a/source/sites/mycompanyinfrance.fr/pages/SocialSecurity/Indépendant.js
+++ b/source/sites/mycompanyinfrance.fr/pages/SocialSecurity/Indépendant.js
@@ -38,8 +38,8 @@ let AvertissementForfaitIndépendants = () => (
 		{emoji('💶')} Notre estimation prend en compte les{' '}
 		<em>cotisations réelles</em> dues par le travailleur indépendant. Pendant la
 		première année de son activité, il paiera un forfait réduit (une somme de
-		l'ordre de 3000€ / an pour un artisan)... mais il sera régularisé l'année
-		suivante selon ce montant réel.
+		l'ordre de 1300€ / an pour un artisan bénéficiant de l'ACRE)... mais il sera
+		régularisé l'année suivante selon ce montant réel.
 	</p>
 )
 

--- a/test/indépendants.test.js
+++ b/test/indépendants.test.js
@@ -12,6 +12,6 @@ describe('indeps', function() {
 			période: 'année'
 		})
 
-		expect(values[0]).to.be.closeTo(39714, 1)
+		expect(values[0]).to.be.closeTo(39765, 1)
 	})
 })


### PR DESCRIPTION
:warning: avancement repris sur #497, celui-ci est obsolète

# Sujets de correction du calcul, prioritaires 
- [x] maladie commerçants, artisans, libéraux non regl : le barème continu est à revoir avec l'excel TI.
  - corriger la formule principale
  - ajouter la formule pour le RSA
  - expliquer le problème pour la part élevée

- [ ] ne pas limiter le simulateur aux entreprises créées en 2019, trouver une solution en demandant l'année de création pour gérer l'ACRE qui n'était pas automatique et les cotisations des libéraux non reglementés (AE avant 1er janvier 2018 et indeps 1er janvier 2019)

- [x] le sujet de la déductibilité des cotisations. On a modifié le calcul en considérant que la contribution pro est non déductible, or elle semble l'être.

- [x] Le calcul de la maladie pour les assiettes minimales n'était pas correct, voir 8393a2c et a60c8ce

- [x] avertir les professions libérales que nous faisons une simplification en prenant un barème de retraite complémentaire particulier 

- [x] Problème de la cotisaiton maladie pour les revneus élevés

```
Comment est déterminé le taux de 3,3% ?

D’après notre calculette pour bénéficier d’un taux de 3,3% le revenu utilisé est de 16210 € soit l’assiette minimale or, pour déterminer le taux il convient d’utiliser le revenu déclaré par l’assuré (cette règle vaut à la fois pour les artisans/commerçants et PL).

Ensuite ? une fois que le taux est déterminé il convient d’appliquer celui-ci sur l’assiette minimale (pour les artisans /commerçants) si le revenu est inférieur à cette assiette.

Par contre, cette assiette minimale ne s’applique pas pour les professions libérales par conséquent, pour ces assurés professions libérales le calcul de la cotisation se fait par le produit du taux par le revenu déclaré.
```

- [ ] Dans la partie des professions libérales d’autres questions doivent être posées notamment, afin de savoir d’une part,  si ce sont des PAM ou des non PAM et si ce sont des non PAM leur activité afin de calculer de la CURPS si nécessaire.

- [ ] [Sujet proche du précédent] L’affichage ne laisse pas apparaître la CFP et la CURPS même si on ne sait pas si dans ce cas l’assuré est redevable de la CURPS pour autant la cotisation Maladie 2 est affichée alors, que les professions libérales ne sont pas redevables de cette cotisation.

## Autres sujets de calcul, moins prioritaires 

- implémenter le taux différencié en cas de conjoint collaborateur. 05499bb

Au sujet de cette particularité sur les conjoints collaborateurs : j'ai ajouté une indication que ça ne concerne pas les artisans. Nous mettons dans l'attribut "note" ce que nous n'avons pas encore pu implémenter dans le calcul. Je pense que pour une première version en ligne, nous pouvons laisser de côté cette particularité. Notamment car ça demande une nouvelle question dans l'interface, il faut la poser sans perturber ceux qui ne sont pas concernés.


## Sujets d'explication des règles, moins prioritaires

- [x] multiplication avec plafond : aligner l'assiette active, assiette ou plafond, avec le taux 

- [ ] ne pas afficher le taux final pour un barème simple de retraite à deux tranches

- [ ] passer les 1.1 et 0.4 en 110% et 40% dans le barème continu

- [ ] Ne peut-on pas remplacer Assiette retraite de base par Assiette minimale retraite de base quand le revenu est inférieur à cette base.
Ne peut-on pas remplacer Assiette maladie par Assiette minimale maladie quand le revenu est inférieur à cette base.


- [ ] Dans la variable [cotisations de l'indépendant](https://demo.mon-entreprise.fr/documentation/indépendant/cotisations) : Pour un PL est-il nécessaire d’afficher la Maladie 2 compte-tenu qu’il n’est pas redevable de cette cotisation même si l’affichage ci-dessous est indiqué si on clique sur Maladie 2?

Je pense que l'on peut répondre à ce problème en mettant tout ce qui concerne la maladie dans une variable maladie qui opérerait une `variations`, en repliant et notant "désactivée" la variation non pertinente. 
Sujet repliage des branches déjà évoqué ici : #355 
Repliage fait dans #492 


- [x] Revoir le JSX de la multiplication pour notamment faire comprendre que le plafond, s'il est dépassé, remplace l'assiette. Fait dans #492 

Afin d'éviter de provoquer la remarque suivante : 
> Pour la cotisation invalidité-décès l’assiette ne peut être supérieure au PASS, le PASS est l’assiette maximale.

- [ ] Règles d'arrondis : je pense que ce n'est pas prioritaire pour une première versionen ligne. Voir #490

 - [x] "Votre taux" : on peut l'arrondir à 2 décimales pour éviter les imprécisions de plusieurs euros dans l'interface
