### PR TITLE
Mise en valeur des charges dans les simulateurs indeps

### DIFF
--- a/source/components/CurrencyInput/CurrencyInput.js
+++ b/source/components/CurrencyInput/CurrencyInput.js
@@ -31,6 +31,7 @@ class CurrencyInput extends Component {
 		return this.input.selectionStart
 	}
 	componentDidMount() {
+		// this.input.select()
 		this.adaptInputSize()
 	}
 	adaptInputSize = () => {
@@ -44,6 +45,7 @@ class CurrencyInput extends Component {
 	componentDidUpdate = (_, __, cursorPosition) => {
 		this.input.selectionStart = cursorPosition
 		this.input.selectionEnd = cursorPosition
+
 		this.adaptInputSize()
 	}
 	focusInput = () => {

--- a/source/components/PeriodSwitch.css
+++ b/source/components/PeriodSwitch.css
@@ -1,38 +1,71 @@
 #PeriodSwitch {
-	margin: 1em;
 	display: flex;
 	align-items: center;
-	justify-content: center;
-}
-#PeriodSwitch .base {
-	background: var(--colour);
-	border-radius: 0.3em;
-	padding: 0.4em;
+	justify-content: flex-end;
 }
 
-#PeriodSwitch label {
+.ui__.toggle {
+	border: 1px solid var(--colour);
+	border-radius: 0.3rem;
+	display: flex;
+}
+.ui__.toggle label {
+	padding: 0.6rem 1.2rem;
 	color: var(--colour);
+	text-transform: uppercase;
+	cursor: pointer;
+}
+.ui__.toggle.small label {
+	font-size: 80%;
+	overflow: hidden;
+	padding: 0.4rem 0.8rem;
+}
+.ui__.toggle label:not(:last-child) {
+	border-right: 1px solid var(--colour);
 }
 
-#PeriodSwitch input[type='radio'] {
+.ui__.toggle input[type='radio'] {
 	position: fixed;
 	left: -100%;
 }
 
-#PeriodSwitch .radioText {
+.ui__.toggle input[type='radio'] ~ *::before {
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	content: '';
+	margin: 0 0.3em;
+	vertical-align: middle;
+	border-radius: 20px;
 	cursor: pointer;
-	border-radius: 0.3em;
-	padding: 0 0.6em;
+	box-shadow: 0 0 0px 1.5px rgb(41, 117, 209);
+	transition: all 0.1s;
+	border: 0.5em solid white;
+}
+.ui__.toggle input[type='radio'] ~ * {
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	transition: all 0.2s;
+}
+.ui__.toggle input[type='radio']:checked ~ *::before {
+	border: 4px solid white;
+	background: var(--colour);
+}
+.ui__.toggle input[type='radio']:focus ~ .radioText {
+	border: 1px dotted gray;
+}
+.ui__.toggle input[type='radio']:checked ~ .radioText {
+	font-weight: 500;
+}
+
+.ui__.toggle input[type='radio']:checked ~ * {
+	background: var(--colour);
+	box-shadow: 0 0 0 3rem var(--colour);
 	color: white;
 }
 
-#PeriodSwitch .radioText:hover {
-	text-decoration: underline;
-}
-
-#PeriodSwitch input[type='radio']:checked + .radioText {
-	background: white;
-	border: 4px solid white;
-	color: var(--colour);
-	text-decoration: none;
+.ui__.toggle label:hover input[type='radio']:not(:checked) ~ * {
+	background: var(--lighterColour);
+	box-shadow: 0 0 0 1rem var(--lighterColour);
 }

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -1,7 +1,6 @@
 import { findRuleByDottedName, nestedSituationToPathMap } from 'Engine/rules'
 import { compose, filter, map, toPairs } from 'ramda'
 import React, { useEffect } from 'react'
-import emoji from 'react-easy-emoji'
 import { Trans, withTranslation } from 'react-i18next'
 import { connect } from 'react-redux'
 import { batchActions } from 'redux-batched-actions'
