### PR TITLE
Adaptation dynamique de la taille de CurrencyInput

### DIFF
--- a/source/components/CurrencyInput/CurrencyInput.js
+++ b/source/components/CurrencyInput/CurrencyInput.js
@@ -73,12 +73,15 @@ class CurrencyInput extends Component {
 		// We display negative numbers iff this was the provided value (but we allow the user to enter them)
 		const valueHasChanged = this.state.value !== this.state.initialValue
 
+		// Autogrow the input
+		const valueLength = (this.state.value || '').toString().length
+
 		return (
 			<div
-				className={classnames(
-					this.props.className,
-					'currencyInput__container'
-				)}>
+				className={classnames(this.props.className, 'currencyInput__container')}
+				{...(valueLength > 5
+					? { style: { width: `${5 + (valueLength - 5) * 0.75}em` } }
+					: {})}>
 				{isCurrencyPrefixed && '€'}
 				<NumberFormat
 					{...forwardedProps}

--- a/source/components/CurrencyInput/CurrencyInput.js
+++ b/source/components/CurrencyInput/CurrencyInput.js
@@ -38,7 +38,7 @@ class CurrencyInput extends Component {
 		// Only trigger the `onChange` event if the value has changed -- and not
 		// only its formating, we don't want to call it when a dot is added in `12.`
 		// for instance
-		if (!this.handleNextChange) {
+		if (!this.handleNextChange || !this.onChange) {
 			return
 		}
 		this.handleNextChange = false

--- a/source/components/CurrencyInput/CurrencyInput.test.js
+++ b/source/components/CurrencyInput/CurrencyInput.test.js
@@ -118,10 +118,23 @@ describe('CurrencyInput', () => {
 
 	it('should not call onChange the value is the same as the current input value', () => {
 		let onChange = spy()
-		const wrapper = mount(<CurrencyInput value={1000} onChange={() => {}} />)
+		const wrapper = mount(<CurrencyInput value={2000} onChange={onChange} />)
 		const input = wrapper.find('input')
 		input.simulate('change', { target: { value: '2000', focus: () => {} } })
 		wrapper.setProps({ value: '2000' })
 		expect(onChange).not.to.have.been.called
+	})
+
+	it('should adapt its size to its content', () => {
+		const wrapper = mount(<CurrencyInput value={1000} />)
+		// It would be better to use `input.offsetWidth` but it's not supported by
+		// Enzyme/JSDOM
+		const getInlineWidth = () =>
+			getComputedStyle(
+				wrapper.find('.currencyInput__container').getDOMNode()
+			).getPropertyValue('width')
+		expect(getInlineWidth()).to.equal('')
+		wrapper.setProps({ value: '1000000' })
+		expect(Number(getInlineWidth().replace(/em$/, ''))).to.be.greaterThan(5)
 	})
 })

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -109,7 +109,8 @@
 
 #targetSelection .attractClick,
 #targetSelection .targetInput {
-	width: 5.5em !important;
+	width: 5.5em;
+	max-width: 7.5em;
 	display: inline-block;
 	text-align: right;
 	background: rgba(255, 255, 255, 0.2);


### PR DESCRIPTION
Le champ de saisie s'adapte à la valeur saisie, cela permet d'afficher entièrement des valeurs à 6 chiffres ou plus.

avant:
![Sélection_346](https://user-images.githubusercontent.com/1730702/58804784-fd607080-8612-11e9-99de-52eb8f2690c9.png)

après:
![Sélection_347](https://user-images.githubusercontent.com/1730702/58804807-05201500-8613-11e9-9c3e-b48aa1afd09d.png)
![Sélection_348](https://user-images.githubusercontent.com/1730702/58804812-06514200-8613-11e9-9a76-c42441f1b700.png)

