### PR TITLE
Grammaire2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
 		"eslint": "LIST=`git diff --cached --name-only --diff-filter=AMR HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
 		"externalize": "node source/externalize.js",
 		"heroku-postbuild": "yarn install --production=false && yarn compile",
-		"pretest": "LIST=`git diff --name-only --diff-filter=AMR HEAD^..HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi && flow check",
+		"pretest": "LIST=`git diff --name-only --diff-filter=AMR HEAD^..HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
 		"start": "node source/server.js",
 		"test-inversions": "yarn test-watch --grep 'inversions'",
 		"test-meca": "yarn test-watch --grep 'Mécanismes'",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"i18next": "^14.1.1",
 		"iframe-resizer": "^3.6.2",
 		"marked": "^0.3.17",
-		"nearley": "^2.13.0",
+		"nearley": "^2.16.0",
 		"ramda": "^0.25.0",
 		"raven-for-redux": "^1.3.1",
 		"raven-js": "^3.26.4",

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -1,4 +1,11 @@
-# Pour éditer ou comprendre ce fichier, utilisez l'éditeur web Nearley : https://omrelli.ug/nearley-playground/
+@preprocessor esmodule
+
+@{% 
+import maSuperFonction from './maSuperFonction'
+import treatVariableTransforms from './treatVariable'
+%}
+
+# To understand or edit this file, use the awesome nearley playground (but save your work, it can crash sometimes) : https://omrelli.ug/nearley-playground/
 
 
 main ->