@@ -54,7 +53,7 @@ export default compose(
 	})
 	return (
 		<div id="PeriodSwitch">
-			<span className="base ui__ card">
+			<div className="base ui__ small toggle">
 				<label>
 					<Field
 						name="période"
@@ -65,7 +64,7 @@ export default compose(
 							updateSituation('mois', batchPeriodChange, situation, rules)
 						}
 					/>
-					<span className="radioText">
+					<span>
 						<Trans>mois</Trans>
 					</span>
 				</label>
@@ -79,11 +78,11 @@ export default compose(
 							updateSituation('année', batchPeriodChange, situation, rules)
 						}
 					/>
-					<span className="radioText">
+					<span>
 						<Trans>année</Trans>
 					</span>
 				</label>
-			</span>
+			</div>
 		</div>
 	)
 })

--- a/source/components/Simulation.js
+++ b/source/components/Simulation.js
@@ -5,7 +5,6 @@ import { React, T } from 'Components'
 import Answers from 'Components/AnswerList'
 import Conversation from 'Components/conversation/Conversation'
 import PageFeedback from 'Components/Feedback/PageFeedback'
-import PeriodSwitch from 'Components/PeriodSwitch'
 import withColours from 'Components/utils/withColours'
 import { compose } from 'ramda'
 import emoji from 'react-easy-emoji'
@@ -101,10 +100,11 @@ export default compose(
 							)}
 						</>
 					)}
+
 					{showTargets && (
 						<Animate.fromBottom>{this.props.targets}</Animate.fromBottom>
 					)}
-
+					{!noUserInput && this.props.explanation}
 					{!noUserInput && !noFeedback && (
 						<Animate.appear delay={2000}>
 							<PageFeedback
@@ -117,8 +117,6 @@ export default compose(
 							/>
 						</Animate.appear>
 					)}
-					<PeriodSwitch />
-					{!noUserInput && this.props.explanation}
 				</>
 			)
 		}

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -18,12 +18,15 @@
 	margin-top: -1rem;
 }
 
-#targetSelection #targets > li.not-editable * {
+#targetSelection #targets > li.small-target * {
 	font-size: 1rem;
 	font-weight: normal;
 }
-#targetSelection #targets > li.not-editable {
+#targetSelection #targets > li.small-target {
 	border-top: none;
+}
+#targetSelection #targets > li.small-target .targetInput {
+	border-width: 1px;
 }
 
 #targetSelection #targets > li {
@@ -40,6 +43,7 @@
 
 #targetSelection #targets > li p {
 	margin: 0.2em 0 0;
+	font-style: italic;
 	opacity: 0.8;
 	line-height: 1.2rem;
 }
@@ -48,23 +52,8 @@
 	display: flex;
 	align-items: center;
 }
-
-#targetSelection .progressCircle {
-	margin-right: 0.6em;
-}
-#targetSelection .progressCircle svg {
-	width: 2em;
-}
-/* IE */
-@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-	#targetSelection .progressCircle svg {
-		max-height: 2.5rem;
-	}
-}
-
-#targetSelection .progressCircle i {
-	color: #5de662;
-	font-size: 220%;
+#targetSelection #targets > li.small-target .header p {
+	display: none;
 }
 
 #targetSelection .optionTitle {
@@ -97,24 +86,19 @@
 }
 
 #targetSelection .targetInputOrValue {
-	font-size: 135%;
-	margin-left: 0.6em;
+	font-size: 125%;
+	margin-left: 0.6rem;
 	text-align: right;
 }
 
-#targetSelection #aidesGlimpse {
-	font-size: 75%;
-	margin-top: 0.3em;
-}
-#targetSelection #aidesGlimpse a {
-	font-weight: 300;
-}
 #targetSelection .editable:not(.attractClick) {
 	border: 2px solid rgba(0, 0, 0, 0);
 	border-bottom: 1px dashed #ffffff91;
 	min-width: 2.5em;
-	margin: 0.2rem 0.6rem;
 	display: inline-block;
+}
+#targetSelection .targetInputOrValue > :not(.targetInput, .attractClick) {
+	margin: 0.2rem 0.6rem;
 }
 
 #targetSelection .attractClick.editable::before {

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -9,7 +9,6 @@ import { compose, isEmpty, isNil, propEq } from 'ramda'
 import React, { Component, PureComponent } from 'react'
 import { withTranslation } from 'react-i18next'
 import { connect } from 'react-redux'
-import { withRouter } from 'react-router'
 import { Link } from 'react-router-dom'
 import { change, Field, formValueSelector, reduxForm } from 'redux-form'
 import {
@@ -33,7 +32,6 @@ export default compose(
 		form: 'conversation',
 		destroyOnUnmount: false
 	}),
