### PR TITLE
Corrections IR hauts revenus

### DIFF
--- a/source/engine/mecanisms.js
+++ b/source/engine/mecanisms.js
@@ -537,10 +537,11 @@ export let mecanismReduction = (recurse, k, v) => {
 	let objectShape = {
 		assiette: false,
 		abattement: defaultNode(0),
+		plafond: defaultNode(Infinity),
 		franchise: defaultNode(0)
 	}
 
-	let effect = ({ assiette, abattement, franchise, décote }) => {
+	let effect = ({ assiette, abattement, plafond, franchise, décote }) => {
 		let v_assiette = val(assiette)
 
 		if (v_assiette == null) return null
@@ -550,12 +551,12 @@ export let mecanismReduction = (recurse, k, v) => {
 				? 0
 				: décote
 				? do {
-						let plafond = val(décote.plafond),
+						let plafondDécote = val(décote.plafond),
 							taux = val(décote.taux)
 
-						v_assiette > plafond
+						v_assiette > plafondDécote
 							? v_assiette
-							: max(0, (1 + taux) * v_assiette - taux * plafond)
+							: max(0, (1 + taux) * v_assiette - taux * plafondDécote)
 				  }
 				: v_assiette
 
@@ -567,9 +568,9 @@ export let mecanismReduction = (recurse, k, v) => {
 				: abattement.category === 'percentage'
 				? max(
 						0,
-						montantFranchiséDécoté - val(abattement) * montantFranchiséDécoté
+						montantFranchiséDécoté - min(val(plafond), val(abattement) * montantFranchiséDécoté)
 				  )
-				: max(0, montantFranchiséDécoté - val(abattement))
+				: max(0, montantFranchiséDécoté - min(val(plafond), val(abattement)))
 			: montantFranchiséDécoté
 	}
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2591,6 +2591,7 @@
   espace: impôt
   description: |
     Voici le fameux barème de l'impôt sur le revenu. C'est un barème marginal à 5 tranches.
+    Une contribution sur les hauts revenus ajoute deux tranches supplémentaires.
 
     Attention : pour un revenu de 100 000€ annuels, le contribuable ne paiera 41 000€ d'impôt (le taux de la 4ème tranche est 41%) ! Ces 41% sont appliqués uniquement à la part de ses revenus supérieure à 72 617€.
   période: année
@@ -2609,8 +2610,14 @@
         - de: 73779
           à: 156244
           taux: 41%
-        - au-dessus de: 156244
+        - de: 156244
+          à: 250000
           taux: 45%
+        - de: 250000
+          à: 500000
+          taux: 48%
+        - au-dessus de: 500000
+          taux: 49%
           exemples:
   exemples:
     - nom: Haut salaire de ~ 10 000€ mensuels
@@ -2619,6 +2626,7 @@
       valeur attendue: 30366
   références:
     Article 197 du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006308322
+    Article 223 sexies du Code général des impôts: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000025049019&cidTexte=LEGITEXT000006069577
 
 - nom: impôt sur le revenu après décote
   espace: impôt

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -2586,6 +2586,7 @@
           - contrat salarié . rémunération . net imposable
           - indépendant . revenu professionnel
       abattement: 10%
+      plafond: 12502
 
 - nom: impôt sur le revenu
   espace: impôt


### PR DESCRIPTION
Cette PR contient deux modifications dans les règles de calcul de l'IR pour les hauts revenus :

* L'intégration de la contribution exceptionnelle sur les hauts revenus. Elle concerne les foyers fiscaux gagnants plus de 250&nbsp;000&nbsp;€ par an et est constituée de deux tranches marginales qui s'ajoutent aux tranches de l'impôt sur le revenu.
  https://www.service-public.fr/particuliers/vosdroits/F31130
  
  Peut-être est-il préférable de créer une nouvelle règle concernant uniquement cette contribution, plutôt que d'ajouter des tranches "virtuelles" à l'IR ?
* L'intégration du plafonnement de la déduction forfaitaire de 10% pour frais professionnels. Ce plafonnement à une influence pour les revenus supérieurs à 125&nbsp;000&nbsp;€
  https://www.service-public.fr/particuliers/vosdroits/F1989

  L'implémentation de ce plafond a nécessité une modification du moteur.