@@ -18,12 +25,7 @@ P -> "(" _ AS _ ")" {% function(d) {return {category:'parentheses', explanation:
     | NumericTerminal           {% id %}
 
 
-Comparison -> Comparable _ ComparisonOperator _ Comparable {% d => ({
-	category: 'comparison',
-	type: 'boolean',
-	operator: d[2][0],
-	explanation: [d[0], d[4]]
-}) %}
+Comparison -> Comparable _ ComparisonOperator _ Comparable {% yo => maSuperFonction(yo) %}
 
 Comparable -> (  AS | NonNumericTerminal) {% d => d[0][0] %}
 
@@ -81,10 +83,9 @@ Term -> Variable {% id %}
 		| number {% id %}
 		| percentage {% id %}
 
-Variable -> VariableFragment (_ Dot _ VariableFragment {% d => d[3] %}):*  {% d => ({
-	category: 'variable',
-	fragments: [d[0], ...d[1]],
-	type: 'numeric | boolean'
+Variable -> VariableFragment (_ Dot _ VariableFragment {% [,,,fragment] => fragment %}):* 
+{% ([firstFragment, nextFragments]) =>  treatVariableTransforms({
+	fragments: [firstFragment, ...nextFragments],
 }) %}
 
 String -> "'" [ .'a-zA-Z\-\u00C0-\u017F ]:+ "'" {% d => ({
@@ -105,7 +106,7 @@ _ -> [\s]     {% d => null %}
 
 number -> [0-9]:+ ([\.] [0-9]:+):?        {% d => ({category: 'value', nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))}) %}
 
-percentage -> [0-9]:+ ([\.] [0-9]:+):? [\%]        {% d => ({category: 'percentage', nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))/100}) %}
+percentage -> [0-9]:+ ([\.] [0-9]:+):? [\%]        {% d => percentage(d)%}
 
 Boolean -> "oui" {% d=> ({category: 'boolean', nodeValue: true}) %}
  | "non" {% d=> ({category: 'boolean', nodeValue: false}) %}

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -111,12 +111,12 @@ _ -> [\s]     {% d => null %}
 
 number -> [0-9]:+ ([\.] [0-9]:+):?        {% d => ({constant:{
 
-	rawNode: d.join(''),
+	rawNode: d,
 nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))}}) %}
 
 percentage -> [0-9]:+ ([\.] [0-9]:+):? [\%]        {% d => ({ 'constant':{
 
-	rawNode: d.join(''),
+	rawNode: d,
 type: 'percentage', nodeValue: parseFloat(d[0].join("")+(d[1]?(d[1][0]+d[1][1].join("")):""))/100}}) %}
 
 

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -1,7 +1,3 @@
-
-# To understand or edit this file, use the awesome nearley playground (but save your work, it can crash sometimes) : https://omrelli.ug/nearley-playground/
-
-
 main ->
 		  AS {% id %}
 		| Comparison {% id %}
@@ -14,7 +10,7 @@ NumericTerminal ->
 		| percentage {% id %}
 		| number {% id %}
 
-Parentheses -> "(" _ AS _ ")" {% ([,,e]) => e %}
+Parentheses -> "(" AS ")" {% ([,e]) => e %}
     | NumericTerminal           {% id %}
 
 ComparisonOperator -> ">" | "<" | ">=" | "<=" | "=" | "!="
@@ -40,7 +36,7 @@ NegatedVariable -> "≠" _ Variable {% ([,,{variable}]) => ({'≠': {explanation
 
 FilteredVariable -> Variable _ Filter {% ([{variable},,filter]) => ({filter: {filter, explanation: variable}}) %}
 
-Filter -> "(" VariableFragment ")" {% ([,filter]) =>filter %}
+Filter -> "[" VariableFragment "]" {% ([,filter]) =>filter %}
 
 TemporalVariable -> Variable _ TemporalTransform {% ([{variable},,temporalTransform]) => ({'temporalTransform': {explanation: variable, temporalTransform} }) %}
 

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -1,3 +1,7 @@
+# This grammar is inspired by the "fancier grammar" tab of the nearley playground : https://omrelli.ug/nearley-playground
+
+# Look for the PEMDAS system : Parentheses, Exponents (omitted here), Multiplication, and you should guess the rest :) 
+
 @preprocessor esmodule
 
 @{% 
@@ -5,7 +9,7 @@ import {string, filteredVariable, variable, temporalVariable,  operation, boolea
 %}
 
 main ->
-		  AS {% id %}
+		  AdditionSubstraction {% id %}
 		| Comparison {% id %}
 		| NonNumericTerminal {% id %}
 
@@ -16,14 +20,14 @@ NumericTerminal ->
 		| percentage {% id %}
 		| number {% id %}
 
-Parentheses -> "(" AS ")" {% ([,e]) => e %}
+Parentheses -> "(" AdditionSubstraction ")" {% ([,e]) => e %}
     | NumericTerminal           {% id %}
 
 ComparisonOperator -> ">" | "<" | ">=" | "<=" | "=" | "!="
 
 Comparison -> Comparable _ ComparisonOperator _ Comparable {% operation('comparison')%}
 
-Comparable -> (  AS | NonNumericTerminal) {% ([[e]]) => e %}
+Comparable -> (  AdditionSubstraction | NonNumericTerminal) {% ([[e]]) => e %}
 
 NonNumericTerminal ->  
 	Boolean  {% id %} 
@@ -46,18 +50,18 @@ Temporality -> "annuel" | "mensuel" {% id %}
 
 
 # Addition and subtraction
-AS -> AS _ ASOperator _ MD  {%  operation('calculation') %}
-    | MD            {% id %}
+AdditionSubstraction -> AdditionSubstraction _ AdditionSubstractionOperator _ MultiplicationDivision  {%  operation('calculation') %}
+    | MultiplicationDivision            {% id %}
 
 	 
-ASOperator	-> "+" {% id %}
+AdditionSubstractionOperator	-> "+" {% id %}
 	| "-" {% id %}
 
-MDOperator	-> "*" {% id %}
+MultiplicationDivisionOperator	-> "*" {% id %}
 	| "/" {% id %}
 
 # Multiplication and division
-MD -> MD _ MDOperator _ Parentheses  {% operation('calculation') %}
+MultiplicationDivision -> MultiplicationDivision _ MultiplicationDivisionOperator _ Parentheses  {% operation('calculation') %}
     | Parentheses             {% id %}
 
 Term -> Variable {% id %}

--- a/source/engine/grammar.ne
+++ b/source/engine/grammar.ne
@@ -34,9 +34,9 @@ NonNumericTerminal ->
 
 NegatedVariable -> "≠" _ Variable {% ([,,{variable}]) => ({'≠': {explanation: variable} }) %}
 
-FilteredVariable -> Variable _ Filter {% ([{variable},,filter]) => ({filter: {filter, explanation: variable}}) %}
+FilteredVariable -> Variable _ Filter {% ([{variable},,filter],l,reject) => ['mensuel', 'annuel'].includes(filter) ? reject : ({filter: {filter, explanation: variable}}) %}
 
-Filter -> "[" VariableFragment "]" {% ([,filter]) =>filter %}
+Filter -> "[" VariableFragment "]" {% ([,filter]) => filter %}
 
 TemporalVariable -> Variable _ TemporalTransform {% ([{variable},,temporalTransform]) => ({'temporalTransform': {explanation: variable, temporalTransform} }) %}
 
@@ -84,10 +84,13 @@ Term -> Variable {% id %}
 		| percentage {% id %}
 
 Variable -> VariableFragment (_ Dot _ VariableFragment {% ([,,,fragment]) => fragment %}):* 
-{% ([firstFragment, nextFragments]) =>  
-({variable: {
-	fragments: [firstFragment, ...nextFragments],
-}}) %}
+{% ([firstFragment, nextFragments], l, reject) =>  {
+let fragments = [firstFragment, ...nextFragments] 
+if (fragments.length === 1 && ['oui', 'non'].includes(fragments[0])) 
+		return reject
+return ({variable: {
+	fragments
+}}) }%}
 
 String -> "'" [ .'a-zA-Z\-\u00C0-\u017F ]:+ "'" {% d => ({constant: {
 	

--- a/source/engine/grammarFunctions.js
+++ b/source/engine/grammarFunctions.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export let boolean = nodeValue => ({
+	category: 'boolean',
+	nodeValue: nodeValue,
+	// eslint-disable-next-line
+	jsx: () => <span className="boolean">{rawNode}</span>
+})
+
+export let percentage = d => ({
+	// We don't need to handle category == 'value' because YAML then returns it as
+	// numerical value, not a String: it goes to treatNumber
+	nodeValue:
+		parseFloat(d[0].join('') + (d[1] ? d[1][0] + d[1][1].join('') : '')) / 100,
+	category: 'percentage',
+	// eslint-disable-next-line
+	jsx: () => <span className="value">{rawNode.split('%')[0]} %</span>
+	//on ajoute l'espace nécessaire en français avant le pourcentage
+})

--- a/source/engine/grammarFunctions.js
+++ b/source/engine/grammarFunctions.js
@@ -1,19 +1,63 @@
-import React from 'react'
+/* Those are postprocessor functions for the Nearley grammar.ne. 
+The advantage of putting them here is to get prettier's JS formatting, since Nealrey doesn't support it https://github.com/kach/nearley/issues/310 */
 
-export let boolean = nodeValue => ({
-	category: 'boolean',
-	nodeValue: nodeValue,
-	// eslint-disable-next-line
-	jsx: () => <span className="boolean">{rawNode}</span>
+export let operation = type => ([A, , operator, , B]) => ({
+	[operator]: {
+		type: type,
+		explanation: [A, B]
+	}
+})
+
+export let filteredVariable = ([{ variable }, , filter], l, reject) =>
+	['mensuel', 'annuel'].includes(filter)
+		? reject
+		: { filter: { filter, explanation: variable } }
+
+export let temporalVariable = ([{ variable }, , temporalTransform]) => ({
+	temporalTransform: { explanation: variable, temporalTransform }
+})
+
+export let variable = ([firstFragment, nextFragments], l, reject) => {
+	let fragments = [firstFragment, ...nextFragments]
+	if (fragments.length === 1 && ['oui', 'non'].includes(fragments[0]))
+		return reject
+	return {
+		variable: {
+			fragments
+		}
+	}
+}
+
+export let number = d => ({
+	constant: {
+		rawNode: d,
+		nodeValue: parseFloat(
+			d[0].join('') + (d[1] ? d[1][0] + d[1][1].join('') : '')
+		)
+	}
 })
 
 export let percentage = d => ({
-	// We don't need to handle category == 'value' because YAML then returns it as
-	// numerical value, not a String: it goes to treatNumber
-	nodeValue:
-		parseFloat(d[0].join('') + (d[1] ? d[1][0] + d[1][1].join('') : '')) / 100,
-	category: 'percentage',
-	// eslint-disable-next-line
-	jsx: () => <span className="value">{rawNode.split('%')[0]} %</span>
-	//on ajoute l'espace nécessaire en français avant le pourcentage
+	constant: {
+		rawNode: d,
+		type: 'percentage',
+		nodeValue:
+			parseFloat(d[0].join('') + (d[1] ? d[1][0] + d[1][1].join('') : '')) / 100
+	}
+})
+
+export let boolean = ([val]) => ({
+	constant: {
+		rawNode: val,
+		type: 'boolean',
+		nodeValue: { oui: true, non: false }[val]
+	}
+})
+
+export let string = d => ({
+	constant: {
+		type: 'string',
+		nodeValue: d[1].join(''),
+		rawNode: d[1].join('')
+	}
 })

--- a/source/engine/grammarFunctions.js
+++ b/source/engine/grammarFunctions.js
@@ -1,9 +1,9 @@
 /* Those are postprocessor functions for the Nearley grammar.ne. 
 The advantage of putting them here is to get prettier's JS formatting, since Nealrey doesn't support it https://github.com/kach/nearley/issues/310 */
 
-export let operation = type => ([A, , operator, , B]) => ({
+export let operation = operationType => ([A, , operator, , B]) => ({
 	[operator]: {
-		type: type,
+		operationType,
 		explanation: [A, B]
 	}
 })

--- a/source/engine/maSuperFonction.js
+++ b/source/engine/maSuperFonction.js
@@ -1,6 +1,0 @@
-export default d => ({
-	category: 'comparison',
-	type: 'boolean',
-	operator: d[2][0],
-	explanation: [d[0], d[4]]
-})

--- a/source/engine/maSuperFonction.js
+++ b/source/engine/maSuperFonction.js
@@ -1,0 +1,6 @@
+export default d => ({
+	category: 'comparison',
+	type: 'boolean',
+	operator: d[2][0],
+	explanation: [d[0], d[4]]
+})

--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -904,3 +904,11 @@ export let mecanismSynchronisation = (recurse, k, v) => {
 export let mecanismError = (recurse, k, v) => {
 	throw new Error("Le mécanisme '" + k + "' est inconnu !" + v)
 }
+export let mecanismOnePossibility = (recurse, k, v) => ({
+	...v,
+	'une possibilité': 'oui',
+	evaluate: (cache, situationGate, parsedRules, node) => ({
+		...node,
+		missingVariables: { [node.dottedName]: 1 }
+	})
+})

--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -565,7 +565,7 @@ export let mecanismReduction = (recurse, k, v) => {
 				? montantFranchiséDécoté === 0
 					? 0
 					: null
-				: abattement.category === 'percentage'
+				: abattement.type === 'percentage'
 				? max(
 						0,
 						montantFranchiséDécoté - min(val(plafond), val(abattement) * montantFranchiséDécoté)
@@ -904,11 +904,11 @@ export let mecanismSynchronisation = (recurse, k, v) => {
 export let mecanismError = (recurse, k, v) => {
 	throw new Error("Le mécanisme '" + k + "' est inconnu !" + v)
 }
-export let mecanismOnePossibility = (recurse, k, v) => ({
+export let mecanismOnePossibility = dottedName => (recurse, k, v) => ({
 	...v,
 	'une possibilité': 'oui',
 	evaluate: (cache, situationGate, parsedRules, node) => ({
 		...node,
-		missingVariables: { [node.dottedName]: 1 }
+		missingVariables: { [dottedName]: 1 }
 	})
 })

--- a/source/engine/treat.js
+++ b/source/engine/treat.js
@@ -115,7 +115,7 @@ export let treatObject = (rules, rule, treatOptions) => rawNode => {
 			'!=': [(a, b) => !equals(a, b), '≠']
 		},
 		operationDispatch = map(
-			([f, unicode]) => mecanismOperation(f, unicode),
+			([f, unicode]) => mecanismOperation(f, unicode || k),
 			knownOperations
 		)
 
@@ -131,7 +131,7 @@ export let treatObject = (rules, rule, treatOptions) => rawNode => {
 			'le maximum de': mecanismMax,
 			'le minimum de': mecanismMin,
 			complément: mecanismComplement,
-			'une possibilité': mecanismOnePossibility,
+			'une possibilité': mecanismOnePossibility(rule.dottedName),
 			'inversion numérique': mecanismInversion(rule.dottedName),
 			allègement: mecanismReduction,
 			variations: mecanismVariations,
@@ -141,7 +141,7 @@ export let treatObject = (rules, rule, treatOptions) => rawNode => {
 				treatNegatedVariable(treatVariable(rules, rule)(v.explanation)),
 			filter: () =>
 				treatVariableTransforms(rules, rule)({
-					filter: v.filtre,
+					filter: v.filter,
 					variable: v.explanation
 				}),
 			variable: () => treatVariableTransforms(rules, rule)({ variable: v }),

--- a/source/engine/treat.js
+++ b/source/engine/treat.js
@@ -211,6 +211,7 @@ export let treatString = (rules, rule) => rawNode => {
 		return {
 			evaluate,
 			jsx,
+
 			operator,
 			text: rawNode,
 			category: parseResult.category,

--- a/source/engine/treat.js
+++ b/source/engine/treat.js
@@ -78,46 +78,12 @@ export let treatString = (rules, rule) => rawNode => {
 		)
 	}
 
-	if (
-		!contains(parseResult.category)([
-			'variable',
-			'calcExpression',
-			'filteredVariable',
-			'comparison',
-			'negatedVariable',
-			'percentage',
-			'boolean'
-		])
-	)
-		throw new Error(
-			"Attention ! Erreur de traitement de l'expression : " + rawNode
-		)
-
 	if (parseResult.category == 'variable')
 		return treatVariableTransforms(rules, rule)(parseResult)
 	if (parseResult.category == 'negatedVariable')
 		return treatNegatedVariable(
 			treatVariable(rules, rule)(parseResult.variable)
 		)
-
-	if (parseResult.category == 'boolean') {
-		return {
-			nodeValue: parseResult.nodeValue,
-			// eslint-disable-next-line
-			jsx: () => <span className="boolean">{rawNode}</span>
-		}
-	}
-
-	// We don't need to handle category == 'value' because YAML then returns it as
-	// numerical value, not a String: it goes to treatNumber
-	if (parseResult.category == 'percentage')
-		return {
-			nodeValue: parseResult.nodeValue,
-			category: 'percentage',
-			// eslint-disable-next-line
-			jsx: () => <span className="value">{rawNode.split('%')[0]} %</span>
-			//on ajoute l'espace nécessaire en français avant le pourcentage
-		}
 
 	if (
 		parseResult.category == 'calcExpression' ||
@@ -234,6 +200,7 @@ export let treatOther = rawNode => {
 		'Cette donnée : ' + rawNode + ' doit être un Number, String ou Object'
 	)
 }
+
 export let treatObject = (rules, rule, treatOptions) => rawNode => {
 	let mecanisms = intersection(keys(rawNode), keys(knownMecanisms))
 

--- a/source/engine/treat.js
+++ b/source/engine/treat.js
@@ -44,7 +44,8 @@ import {
 	mecanismReduction,
 	mecanismSum,
 	mecanismSynchronisation,
-	mecanismVariations
+	mecanismVariations,
+	mecanismOnePossibility
 } from './mecanisms'
 import { Node } from './mecanismViews/common'
 import { treat } from './traverse'
@@ -228,11 +229,7 @@ export let treatObject = (rules, rule, treatOptions) => rawNode => {
 			'le maximum de': mecanismMax,
 			'le minimum de': mecanismMin,
 			complément: mecanismComplement,
-			'une possibilité': always({
-				...v,
-				'une possibilité': 'oui',
-				missingVariables: { [rule.dottedName]: 1 }
-			}),
+			'une possibilité': mecanismOnePossibility,
 			'inversion numérique': mecanismInversion(rule.dottedName),
 			allègement: mecanismReduction,
 			variations: mecanismVariations,

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -9,7 +9,7 @@ import {
 } from './rules'
 import { getSituationValue } from './variables'
 
-export let treatVariable = (rules, rule, filter) => parseResult => {
+export let treatVariable = (rules, rule, filter) => ({ fragments }) => {
 	let evaluate = (cache, situation, parsedRules, node) => {
 		let dottedName = node.dottedName,
 			// On va vérifier dans le cache courant, dict, si la variable n'a pas été déjà évaluée
@@ -77,8 +77,7 @@ export let treatVariable = (rules, rule, filter) => parseResult => {
 		}
 	}
 
-	let { fragments } = parseResult,
-		variablePartialName = fragments.join(' . '),
+	let variablePartialName = fragments.join(' . '),
 		dottedName = disambiguateRuleReference(rules, rule, variablePartialName)
 
 	return {
@@ -187,7 +186,7 @@ export let treatVariableTransforms = (rules, rule) => parseResult => {
 		return result
 	}
 	let node = treatVariable(rules, rule, parseResult.filter)(
-		parseResult.variable || parseResult
+		parseResult.variable
 	)
 
 	return {

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -28,7 +28,7 @@ export let treatVariable = (rules, rule, filter) => parseResult => {
 				situationValue == null &&
 				(variableHasCond ||
 					variableHasFormula ||
-					findParentDependency(rules, variable))
+					findParentDependency(parsedRules, variable))
 
 		//		if (dottedName.includes('jeune va')) debugger
 
@@ -131,7 +131,7 @@ export let treatVariableTransforms = (rules, rule) => parseResult => {
 		let supportedPeriods = ['mois', 'année', 'flexible']
 		if (nodeValue == null) return filteredNode
 		let ruleToTransform = findRuleByDottedName(
-			rules,
+			parsedRules,
 			filteredNode.explanation.dottedName
 		)
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -667,7 +667,7 @@
 
     Le contrat n'est en fait pas nécessaire dans le droit français, il est possible d'employer quelqu'un sans contrat par exemple dans les cas suivants:
     - Particuliers employeurs : Plus de 8 heures par semaine ou de plus de 4 semaines consécutives dans l'année.
-    - CDI : La signature d’un contrat de travail n’est pas obligatoire dans certains cas. C’est le cas du Contrat de travail à Durée Indéterminée, considéré comme la forme normale et générale de la relation de travail entre un salarié et un employeur (Art. L1221-2 du Code du travail).
+    - CDI : La signature d’un contrat de travail n’est pas obligatoire dans certains cas. C’est le cas du Contrat de travail à Durée Ind��terminée, considéré comme la forme normale et générale de la relation de travail entre un salarié et un employeur (Art. L1221-2 du Code du travail).
 
 - espace: contrat salarié
   nom: assimilé salarié

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -806,7 +806,7 @@
   formule:
     somme:
       - prévoyance obligatoire cadre
-      - complémentaire santé (employeur)
+      - complémentaire santé [employeur]
 
 - espace: contrat salarié
   nom: avantages en nature
@@ -888,15 +888,15 @@
   période: flexible
   formule:
     somme:
-      - vieillesse (salarié)
-      - maladie (salarié)
-      - retraite complémentaire (salarié)
-      - contribution d'équilibre général (salarié)
-      - contribution d'équilibre technique (salarié)
+      - vieillesse [salarié]
+      - maladie [salarié]
+      - retraite complémentaire [salarié]
+      - contribution d'équilibre général [salarié]
+      - contribution d'équilibre technique [salarié]
       - CSG
       - CRDS
-      - APEC (salarié)
-      - complémentaire santé (salarié)
+      - APEC [salarié]
+      - complémentaire santé [salarié]
 
 - espace: contrat salarié . cotisations
   nom: patronales
@@ -905,18 +905,18 @@
   format: euros
   formule:
     somme:
-      - maladie (employeur)
+      - maladie [employeur]
       - ATMP
       - prévoyance obligatoire cadre
-      - complémentaire santé (employeur)
+      - complémentaire santé [employeur]
       - médecine du travail
-      - vieillesse (employeur)
-      - retraite complémentaire (employeur)
-      - contribution d'équilibre général (employeur)
-      - contribution d'équilibre technique (employeur)
+      - vieillesse [employeur]
+      - retraite complémentaire [employeur]
+      - contribution d'équilibre général [employeur]
+      - contribution d'équilibre technique [employeur]
       - allocations familiales
-      - chômage (employeur)
-      - APEC (employeur)
+      - chômage [employeur]
+      - APEC [employeur]
       - AGS
       - FNAL
       - participation effort de construction
@@ -958,7 +958,7 @@
     somme:
       - rémunération . net de cotisations
       - avantages sociaux
-      - CSG (non déductible)
+      - CSG [non déductible]
       - CRDS
 
 - espace: contrat salarié . rémunération . net imposable
@@ -1614,8 +1614,8 @@
       - 1634.39
       - somme:
           - allocations familiales
-          - maladie (employeur)
-          - vieillesse (employeur)
+          - maladie [employeur]
+          - vieillesse [employeur]
 
 - espace: contrat salarié
   nom: réduction générale
@@ -1687,12 +1687,12 @@
   formule:
     somme:
       - allocations familiales
-      - FNAL (employeur)
-      - maladie (employeur)
-      - vieillesse (employeur)
+      - FNAL [employeur]
+      - maladie [employeur]
+      - vieillesse [employeur]
       - part de la cotisation ATMP
-      - retraite complémentaire (employeur)
-      - contribution d'équilibre général (employeur)
+      - retraite complémentaire [employeur]
+      - contribution d'équilibre général [employeur]
   références:
     changements 2019: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/la-reduction-generale-des-cotisa.html
 
@@ -2070,7 +2070,7 @@
     somme:
       - assiette CSG abattue
       - prévoyance obligatoire cadre
-      - complémentaire santé (employeur)
+      - complémentaire santé [employeur]
 
 - espace: contrat salarié
   nom: assiette CSG abattue
@@ -2382,7 +2382,7 @@
     somme:
       - cotisations . assiette
       - prévoyance obligatoire cadre
-      - complémentaire santé (employeur)
+      - complémentaire santé [employeur]
 
   références:
     assiette: http://bofip.impots.gouv.fr/bofip/6690-PGP.html
@@ -2555,7 +2555,7 @@
   période: flexible
   formule:
     somme:
-      - complémentaire santé (employeur)
+      - complémentaire santé [employeur]
       - prévoyance obligatoire cadre
 
 # Ci-dessous une implémentation basique de l'impôt sur le revenu annuel dans le but d'illustrer un post de blog
@@ -2805,7 +2805,7 @@
 
 - espace: indépendant
   nom: revenu net de cotisations
-  formule: revenu professionnel - cotisations et contributions . CSG et CRDS (non déductible)
+  formule: revenu professionnel - cotisations et contributions . CSG et CRDS [non déductible]
   période: flexible
 
 - espace: indépendant
@@ -3049,7 +3049,7 @@
   formule:
     somme:
       - cotisations à payer
-      - CSG et CRDS (déductible)
+      - CSG et CRDS [déductible]
       - formation professionnelle
   format: euros
   période: flexible
@@ -3379,14 +3379,14 @@
   formule:
     somme:
       - impôt . impôt sur le revenu à payer
-      - cotisations et contributions . CSG et CRDS (non déductible)
+      - cotisations et contributions . CSG et CRDS [non déductible]
 
 - nom: auto entrepreneur
   icônes: 🚶
   par défaut: non
   question: L'activité est-elle exercée en auto-entreprise ?
   description: |
-    L'auto-entreprise est une entreprise individuelle simplifiée. À l'origine connu sous l'appellation « auto-entrepreneur », le régime de « micro-entrepreneur » est un régime de travailleur indépendant créé pour simplifier la gestion administrative, notamment en remplaçant toutes les cotisations sociales par un prélèvement unique mensuel.
+    L'auto-entreprise est une entreprise individuelle simplifi��e. À l'origine connu sous l'appellation « auto-entrepreneur », le régime de « micro-entrepreneur » est un régime de travailleur indépendant créé pour simplifier la gestion administrative, notamment en remplaçant toutes les cotisations sociales par un prélèvement unique mensuel.
 
 - espace: auto entrepreneur
   nom: base des cotisations

--- a/test/bug-cotisations.test.js
+++ b/test/bug-cotisations.test.js
@@ -13,7 +13,7 @@ describe('bug-analyse-many', function() {
       - nom: cotisations
         formule: 
           somme: 
-            - cotisation a (salarié)
+            - cotisation a [salarié]
             - cotisation b
 
       - nom: cotisation a

--- a/test/inversion.test.js
+++ b/test/inversion.test.js
@@ -198,7 +198,7 @@ describe('inversions', () => {
                 taux: 50%
 
       - nom: total
-        formule: cotisation (employeur) + cotisation (salarié)
+        formule: cotisation [employeur] + cotisation [salarié]
 
       - nom: brut
         format: euro

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -117,7 +117,7 @@
 - espace: CDD
   nom: poursuivi en CDI
 
-- test: booléen
+- test: variable booléene
   formule: CDD . poursuivi en CDI
   exemples:
     - situation:
@@ -126,6 +126,11 @@
     - situation:
         CDD . poursuivi en CDI: non
       valeur attendue: false
+
+- test: booléen
+  formule: oui
+  exemples:
+    - valeur attendue: true
 
 - test: négation
   formule: ≠ CDD . poursuivi en CDI
@@ -177,6 +182,7 @@
 
 - test: variable modifiée temporellement
   formule: revenu [annuel]
+  période: aucune
   exemples:
     - situation:
         revenu: 1000

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -1,3 +1,18 @@
+- test: entier
+  formule: 5
+  exemples:
+    - valeur attendue: 5
+
+- test: nombre décimal
+  formule: 5.4
+  exemples:
+    - valeur attendue: 5.4
+
+- test: addition de nombres
+  formule: 28 + 1.1
+  exemples:
+    - valeur attendue: 29.1
+
 - nom: salaire de base
 - nom: contrat . salaire de base
 

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -13,6 +13,11 @@
   exemples:
     - valeur attendue: 29.1
 
+- test: addition de plusieurs nombres
+  formule: 27 + 1.1 + 0.9
+  exemples:
+    - valeur attendue: 29
+
 - nom: salaire de base
 - nom: contrat . salaire de base
 

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -18,6 +18,16 @@
   exemples:
     - valeur attendue: 29
 
+- test: addition et multiplication
+  formule: 27 + 1 * 2
+  exemples:
+    - valeur attendue: 29
+
+- test: parenthèses
+  formule: 14.5 * (6 - 4)
+  exemples:
+    - valeur attendue: 29
+
 - nom: salaire de base
 - nom: contrat . salaire de base
 

--- a/test/traverse.test.js
+++ b/test/traverse.test.js
@@ -359,7 +359,7 @@ describe('analyse with mecanisms', function() {
 	it('should handle filtering on components', function() {
 		let rawRules = [
 				{ nom: 'top' },
-				{ nom: 'startHere', espace: 'top', formule: 'composed (salarié)' },
+				{ nom: 'startHere', espace: 'top', formule: 'composed [salarié]' },
 				{
 					nom: 'composed',
 					espace: 'top',
@@ -401,7 +401,7 @@ describe('analyse with mecanisms', function() {
 				{
 					nom: 'startHere',
 					espace: 'top',
-					formule: 'composed (salarié) + composed (employeur)'
+					formule: 'composed [salarié] + composed [employeur]'
 				},
 				{ nom: 'orHere', espace: 'top', formule: 'composed' },
 				{

--- a/yarn.lock
+++ b/yarn.lock
@@ -6186,7 +6186,7 @@ nearley-loader@^2.0.0:
   resolved "https://registry.yarnpkg.com/nearley-loader/-/nearley-loader-2.0.0.tgz#8d75fd2ab3ca9f6153ae099b2bf18f8d5605d203"
   integrity sha512-kkUlMrkLWMoQPlOVmv7a8aHFEiTOShPb1H+CkvJrDMYpMCqnQUpfJgViGFlh0wufMQlGcawPzebcng6KnDJEdg==
 
-nearley@^2.13.0, nearley@^2.7.10:
+nearley@^2.16.0, nearley@^2.7.10:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.16.0.tgz#77c297d041941d268290ec84b739d0ee297e83a7"
   integrity sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==


### PR DESCRIPTION
Pour gérer une grammaire avec des opérations complexes, on doit reprendre treatString, et l'intégrer dans les fonctions de postprocessing de la grammaire.


Sauf qu'on ne peut pas accéder aux `rules` ni `rule`. On va donc les appliquer par la suite dans l'étape de parcours de l'arbre. 

[edit] non, on prend une approche intermédiaire

- [x] est-ce que la refactor a impacté la visualisation des expressions ? Non, mais les opérations multiples ne sont pas lisiblement expliquées. Pas bloquant aujourd'hui : elles sont utilisables pour le calcul seulement.
- [x] le code JS dans la grammaire n'est pas formatté par prettier, mieux vaut l'externaliser 
- [ ] autres éléments à refactorer ?