-	withRouter,
 	connect(
 		state => ({
 			getTargetValue: dottedName =>
@@ -61,7 +59,6 @@ export default compose(
 			const props = this.props
 			const targets = props.analysis ? props.analysis.targets : []
 			// Initialize defaultValue for target that can't be computed
-
 			targets
 				.filter(
 					target =>
@@ -112,9 +109,8 @@ export default compose(
 					conversationStarted,
 					activeInput,
 					setActiveInput,
-					analysis,
-
-					match
+					setFormValue,
+					analysis
 				} = this.props,
 				targets = analysis ? analysis.targets : []
 
@@ -130,58 +126,17 @@ export default compose(
 								)
 							})
 							.map(target => (
-								<li
-									key={target.name}
-									className={!target.question ? 'not-editable' : undefined}>
-									<Animate.appear alreadyPresent={!target.nodeValue}>
-										<div>
-											<div className="main">
-												<Header
-													{...{
-														match,
-														target,
-														conversationStarted,
-														isActiveInput: activeInput === target.dottedName
-													}}
-												/>
-												{!target.question && (
-													<span
-														style={{
-															flex: 1,
-															borderBottom: '1px dashed #ffffff91',
-															marginLeft: '1rem'
-														}}
-													/>
-												)}
-												<TargetInputOrValue
-													{...{
-														target,
-														targets,
-														activeInput,
-														setActiveInput,
-														setFormValue: this.props.setFormValue
-													}}
-												/>
-											</div>
-											{activeInput === target.dottedName &&
-												!conversationStarted && (
-													<Animate.fromTop>
-														<InputSuggestions
-															suggestions={target.suggestions}
-															onFirstClick={value =>
-																this.props.setFormValue(
-																	target.dottedName,
-																	'' + value
-																)
-															}
-															rulePeriod={target.période}
-															colouredBackground={true}
-														/>
-													</Animate.fromTop>
-												)}
-										</div>
-									</Animate.appear>
-								</li>
+								<Target
+									key={target.dottedName}
+									{...{
+										conversationStarted,
+										target,
+										setFormValue,
+										activeInput,
+										setActiveInput,
+										targets
+									}}
+								/>
 							))}
 					</ul>
 				</div>
@@ -189,6 +144,67 @@ export default compose(
 		}
 	}
 )
