### PR TITLE
🔨 Rattachement aux libéraux règlementés pour les lib < 2019

### DIFF
--- a/source/components/SimulateurWarning.js
+++ b/source/components/SimulateurWarning.js
@@ -22,7 +22,6 @@ export default function SimulateurWarning({ simulateur, autoFolded }) {
 			<div className={`content ${folded ? '' : 'ui__ card'}`}>
 				{!folded && (
 					<ul style={{ marginLeft: '1em' }}>
-						<li>réservé aux entreprises créées en 2019</li>
 						{simulateur !== 'auto-entreprise' && (
 							<li>
 								le chiffre d'affaires déduit des charges va à 100% dans la

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -10,9 +10,7 @@ questions:
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
   - entreprise . catégorie d'activité . libérale règlementée
-  # pour l'instant pas utilisées
-  # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
-
+  - entreprise . ACCRE obtenu
   - entreprise . année d'activité
 
 questions à l'affiche:

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -11,9 +11,6 @@ questions:
   - entreprise . catégorie d'activité . restauration ou hébergement
 
   - entreprise . catégorie d'activité . libérale règlementée
-  # pour l'instant pas utilisées
-  # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale reglementée
-
 bloquant:
   - entreprise . chiffre d'affaires
 situation:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3030,6 +3030,10 @@
 
 - espace: indépendant
   nom: rattachement libéral règlementé
+  description: | 
+    Les entreprises libérales non règlementées créées avant 2019 étaient rattachées aux règlementées pour le calcul des cotisations sociales. Depuis 2019 ce n'est plus le cas, elles sont rattachées aux artisans-commerçants, donc dépendent de la sécurité sociale des indépendants.
+  références: 
+    article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
   formule:
     une de ces conditions: 
       - entreprise . catégorie d'activité . libérale règlementée

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3087,7 +3087,7 @@
   titre: Maladie 2
   description: Cotisations pour les indémnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
   période: flexible
-  non applicable si: rattachement libéral règlementée
+  non applicable si: rattachement libéral règlementé
   formule:
     multiplication:
       assiette: maladie . assiette

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3027,6 +3027,9 @@
       - cotisations à payer
       - CSG et CRDS (déductible)
       - formation professionnelle
+  format: euros
+  période: flexible
+
 
 - espace: indépendant
   nom: rattachement libéral règlementé
@@ -3034,12 +3037,12 @@
     Les entreprises libérales non règlementées créées avant 2019 étaient rattachées aux règlementées pour le calcul des cotisations sociales. Depuis 2019 ce n'est plus le cas, elles sont rattachées aux artisans-commerçants, donc dépendent de la sécurité sociale des indépendants.
   références: 
     article de loi (chercher "travailleurs indépendants créant leur activité"): https://www.legifrance.gouv.fr/eli/loi/2017/12/30/CPAX1725580L/jo/texte#JORFARTI000036339157
-  formule:
+  applicable si:
     une de ces conditions: 
       - entreprise . catégorie d'activité . libérale règlementée
       - toutes ces conditions: 
           - entreprise . année d'activité != 'première année'
-          - entreprise . catégorie d'activité . libérale
+          - entreprise . catégorie d'activité = 'libérale'
 
   période: flexible
   format: euros

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3027,6 +3027,16 @@
       - cotisations à payer
       - CSG et CRDS (déductible)
       - formation professionnelle
+
+- espace: indépendant
+  nom: rattachement libéral règlementé
+  formule:
+    une de ces conditions: 
+      - entreprise . catégorie d'activité . libérale règlementée
+      - toutes ces conditions: 
+          - entreprise . année d'activité != 'première année'
+          - entreprise . catégorie d'activité . libérale
+
   période: flexible
   format: euros
 
@@ -3035,7 +3045,7 @@
   période: flexible
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale règlementée
+      - si: rattachement libéral règlementé
         alors: libérale règlementée
 
       - sinon: artisans commerçants libéraux
@@ -3073,7 +3083,7 @@
   titre: Maladie 2
   description: Cotisations pour les indémnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
   période: flexible
-  non applicable si: entreprise . catégorie d'activité . libérale règlementée
+  non applicable si: rattachement libéral règlementée
   formule:
     multiplication:
       assiette: maladie . assiette
@@ -3161,7 +3171,7 @@
   période: année
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale règlementée
+      - si: rattachement libéral règlementé
         alors:
           multiplication:
             assiette: assiette
@@ -3205,7 +3215,7 @@
   note: Pour les professions libérales, nous avons retenu un des 8 régimes de retraite, celui de la CIPAV, la caisse interprofessionnelle.
   formule:
     variations:
-      - si: entreprise . catégorie d'activité . libérale règlementée
+      - si: rattachement libéral règlementé
         alors:
           barème linéaire:
             assiette: revenu professionnel

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3469,15 +3469,14 @@
       multiplicateur: ACRE . plafond
       tranches:
         - en-dessous de: 1
-          taux: ACRE * taux
+          taux: ACRE * taux de cotisation
         - au-dessus de: 1
-          taux: taux
+          taux: taux de cotisation
   références:
     La protection sociale du micro-entrepreneur: https://bpifrance-creation.fr/encyclopedie/micro-entreprise-regime-auto-entrepreneur/fiscal-social-comptable/protection-sociale
 
 - espace: auto entrepreneur . cotisations sociales
-  nom: taux
-  titre: taux de cotisation
+  nom: taux de cotisation
   description: |
     Les cotisations sociales de l'auto-entreprise sont simplifiées : il n'y a qu'une ligne unique dont le taux dépend de la catégorie d'activité.
   formule:
@@ -3485,14 +3484,24 @@
       - si:
           une de ces conditions:
             - entreprise . catégorie d'activité . service ou vente = 'vente de biens'
-
             - entreprise . catégorie d'activité . restauration ou hébergement
         alors: 12.8%
       - sinon: 22%
 
+- espace: entreprise
+  nom: ACCRE obtenu
+  question: Avez-vous obtenu l'ACCRE lors de votre création d'entreprise ?
+  description: |
+    Pour les entreprises créées avant 2019, la réduction de cotisation ACRE s'appellait ACCRE et n'était pas automatique : il fallait notamment être indemnisé par pôle-emploi et faire la demande. 
+  par défaut: non
+
 - espace: auto entrepreneur . cotisations sociales
   nom: ACRE
   titre: Taux ACRE
+  applicable si: 
+    une de ces conditions: 
+      - entreprise . année d'activité = 'première année'
+      - entreprise . ACCRE obtenu 
   période: flexible
   description: Ce taux réduit le montant des cotisations sociales de l'auto-entrepreneur pour l'aider dans ses premières années d'activité.
   formule:

--- a/test/indépendants.test.js
+++ b/test/indépendants.test.js
@@ -12,6 +12,6 @@ describe('indeps', function() {
 			période: 'année'
 		})
 
-		expect(values[0]).to.be.closeTo(39765, 1)
+		expect(values[0]).to.be.closeTo(41513, 1)
 	})
 })


### PR DESCRIPTION
C'est du gachis de réserver le simulateur aux entreprises créées avant 2019. La simulation se place en 2019, donc la question de l'année d'activité nous donne l'année de création, dont on peut déduire les deux paramètres épineux :   
  - [x] si < 2019, le calcul pour les indeps libéraux non règlementés sont rattachés aux artisans-commerçants
  - [x] si < première année, pas d'ACRE pour l'assmilé et l'indep 
  - [x] si < première année, pour les AE, poser la questionde l'ACRE qui n'est pas automatique mais possible.
  - [ ] si < 2018, idem mais pour les AE.
J'ai l'impression que pour ce dernier point, il n'y a pas d'impact. La caisse de rattachement retraite change, mais pas les cotisations.