+
+const Target = ({
+	target,
+	activeInput,
+	conversationStarted,
+	targets,
+	setActiveInput,
+	setFormValue
+}) => {
+	const isSmallTarget =
+		!target.question || !target.formule || isEmpty(target.formule)
+	return (
+		<li
+			key={target.name}
+			className={isSmallTarget ? 'small-target' : undefined}>
+			<Animate.appear alreadyPresent={!target.nodeValue}>
+				<div>
+					<div className="main">
+						<Header
+							{...{
+								target,
+								conversationStarted,
+								isActiveInput: activeInput === target.dottedName
+							}}
+						/>
+						{isSmallTarget && (
+							<span
+								style={{
+									flex: 1,
+									borderBottom: '1px dashed #ffffff91',
+									marginLeft: '1rem'
+								}}
+							/>
+						)}
+						<TargetInputOrValue
+							{...{
+								target,
+								targets,
+								activeInput,
+								setActiveInput,
+								setFormValue
+							}}
+						/>
+					</div>
+					{activeInput === target.dottedName && !conversationStarted && (
+						<Animate.fromTop>
+							<InputSuggestions
+								suggestions={target.suggestions}
+								onFirstClick={value =>
+									this.props.setFormValue(target.dottedName, '' + value)
+								}
+								rulePeriod={target.période}
+								colouredBackground={true}
+							/>
+						</Animate.fromTop>
+					)}
+				</div>
+			</Animate.appear>
+		</li>
+	)
+}
 
 let Header = withSitePaths(({ target, conversationStarted, sitePaths }) => {
 	const ruleLink =

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames'
 import Controls from 'Components/Controls'
 import InputSuggestions from 'Components/conversation/InputSuggestions'
+import PeriodSwitch from 'Components/PeriodSwitch'
 import withColours from 'Components/utils/withColours'
 import withLanguage from 'Components/utils/withLanguage'
 import withSitePaths from 'Components/utils/withSitePaths'
@@ -84,7 +85,9 @@ export default compose(
 			return (
 				<div id="targetSelection">
 					<QuickLinks />
+
 					{!noUserInput && <Controls controls={analysis.controls} />}
+					<PeriodSwitch />
 					<div style={{ height: '10px' }}>
 						<Progress percent={progress} />
 					</div>

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -266,7 +266,7 @@ const TargetValue = connect(
 						editable: target.question,
 						attractClick: target.question && isNil(target.nodeValue)
 					})}
-					tabIndex="0"
+					{...(target.question ? { tabIndex: 0 } : {})}
 					onClick={this.showField(value)}
 					onFocus={this.showField(value)}>
 					<AnimatedTargetValue value={value} />
@@ -277,7 +277,7 @@ const TargetValue = connect(
 			let { target, setFormValue, activeInput, setActiveInput } = this.props
 			return () => {
 				if (!target.question) return
-				if (value != null)
+				if (value != null && !Number.isNaN(value))
 					setFormValue(target.dottedName, Math.round(value) + '')
 
 				if (activeInput) setFormValue(activeInput, '')
@@ -286,65 +286,3 @@ const TargetValue = connect(
 		}
 	}
 )
-
-// let TargetInput = withLanguage(
-// 	({
-// 		target,
-// 		targets,
-// 		activeInput,
-// 		setActiveInput,
-// 		language,
-// 		setFormValue
-// 	}) => (
-// 		<span className="targetInputContainer">
-// 			{!target.question ? (
-// 				<Montant numFractionDigit={0}>{target.nodeValue}</Montant>
-// 			) : activeInput === target.dottedName || !target.formule ? (
-// 				<Field
-// 					name={target.dottedName}
-// 					onFocus={() => {
-// 						if (target.dottedName !== activeInput) {
-// 							setActiveInput(target.dottedName)
-// 						}
-// 					}}
-// 					component={CurrencyField}
-// 					defaultValue={0}
-// 					autoFocus={target.formule}
-// 					className={classnames('targetInput', {
-// 						active: target.dottedName === activeInput
-// 					})}
-// 					language={language}
-// 				/>
-// 			) : (
-// 				<span style={{ position: 'relative' }}>
-// 					<CurrencyInput
-// 						onFocus={() => {
-// 							if (!target.question) return
-// 							if (target.nodeValue)
-// 								setFormValue(
-// 									target.dottedName,
-// 									Math.round(target.nodeValue) + ''
-// 								)
-// 							const previousActiveTarget = targets.find(
-// 								t => t.dottedName === activeInput
-// 							)
-// 							if (
-// 								previousActiveTarget?.formule ||
-// 								previousActiveTarget?.explanation?.formule
-// 							) {
-// 								setFormValue(activeInput, '')
-// 							}
-// 							setActiveInput(target.dottedName)
-// 						}}
-// 						className={classnames('targetInput', {
-// 							active: target.dottedName === activeInput
-// 						})}
-// 						language={language}
-// 						value={Math.round(target.nodeValue) || ''}
-// 					/>
-// 					<EvaporatingDifference value={target.nodeValue} />
-// 				</span>
-// 			)}
-// 		</span>
-// 	)
-// )

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -1,15 +1,14 @@
 objectifs:
   - entreprise . chiffre d'affaires
+  - entreprise . charges
   - contrat salarié . cotisations
   - impôt . neutre
   - contrat salarié . salaire . net après impôt
 
 questions:
-  - entreprise . charges
   - entreprise . année d'activité
 
 questions à l'affiche:
-  Charges: entreprise . charges
   Année d'activité: entreprise . année d'activité
 
 situation:

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -1,6 +1,6 @@
 objectifs:
   - entreprise . chiffre d'affaires
-  - entreprise . charges non déductibles
+  - entreprise . charges
   - auto entrepreneur . cotisations sociales
   - impôt . impôt sur le revenu à payer
   - revenu net
@@ -10,13 +10,12 @@ questions:
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
   - entreprise . catégorie d'activité . libérale règlementée
-  # pour l'instant pas utilisées 
+  # pour l'instant pas utilisées
   # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
-  - entreprise . charges
+
   - entreprise . année d'activité
 
 questions à l'affiche:
-  Charges: entreprise . charges
   Commerçant, artisan, ou libéral ?: entreprise . catégorie d'activité
   Année d'activité: entreprise . année d'activité
 

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -1,9 +1,9 @@
 objectifs:
   - entreprise . chiffre d'affaires
   - entreprise . charges
-  - indépendant . cotisations à payer
+  - indépendant . cotisations et contributions
   - indépendant . revenu professionnel
-  - impôt . impôt sur le revenu à payer
+  - indépendant . impôt et contributions non déductibles
   - revenu net
 
 questions:

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -1,22 +1,22 @@
 objectifs:
   - entreprise . chiffre d'affaires
+  - entreprise . charges
+  - indépendant . cotisations à payer
   - indépendant . revenu professionnel
   - impôt . impôt sur le revenu à payer
   - revenu net
 
 questions:
-  - entreprise . charges
   - entreprise . catégorie d'activité
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
   - entreprise . catégorie d'activité . libérale règlementée
-  # pour l'instant pas utilisées 
+  # pour l'instant pas utilisées
   # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
   - entreprise . année d'activité
   - situation personnelle . RSA
 
 questions à l'affiche:
-  Charges: entreprise . charges
   Commerçant, artisan, ou libéral ?: entreprise . catégorie d'activité
   Année d'activité: entreprise . année d'activité
 

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -5,13 +5,15 @@ objectifs:
   - revenu net
 questions:
   - entreprise . chiffre d'affaires
+  - entreprise . charges
   - entreprise . catégorie d'activité
   - entreprise . catégorie d'activité . service ou vente
   - entreprise . catégorie d'activité . restauration ou hébergement
+
   - entreprise . catégorie d'activité . libérale règlementée
-  # pour l'instant pas utilisées 
+  # pour l'instant pas utilisées
   # - entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale reglementée
-  - entreprise . charges
+
 bloquant:
   - entreprise . chiffre d'affaires
 situation:

--- a/source/components/ui/Montant.js
+++ b/source/components/ui/Montant.js
@@ -29,7 +29,8 @@ const Montant = ({
 	<span className={'montant ' + className} style={style}>
 		{value === 0 || Number.isNaN(value)
 			? '—'
-			: NumberFormat(language, {
+			: // // $FlowFixMe
+			  NumberFormat(language, {
 					style: type,
 					currency: 'EUR',
 					maximumFractionDigits: numFractionDigit,

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2661,7 +2661,7 @@
 - nom: revenu net
   titre: Revenu net
   format: euros
-  résumé: Après cotisations et impôt sur le revenu
+  résumé: Après le paiement de l'impôt sur le revenu
   période: flexible
   question: Quel revenu voulez-vous toucher ?
   description: |
@@ -2720,7 +2720,7 @@
   formule:
     somme:
       - contrat salarié . rémunération . total
-      - indépendant . revenu brut
+      - indépendant . revenu total du dirigeant
       - auto entrepreneur . base des cotisations
 
 - espace: entreprise
@@ -2757,7 +2757,7 @@
   formule: charges
   période: flexible
 
-- espace: indépendant
+- espace: indépendant . cotisations et contributions
   nom: réduction ACRE
   applicable si: entreprise . année d'activité = 'première année'
   période: flexible
@@ -2766,7 +2766,7 @@
       assiette: cotisations - cotisations . retraite complémentaire
       taux: taux ACRE
 
-- espace: indépendant
+- espace: indépendant . cotisations et contributions . réduction ACRE
   nom: taux ACRE
   période: flexible
   formule:
@@ -2786,6 +2786,7 @@
 
 - espace: indépendant
   nom: revenu professionnel
+  résumé: Après le paiement des cotisations et des charges
   question: Quel est votre revenu professionnel ?
   description: |
 
@@ -2798,7 +2799,7 @@
   formule:
     inversion numérique:
       avec:
-        - revenu brut
+        - revenu total du dirigeant
         - revenu net
         - entreprise . chiffre d'affaires
 
@@ -2907,9 +2908,9 @@
     - si: libérale règlementée
       niveau: avertissement
       message: |
-        Attention, le simulateur n'est pas encore complet pour les professions libérales règlementées : 
+        Attention, le simulateur n'est pas encore complet pour les professions libérales règlementées :
 
-        - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant. 
+        - pour la retraite complémentaire, seul le barème interprofessionnel, celui de la CIPAV, a été intégré pour l'instant.
         - assurez-vous que le statut auto-entrepreneur est bien compatible avec votre profession règlementée
         - pour les praticiens et auxiliaires médicaux (PAM), [les spécificités de calcul des cotisations](https://www.urssaf.fr/portail/home/praticien-et-auxiliaire-medical/mes-cotisations/le-calcul-de-mes-cotisations/la-participation-de-la-cpam-a-me.html) et la [CURPS](https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-aux-unions-regio/qui-est-redevable-de-la-curps.html) ne sont pas encore intégrées.
 
@@ -2999,12 +3000,12 @@
   par défaut: non
   question: Activité à la sécurité sociale des indépendants ?
 
-- espace: indépendant
+- espace: indépendant . cotisations et contributions
   nom: cotisations à payer
   période: flexible
   formule: cotisations - réduction ACRE
 
-- espace: indépendant
+- espace: indépendant . cotisations et contributions
   nom: cotisations
   période: flexible
   références:
@@ -3020,10 +3021,17 @@
 
 - espace: indépendant
   nom: cotisations et contributions
-
-- espace: indépendant . cotisations
+  formule:
+    somme:
+      - cotisations à payer
+      - CSG et CRDS (déductible)
+      - formation professionnelle
   période: flexible
+  format: euros
+
+- espace: indépendant . cotisations et contributions . cotisations
   nom: maladie
+  période: flexible
   formule:
     variations:
       - si: entreprise . catégorie d'activité . libérale règlementée
@@ -3031,7 +3039,7 @@
 
       - sinon: artisans commerçants libéraux
 
-- espace: indépendant . cotisations . maladie
+- espace: indépendant . cotisations et contributions . cotisations . maladie
   période: flexible
   nom: libérale règlementée
   titre: maladie libérale règlementée
@@ -3043,9 +3051,11 @@
         0: 1.5%
         1.1: 6.5%
 
-- espace: indépendant . cotisations . maladie
+
+- espace: indépendant . cotisations et contributions . cotisations . maladie
   nom: assiette
   titre: assiette maladie
+
   période: flexible
   formule:
     variations:
@@ -3058,7 +3068,7 @@
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-- espace: indépendant . cotisations
+- espace: indépendant . cotisations et contributions . cotisations
   nom: indemnités journalières maladie
   titre: Maladie 2
   description: Cotisations pour les indémnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
@@ -3070,7 +3080,7 @@
       taux: 0.85%
       plafond: 5 * plafond sécurité sociale temps plein
 
-- espace: indépendant . cotisations . maladie
+- espace: indépendant . cotisations et contributions . cotisations . maladie
   nom: artisans commerçants libéraux
   période: flexible
   formule:
@@ -3085,13 +3095,13 @@
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
   note: |
-    On retrouve dans le décret ci-dessous la phrase suivante : 
+    On retrouve dans le décret ci-dessous la phrase suivante :
 
     > I.-Par dérogation au premier alinéa, le taux de la cotisation est fixé à 6,5 % lorsque le revenu d'activité est supérieur à cinq fois la valeur annuelle du plafond de la sécurité sociale déterminée conformément à l'article D. 613-2.
 
     Le terme "lorsque" laisse entendre qu'en cas de dépassement du seuil 5xPSS, tout le revenu est soumis à 6.5%. Il semblerait qu'une interprétation inverse soit à privilégier : seule la part supérieure à ce seuil est soumise à ce taux, et c'est cette implémentation que nou avons retenue.
 
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+- espace: indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
   nom: taux variable
   période: flexible
   formule:
@@ -3100,7 +3110,7 @@
         alors: taux RSA
       - sinon: taux
 
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+- espace: indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
   nom: taux RSA
   période: flexible
   formule:
@@ -3110,7 +3120,8 @@
   note: |
     Pour les indépendants au RSA, seule la réduction simple définie dans le décret de calcul de la cotisation maladie est prise en compte. La réduction renforcée en-dessous de 40% du plafond de la sécurité sociale ne l'est pas, car il n'y a pas d'assiette minimale.
 
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+
+- espace: indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
   nom: taux RSA part variable
   période: flexible
   formule:
@@ -3118,7 +3129,7 @@
       assiette: 5%
       taux: revenu professionnel / seuil supérieur de réduction
 
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+- espace: indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
   nom: seuil supérieur de réduction
   période: flexible
   formule:
@@ -3126,7 +3137,7 @@
       assiette: plafond sécurité sociale temps plein
       taux: 110%
 
-- espace: indépendant . cotisations . maladie . artisans commerçants libéraux
+- espace: indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
   nom: taux
   période: flexible
   formule:
@@ -3139,15 +3150,15 @@
         0.4: 3.168%
         1.1: 6.35%
   note: |
-    Cette cotisation est à la base très simple : la cotisation maladie est de 7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà. Cependant : 
-    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs. 
+    Cette cotisation est à la base très simple : la cotisation maladie est de 7.2% jusqu'à 5 fois le plafond de la sécurité sociale, puis 6.5% au-delà. Cependant :
+    - pour son recouvrement, cette cotisation est séparée en 2 : maladie et maladie 2, cette deuxième au taux de 0.85%. Ainsi le montant de 7.2% cité dans le décret est rabaissé à 6.35% dans nos calculs.
     - des réductions de cotisation ont été introduites : une exonération simple en-dessous de 110% du plafond de la sécurité sociale, puis une exonération renforcée en-dessous de 40%. Le barème ci-dessus prend en compte ces réductions.
 
   références:
     décret formule de calcul: https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000036342439&categorieLien=id
 
 
-- espace: indépendant . cotisations
+- espace: indépendant . cotisations et contributions . cotisations
   nom: retraite de base
   période: année
   formule:
@@ -3174,7 +3185,7 @@
               - au-dessus de: 1
                 taux: 0.6%
 
-- espace: indépendant . cotisations . retraite de base
+- espace: indépendant . cotisations et contributions . cotisations . retraite de base
   nom: assiette
   période: flexible
   titre: assiette retraite de base
@@ -3189,7 +3200,7 @@
   références:
     secu-independants.fr: https://www.secu-independants.fr/cotisations/calcul-des-cotisations/cotisations-minimales/
 
-- espace: indépendant . cotisations
+- espace: indépendant . cotisations et contributions . cotisations
   nom: retraite complémentaire
   période: année
   format: euros
@@ -3235,7 +3246,7 @@
               - au-dessus de: 162096
                 taux: 0%
 
-- espace: indépendant . cotisations
+- espace: indépendant . cotisations et contributions . cotisations
   nom: invalidité et décès
   période: flexible
   formule:
@@ -3246,7 +3257,7 @@
 
       # TODO invalidité décès pour les libéraux
       # 3 classes, 76, 228, 380€
-- espace: indépendant . cotisations . invalidité et décès
+- espace: indépendant . cotisations et contributions . cotisations . invalidité et décès
   nom: assiette
   période: flexible
   titre: assiette invalidité et décès
@@ -3304,7 +3315,7 @@
     fiche URSSAF: https://www.urssaf.fr/portail/home/independant/mes-cotisations/quelles-cotisations/la-contribution-a-la-formation-p/base-de-calcul-et-taux-de-la-con.html
     brève URSSAF pour les artisans: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-independant/transfert-du-recouvrement-de-la.html
 
-- espace: indépendant . cotisations
+- espace: indépendant . cotisations et contributions . cotisations
   nom: allocations familiales
   période: flexible
   formule:
@@ -3317,14 +3328,20 @@
         1.4: 3.1%
 
 - espace: indépendant
-  nom: revenu brut
+  nom: revenu total du dirigeant
   période: flexible
   formule:
     somme:
       - revenu professionnel
-      - cotisations à payer
-      - cotisations et contributions . CSG et CRDS (déductible)
-      - cotisations et contributions . formation professionnelle
+      - cotisations et contributions
+
+- espace: indépendant
+  nom: impôt et contributions non déductibles
+  période: flexible
+  formule:
+    somme:
+      - impôt . impôt sur le revenu à payer
+      - cotisations et contributions . CSG et CRDS (non déductible)
 
 - nom: auto entrepreneur
   icônes: 🚶

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2661,7 +2661,7 @@
 - nom: revenu net
   titre: Revenu net
   format: euros
-  résumé: Après le paiement de l'impôt sur le revenu
+  résumé: Après impôt sur le revenu
   période: flexible
   question: Quel revenu voulez-vous toucher ?
   description: |
@@ -2786,7 +2786,7 @@
 
 - espace: indépendant
   nom: revenu professionnel
-  résumé: Après le paiement des cotisations et des charges
+  résumé: Après cotisations et des charges
   question: Quel est votre revenu professionnel ?
   description: |
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2745,10 +2745,6 @@
 
   références:
     Charges déductibles ou non du résultat fiscal d'une entreprise: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31973
-  suggestions:
-    25k€: 25000
-    50k€: 50000
-    100k€: 100000
   période: flexible
   par défaut: 0
   format: euros

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -68,9 +68,10 @@ export let noUserInputSelector = createSelector(
 	[
 		formattedSituationSelector,
 		targetNamesSelector,
+		parsedRulesSelector,
 		state => state.simulation?.config?.bloquant
 	],
-	(situation, targetNames, bloquant) => {
+	(situation, targetNames, parsedRules, bloquant) => {
 		if (!situation) {
 			return true
 		}
@@ -79,7 +80,11 @@ export let noUserInputSelector = createSelector(
 			bloquant && bloquant.every(rule => situations.includes(rule))
 		const targetIsAnswered =
 			targetNames &&
-			targetNames.some(target => Object.keys(situation).includes(target))
+			targetNames.some(
+				targetName =>
+					findRuleByDottedName(parsedRules, targetName)?.formule &&
+					targetName in situation
+			)
 		return !(allBlockingAreAnswered || targetIsAnswered)
 	}
 )

--- a/source/sites/mycompanyinfrance.fr/App.js
+++ b/source/sites/mycompanyinfrance.fr/App.js
@@ -65,7 +65,7 @@ class InFranceRoute extends Component {
 				sitePaths={paths}
 				reduxMiddlewares={middlewares}
 				onStoreCreated={persistEverything()}
-				initialStore={retrievePersistedState()}>
+				initialStore={retrievePersistedState() || {}}>
 				<TrackPageView />
 				<div id="content">
 					<RouterSwitch />

--- a/source/sites/mycompanyinfrance.fr/App.js
+++ b/source/sites/mycompanyinfrance.fr/App.js
@@ -12,7 +12,10 @@ import { withTranslation } from 'react-i18next'
 import { Route, Switch } from 'react-router-dom'
 import 'Ui/index.css'
 import Provider from '../../Provider'
-import { persistEverything } from '../../storage/persistEverything'
+import {
+	persistEverything,
+	retrievePersistedState
+} from '../../storage/persistEverything'
 import ReactPiwik from '../../Tracker'
 import './App.css'
 import Footer from './layout/Footer/Footer'
@@ -62,7 +65,7 @@ class InFranceRoute extends Component {
 				sitePaths={paths}
 				reduxMiddlewares={middlewares}
 				onStoreCreated={persistEverything()}
-				initialStore={{}}>
+				initialStore={retrievePersistedState()}>
 				<TrackPageView />
 				<div id="content">
 					<RouterSwitch />


### PR DESCRIPTION
Je reste convaincu de l'importance de la question des charges pour une grande partie des utilisateurs, mais l'afficher dès le départ me semble être une fausse bonne idée. Comme on le voit sur [cette démo](https://deploy-preview-502--syso.netlify.com/sécurité-sociale/indépendant.
), quand on débarque sur cette page, on a dans un premier temps tous ces boutons :

- lire le bandeau d'avertissement et le replier 
- CA
- net
- revenu pro
- charges
- période de simulation

Puis s'ajoutent rapidement : 
- Je suis satisfait : oui / non, Faire une suggestion
- Catégorie d'activité
- Année d'activité

**Je pense que l'on s'est égarés** dans ce trop plein de possibilités. Je suggère donc de :
 
- laisser le temps à l'utilisateur de saisir un des revenus (CA, revenu brut, net) 
- lui donner sa  récompense immédiate : chez nous, il n'aura pas à remplir 30 champs pour avoir son premier résultat
- lui faire apparaître automatiquement (quelques secondes) la prochaine question, celle des charges. Et ainsi de suite.

L'utilisateur qui découvre le simulateur est donc totalement guidé vers une simulation complète, pas à pas, dans l'ordre d'importance des questions. C'est notre cible principale, il ne faut pas la perdre. 

Pour satisfaire l'utilisateur expert, au-dela d'une sauvegarde améliorée des données, nous pouvons lui donner la possibilité de répondre à la demande à n'importe quelle question via un champs de recherche.

On rejoint alors la réflexion sur le simulateur de comparaison des régimes : 
- d'abord une comparaison des avantages des différents régimes
- puis un clic sur "faire une simulation chiffrée" permet de préciser la comparaison avec les sommes en jeu, question par question. 

