### PR TITLE
Ajoute la niche fiscale et sociale du régime des impatriés

### DIFF
--- a/cypress/integration/mon-entreprise/simulateurs.js
+++ b/cypress/integration/mon-entreprise/simulateurs.js
@@ -31,13 +31,16 @@ describe('Simulateurs test', function() {
 				: 'Self-employed income simulator'
 		)
 	})
-	it('should give an estimation for the self-employed income', function() {
+	it('donne une estimation pour le revenu des indépendants', function() {
 		cy.visit(
 			fr ? '/sécurité-sociale/indépendant' : '/social-security/self-employed'
 		)
-		salaryInput(fr ? "Chiffre d'affaires" : 'Turnover').type(100000, {
-			force: true
-		})
+		salaryInput(fr ? 'Rémunération totale' : 'Director total income').type(
+			100000,
+			{
+				force: true
+			}
+		)
 		cy.contains(fr ? 'Cotisations et contributions' : 'All contributions')
 		cy.contains(fr ? "Type d'activité" : 'Activity type').click()
 		cy.contains(

--- a/cypress/integration/mon-entreprise/status.js
+++ b/cypress/integration/mon-entreprise/status.js
@@ -28,6 +28,8 @@ describe('Status guide', function() {
 		cy.get('.ui__.answer-group')
 			.contains(fr ? 'Société' : 'Limited liability company')
 			.click()
+		// The click fails randomly and unexplicablly on CI
+		cy.wait(200)
 		cy.get('.answer-group button')
 			.contains('Assimilé')
 			.click()

--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -28,24 +28,27 @@ const QuickLinks = ({ goToQuestion, quickLinks, quickLinksToHide }: Props) => {
 		toPairs,
 		reject(dottedName => contains(dottedName, quickLinksToHide))
 	)(quickLinks)
+
 	return (
-		<span>
-			<small>
-				<T k="quicklinks.autres">Autres questions :</T>
-			</small>{' '}
-			{links.map(([label, dottedName]) => (
-				<>
-					<button
-						key={dottedName}
-						className="ui__ link-button"
-						onClick={() => goToQuestion(dottedName)}>
-						<T k={'quicklinks.' + label}>{label}</T>
-					</button>{' '}
-					/{' '}
-				</>
-			))}{' '}
-			{/* <button className="ui__ link-button">Voir la liste</button> */}
-		</span>
+		!!links.length && (
+			<span>
+				<small>
+					<T k="quicklinks.autres">Autres questions :</T>
+				</small>{' '}
+				{links.map(([label, dottedName]) => (
+					<>
+						<button
+							key={dottedName}
+							className="ui__ link-button"
+							onClick={() => goToQuestion(dottedName)}>
+							<T k={'quicklinks.' + label}>{label}</T>
+						</button>{' '}
+						/{' '}
+					</>
+				))}{' '}
+				{/* <button className="ui__ link-button">Voir la liste</button> */}
+			</span>
+		)
 	)
 }
 
@@ -55,7 +58,7 @@ export default (compose(
 	connect(
 		(state, props) => ({
 			key: props.language,
-			quickLinks: state.simulation?.config["questions à l'affiche"],
+			quickLinks: state.simulation?.config.questions?.["à l'affiche"],
 			quickLinksToHide: [
 				...state.conversationSteps.foldedSteps,
 				currentQuestionSelector(state)

--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -24,7 +24,6 @@ const QuickLinks = ({ goToQuestion, quickLinks, quickLinksToHide }: Props) => {
 	if (!quickLinks) {
 		return null
 	}
-	console.log(quickLinksToHide)
 	const links = compose(
 		toPairs,
 		reject(dottedName => contains(dottedName, quickLinksToHide))

--- a/source/components/SalaryExplanation.js
+++ b/source/components/SalaryExplanation.js
@@ -2,7 +2,8 @@ import Distribution from 'Components/Distribution'
 import PaySlip from 'Components/PaySlip'
 import withTracker from 'Components/utils/withTracker'
 import { compose } from 'ramda'
-import React from 'react'
+import React, { useRef } from 'react'
+import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
 import { formValueSelector } from 'redux-form'
@@ -29,6 +30,7 @@ export default compose(
 		showDistributionFirst: !state.conversationSteps.foldedSteps.length
 	}))
 )(function SalaryExplanation({ showDistributionFirst }) {
+	const distributionRef = useRef({})
 	return (
 		<ErrorBoundary>
 			<Animate.fromTop key={showDistributionFirst}>
@@ -39,8 +41,22 @@ export default compose(
 					</>
 				) : (
 					<>
+						<div css="text-align: center">
+							<button
+								className="ui__ small simple button"
+								onClick={() =>
+									distributionRef.current.scrollIntoView({
+										behavior: 'smooth',
+										block: 'start'
+									})
+								}>
+								{emoji('📊')} Voir la répartition des cotisations
+							</button>
+						</div>
 						<PaySlipSection />
-						<DistributionSection />
+						<div ref={distributionRef}>
+							<DistributionSection />
+						</div>
 					</>
 				)}
 				<br />

--- a/source/components/SchemeComparaison.js
+++ b/source/components/SchemeComparaison.js
@@ -53,8 +53,8 @@ type SimulationResult = {
 	trimestreValidés: RègleAvecValeur,
 	indemnitésJournalières: RègleAvecMontant,
 	indemnitésJournalièresATMP?: RègleAvecMontant,
-	revenuNetAvantImpôts: RègleAvecMontant,
-	revenuNetAprèsImpôts: RègleAvecMontant,
+	revenuNetDeCotisations: RègleAvecMontant,
+	revenuNetAprèsImpôt: RègleAvecMontant,
 	plafondDépassé?: boolean
 }
 
@@ -73,7 +73,7 @@ const SchemeComparaison = ({
 }: Props) => {
 	const [showMore, setShowMore] = useState(false)
 	const [conversationStarted, setConversationStarted] = useState(
-		!!assimiléSalarié.revenuNetAprèsImpôts.montant
+		!!assimiléSalarié.revenuNetAprèsImpôt.montant
 	)
 	const startConversation = useCallback(() => setConversationStarted(true), [
 		setConversationStarted
@@ -337,17 +337,16 @@ const SchemeComparaison = ({
 						</div>
 					)}
 				</div>
-
-				{conversationStarted && !!assimiléSalarié.revenuNetAprèsImpôts.montant && (
+				{conversationStarted && !!assimiléSalarié.revenuNetAprèsImpôt.montant && (
 					<>
-						<T k="comparaisonRégimes.revenuNetApresImpots">
-							<h3 className="legend">Revenu net après impôts</h3>
+						<T k="comparaisonRégimes.revenuNetApresImpot">
+							<h3 className="legend">Revenu net après impôt</h3>
 						</T>
 						<div className="AS">
 							<Animate.appear className="ui__ plain card">
 								<RuleValueLink
 									onClick={() => setSituationBranch(0)}
-									{...assimiléSalarié.revenuNetAprèsImpôts}
+									{...assimiléSalarié.revenuNetAprèsImpôt}
 								/>
 							</Animate.appear>
 						</div>
@@ -355,7 +354,7 @@ const SchemeComparaison = ({
 							<Animate.appear className="ui__ plain card">
 								<RuleValueLink
 									onClick={() => setSituationBranch(1)}
-									{...indépendant.revenuNetAprèsImpôts}
+									{...indépendant.revenuNetAprèsImpôt}
 								/>
 							</Animate.appear>
 						</div>
@@ -370,12 +369,12 @@ const SchemeComparaison = ({
 								) : (
 									<RuleValueLink
 										onClick={() => setSituationBranch(2)}
-										{...autoEntrepreneur.revenuNetAprèsImpôts}
+										{...autoEntrepreneur.revenuNetAprèsImpôt}
 									/>
 								)}
 							</Animate.appear>
 						</div>
-						<T k="comparaisonRégimes.revenuNetAvantImpots">
+						<T k="comparaisonRégimes.revenuNetAvantImpot">
 							<h3 className="legend">
 								Revenu net de cotisations <small>(avant impôts)</small>
 							</h3>
@@ -383,13 +382,13 @@ const SchemeComparaison = ({
 						<div className="AS">
 							<RuleValueLink
 								onClick={() => setSituationBranch(0)}
-								{...assimiléSalarié.revenuNetAvantImpôts}
+								{...assimiléSalarié.revenuNetDeCotisations}
 							/>
 						</div>
 						<div className="indep">
 							<RuleValueLink
 								onClick={() => setSituationBranch(1)}
-								{...indépendant.revenuNetAvantImpôts}
+								{...indépendant.revenuNetDeCotisations}
 							/>
 						</div>
 						<div className="auto">
@@ -398,7 +397,7 @@ const SchemeComparaison = ({
 							) : (
 								<RuleValueLink
 									onClick={() => setSituationBranch(2)}
-									{...autoEntrepreneur.revenuNetAvantImpôts}
+									{...autoEntrepreneur.revenuNetDeCotisations}
 								/>
 							)}
 						</div>
@@ -628,10 +627,10 @@ export default (compose(
 					indemnitésJournalières: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
 					})('protection sociale . santé . indemnités journalières'),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
 					})('auto entrepreneur . revenu net de cotisations'),
 					// $FlowFixMe
@@ -652,12 +651,12 @@ export default (compose(
 					indemnitésJournalières: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
 					})('protection sociale . santé . indemnités journalières'),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
-					})('indépendant . revenu professionnel')
+					})('indépendant . revenu net de cotisations')
 				},
 				assimiléSalarié: {
 					retraite: règleAvecMontantSelector(state, {
@@ -674,10 +673,10 @@ export default (compose(
 					})(
 						'protection sociale . accidents du travail et maladies professionnelles'
 					),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Assimilé salarié'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Assimilé salarié'
 					})('contrat salarié . salaire . net')
 				}

--- a/source/components/SimulateurWarning.js
+++ b/source/components/SimulateurWarning.js
@@ -17,31 +17,22 @@ export default withLanguage(function SimulateurWarning({
 			<p>
 				{emoji('🚩 ')}
 				<strong>
-					<T k="simulateurs.warning.titre">Outil en cours de développement </T>
+					<T k="simulateurs.warning.titre">Avant de commencer...</T>
 				</strong>{' '}
 				{folded && (
 					<button
 						className="ui__ button simple small"
 						onClick={() => fold(false)}>
-						<T k="simulateurs.warning.plus">(plus d'info)</T>
+						<T k="simulateurs.warning.plus">Lire les précisions</T>
 					</button>
 				)}
 			</p>
 			<div className={`content ${folded ? '' : 'ui__ card'}`}>
 				{!folded && (
 					<ul style={{ marginLeft: '1em' }}>
-						{simulateur !== 'auto-entreprise' &&
-							simulateur !== 'assimilé-salarié' && (
-								<li>
-									<T k="simulateurs.warning.line1">
-										le chiffre d'affaires déduit des charges va à 100% dans la
-										rémunération du dirigeant
-									</T>
-								</li>
-							)}
 						<li>
-							<T k="simulateurs.warning.line2">
-								l'impôt sur le revenu est calculé pour un célibataire sans
+							<T k="simulateurs.warning.impôt">
+								L'impôt sur le revenu est calculé pour un célibataire sans
 								enfant et sans autre revenu.
 							</T>{' '}
 							{simulateur == 'auto-entreprise' && language === 'fr' && (
@@ -49,11 +40,22 @@ export default withLanguage(function SimulateurWarning({
 							)}
 						</li>
 						<li>
-							<T k="simulateurs.warning.line3">
-								les calculs sont indicatifs et ne se substituent pas aux
+							<T k="simulateurs.warning.urssaf">
+								Les calculs sont indicatifs et ne se substituent pas aux
 								décomptes réels des Urssaf, impots.gouv.fr, etc
 							</T>
 						</li>
+						{simulateur == 'auto-entreprise' && (
+							<li>
+								<T k="simulateurs.warning.auto-entrepreneur">
+									{' '}
+									les auto-entrepreneurs ne peuvent pas déduire leurs charges de
+									leur chiffre d'affaires. Il faut donc retrancher au net tous
+									les coûts liés à l'entreprise pour obtenir le revenu
+									réellement perçu.
+								</T>
+							</li>
+						)}
 					</ul>
 				)}
 

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -1,9 +1,4 @@
 objectifs:
-  - icône: 🏢
-    nom: Mon entreprise
-    objectifs:
-      - entreprise . chiffre d'affaires
-      - entreprise . charges
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
@@ -12,6 +7,11 @@ objectifs:
       - contrat salarié . salaire . net
       - impôt . neutre
       - contrat salarié . salaire . net après impôt
+  # - icône: 🏢
+  #   nom: Mon entreprise
+  #   objectifs:
+  #     - entreprise . charges
+  #     - entreprise . chiffre d'affaires
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -24,6 +24,7 @@ questions:
     - entreprise . charges
     - entreprise . rémunération du dirigeant
     - entreprise . association non lucrative
+    - contrat salarié . régime des impatriés
   non prioritaires:
     - entreprise . établissement bancaire
     - contrat salarié . complémentaire santé . part employeur

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -14,14 +14,20 @@ objectifs:
       - contrat salarié . salaire . net après impôt
 
 questions:
-  blacklist:
-    - contrat salarié . avantages en nature . montant
+  à l'affiche:
+    ACRE: entreprise . année d'activité
+    Commune: établissement . localisation
+    Indemnité vélo: contrat salarié . indemnité kilométrique vélo . active
+    Effectif: entreprise . effectif
+  liste noire:
+    - contrat salarié . avantages en nature
+    - entreprise . charges
     - entreprise . rémunération du dirigeant
-
-questions à l'affiche:
-  ACRE: entreprise . année d'activité
-  Commune: établissement . localisation
-  Charges: entreprise . charges
+    - entreprise . association non lucrative
+  non prioritaires:
+    - entreprise . établissement bancaire
+    - contrat salarié . complémentaire santé . part employeur
+    - contrat salarié . régime des impatriés
 
 situation:
   auto entrepreneur: non

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -5,10 +5,11 @@ objectifs:
   - impôt . impôt sur le revenu à payer
   - revenu net
 
-questions à l'affiche:
-  Type d'activité: entreprise . catégorie d'activité
-  ACRE: entreprise . année d'activité
-  Charges: entreprise . charges
+questions:
+  à l'affiche:
+    Type d'activité: entreprise . catégorie d'activité
+    ACRE: entreprise . année d'activité
+    Charges: entreprise . charges
 
 situation:
   auto entrepreneur: oui

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -1,15 +1,17 @@
 objectifs:
   - entreprise . chiffre d'affaires
-  - entreprise . charges
   - auto entrepreneur . cotisations et contributions
-  - impôt . impôt sur le revenu à payer
-  - revenu net
+  - auto entrepreneur . revenu net de cotisations
+  - impôt
+  - revenu net après impôt
 
 questions:
   à l'affiche:
     Type d'activité: entreprise . catégorie d'activité
     ACRE: entreprise . année d'activité
     Charges: entreprise . charges
+  liste noire:
+    - entreprise . charges
 
 situation:
   auto entrepreneur: oui

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -14,14 +14,13 @@ objectifs:
       - revenu net
 
 questions:
-  blacklist:
+  à l'affiche:
+    Type d'activité: entreprise . catégorie d'activité
+    ACRE: entreprise . année d'activité
+    Charges: entreprise . charges
+  liste noire:
     - entreprise . charges
     - entreprise . rémunération du dirigeant
-
-questions à l'affiche:
-  Type d'activité: entreprise . catégorie d'activité
-  ACRE: entreprise . année d'activité
-  Charges: entreprise . charges
 
 situation:
   indépendant: oui

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -1,17 +1,18 @@
 objectifs:
-  - icône: 🏢
-    nom: Mon entreprise
-    objectifs:
-      - entreprise . chiffre d'affaires
-      - entreprise . charges
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
-      - indépendant . revenu total du dirigeant
+      - entreprise . rémunération totale du dirigeant
       - indépendant . cotisations et contributions
+      - indépendant . revenu net de cotisations
       - indépendant . revenu professionnel
-      - indépendant . impôt et contributions non déductibles
-      - revenu net
+      - impôt
+      - revenu net après impôt
+  # - icône: 🏢
+  #   nom: Mon entreprise
+  #   objectifs:
+  #     - entreprise . charges
+  #     - entreprise . chiffre d'affaires
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -2,7 +2,8 @@ titre: |
   Calcul du revenu du travailleur indépendant ou dirigeant d'entreprise après paiement des cotisations et de l'impôt sur le revenu.
 
 objectifs:
-  - revenu net
+  - revenu net après impôt
+  - revenu net de cotisations
   - protection sociale . retraite
   - protection sociale . retraite . trimestres validés par an
   - protection sociale . santé . indemnités journalières
@@ -10,7 +11,7 @@ objectifs:
 
 questions:
   uniquement:
-    - entreprise . chiffre d'affaires
+    - entreprise . rémunération totale du dirigeant
     - entreprise . charges
     - entreprise . catégorie d'activité
     - entreprise . catégorie d'activité . service ou vente

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -7,13 +7,15 @@ objectifs:
   - protection sociale . retraite . trimestres validés par an
   - protection sociale . santé . indemnités journalières
   - protection sociale . accidents du travail et maladies professionnelles
+
 questions:
-  - entreprise . chiffre d'affaires
-  - entreprise . charges
-  - entreprise . catégorie d'activité
-  - entreprise . catégorie d'activité . service ou vente
-  - entreprise . catégorie d'activité . restauration ou hébergement
-  - entreprise . catégorie d'activité . libérale règlementée
+  uniquement:
+    - entreprise . chiffre d'affaires
+    - entreprise . charges
+    - entreprise . catégorie d'activité
+    - entreprise . catégorie d'activité . service ou vente
+    - entreprise . catégorie d'activité . restauration ou hébergement
+    - entreprise . catégorie d'activité . libérale règlementée
 
 situation:
   période: année

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -5,23 +5,23 @@ objectifs:
   - contrat salarié . salaire . net
   - contrat salarié . salaire . net après impôt
 
-questions à l'affiche:
-  Cadre: contrat salarié . statut cadre . choix statut cadre
-  CDD: contrat salarié . CDD
-  Temps partiel: contrat salarié . temps partiel
-  Commune: établissement . localisation
-  JEI: contrat salarié . statut JEI
-  Association: entreprise . association non lucrative
-  Avantages: contrat salarié . avantages en nature
-
-questions non prioritaires:
-  - contrat salarié . indemnité kilométrique vélo . active
-  - contrat salarié . avantages en nature
-  - entreprise . établissement bancaire
-  - entreprise . association non lucrative
-  - contrat salarié . statut JEI
-  - contrat salarié . complémentaire santé . part employeur
-  - contrat salarié . régime des impatriés
+questions:
+  à l'affiche:
+    Cadre: contrat salarié . statut cadre . choix statut cadre
+    CDD: contrat salarié . CDD
+    Temps partiel: contrat salarié . temps partiel
+    Commune: établissement . localisation
+    JEI: contrat salarié . statut JEI
+    Association: entreprise . association non lucrative
+    Avantages: contrat salarié . avantages en nature
+  non prioritaires:
+    - contrat salarié . indemnité kilométrique vélo . active
+    - contrat salarié . avantages en nature
+    - entreprise . établissement bancaire
+    - entreprise . association non lucrative
+    - contrat salarié . statut JEI
+    - contrat salarié . complémentaire santé . part employeur
+    - contrat salarié . régime des impatriés
 
 situation:
   contrat salarié: oui

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -12,6 +12,16 @@ questions à l'affiche:
   Commune: établissement . localisation
   JEI: contrat salarié . statut JEI
   Association: entreprise . association non lucrative
+  Avantages: contrat salarié . avantages en nature
+
+questions non prioritaires:
+  - contrat salarié . indemnité kilométrique vélo . active
+  - contrat salarié . avantages en nature
+  - entreprise . établissement bancaire
+  - entreprise . association non lucrative
+  - contrat salarié . statut JEI
+  - contrat salarié . complémentaire santé . part employeur
+  - contrat salarié . régime des impatriés
 
 situation:
   contrat salarié: oui

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -21,6 +21,7 @@ questions:
     - entreprise . association non lucrative
     - contrat salarié . statut JEI
     - contrat salarié . complémentaire santé . part employeur
+  liste noire:
     - contrat salarié . régime des impatriés
 
 situation:

--- a/source/engine/treatVariable.js
+++ b/source/engine/treatVariable.js
@@ -22,13 +22,11 @@ export let treatVariable = (rules, rule, filter) => ({ fragments }) => {
 			variableHasFormula = variable.formule != null,
 			variableHasCond =
 				variable['applicable si'] != null ||
-				variable['non applicable si'] != null,
+				variable['non applicable si'] != null ||
+				findParentDependency(parsedRules, variable),
 			situationValue = getSituationValue(situation, dottedName, variable),
 			needsEvaluation =
-				situationValue == null &&
-				(variableHasCond ||
-					variableHasFormula ||
-					findParentDependency(parsedRules, variable))
+				situationValue == null && (variableHasCond || variableHasFormula)
 
 		//		if (dottedName.includes('jeune va')) debugger
 
@@ -68,12 +66,9 @@ export let treatVariable = (rules, rule, filter) => ({ fragments }) => {
 
 			// SITUATION 4.2 : La condition est connue et fausse
 			if (explanation.isApplicable === false) return cacheAndNode(false, {})
+
 			// SITUATION 4.3 : La condition n'est pas connue
-			if (explanation.isApplicable == null)
-				return cacheAndNode(null, {
-					...explanation.missingVariables,
-					...(variable.question ? { [dottedName]: variableScore } : {})
-				})
+			return cacheAndNode(null, explanation.missingVariables)
 		}
 	}
 

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -597,7 +597,6 @@ newsletter:
     description: |
       Subscribe to our monthly newsletter to receive <2>official advice on starting a business</2> and access new features in advance.
 S'inscrire: Register
-simulationWarning: This is an estimate based on <2>purely theoretical data</2> on turnover, charges and the single tax base without children, excluding any other income, which <5>cannot be the responsibility of the social security bodies concerned with regard to the actual declarations and calculations.</5>
 
 Renseigner mon entreprise: Find my company
 Simulations personnalisées: Customized simulations
@@ -609,11 +608,11 @@ Comparer les trois régimes: Compare the three schemes
 simulateurs:
   inversionFail: The amount entered is too small or results in an impossible situation, try another one
   warning:
-    titre: Tool under development
-    plus: (more info)
-    line1: the turnover deducted from expenses goes to 100% in the director's remuneration
-    line2: income tax is calculated for a single person without children and without other income.
-    line3: the figures are indicative and do not replace the actual accounts of the Urssaf, impots.gouv.fr, etc
+    titre: Before starting...
+    plus: Read explanations
+    impôt: Income tax is calculated for a single person without children and without other income.
+    urssaf: The figures are indicative and do not replace the actual accounts of the Urssaf, impots.gouv.fr, etc
+    auto-entrepreneur: Self-employed entrepreneurs cannot deduct their expenses from their turnover. Therefore, all costs related to the business must be deducted on a net basis to obtain the actual income received.
   précision:
     défaut: 'Refine the simulation by answering the following questions:'
     faible: Low accuracy
@@ -730,9 +729,9 @@ comparaisonRégimes:
     <0> Optional health and pension policies deductible</0>
     <1> Yes <1>(under certain conditions)</1></1>
     <2> Yes <1>("Madelin" Law)</1></2>
-  revenuNetApresImpots: |
+  revenuNetApresImpot: |
     <0>Net income after taxes</0>
-  revenuNetAvantImpots: |
+  revenuNetAvantImpot: |
     <0>Net contribution income<1>(before income tax)</1></0>
   retraiteEstimation:
     legend: |

--- a/source/reducers/rootReducer.js
+++ b/source/reducers/rootReducer.js
@@ -23,6 +23,8 @@ function explainedVariable(state = null, { type, variableName = null }) {
 	switch (type) {
 		case 'EXPLAIN_VARIABLE':
 			return variableName
+		case 'STEP_ACTION':
+			return null
 		default:
 			return state
 	}

--- a/source/reducers/rootReducer.js
+++ b/source/reducers/rootReducer.js
@@ -70,40 +70,30 @@ function lang(state = i18n.language, { type, lang }) {
 
 type ConversationSteps = {|
 	+foldedSteps: Array<string>,
-	+unfoldedStep: ?string,
-	+priorityNamespace: ?string
+	+unfoldedStep: ?string
 |}
 
 function conversationSteps(
 	state: ConversationSteps = {
 		foldedSteps: [],
-		unfoldedStep: null,
-		priorityNamespace: null
+		unfoldedStep: null
 	},
 	action: Action
 ): ConversationSteps {
 	if (action.type === 'RESET_SIMULATION')
-		return { foldedSteps: [], unfoldedStep: null, priorityNamespace: null }
-	if (action.type === 'START_CONVERSATION' && action.priorityNamespace)
-		return {
-			foldedSteps: state.foldedSteps,
-			unfoldedStep: null,
-			priorityNamespace: action.priorityNamespace
-		}
+		return { foldedSteps: [], unfoldedStep: null }
 
 	if (action.type !== 'STEP_ACTION') return state
 	const { name, step } = action
 	if (name === 'fold')
 		return {
 			foldedSteps: [...state.foldedSteps, step],
-			unfoldedStep: null,
-			priorityNamespace: state.priorityNamespace
+			unfoldedStep: null
 		}
 	if (name === 'unfold') {
 		return {
 			foldedSteps: without([step], state.foldedSteps),
-			unfoldedStep: step,
-			priorityNamespace: state.priorityNamespace
+			unfoldedStep: step
 		}
 	}
 	return state

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -753,12 +753,12 @@
       question: Quel est le salaire ?
       titre: salaire
       avec:
-        - entreprise . chiffre d'affaires
         - rémunération . total
         - salaire . net
         - salaire . net après impôt
         - équivalent temps plein
-        - revenu net
+        - entreprise . chiffre d'affaires
+        - entreprise . rémunération totale du dirigeant
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
@@ -2766,6 +2766,9 @@
 - nom: impôt
   icônes: 🏛️
   description: Cet ensemble de formules est un modèle ultra-simplifié de l'impôt sur le revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
+  titre: impôt sur le revenu
+  période: flexible
+  formule: impôt sur le revenu après décote
 
 - espace: impôt
   nom: revenu abattu
@@ -2882,28 +2885,26 @@
   formule: impôt sur le revenu après décote + CEHR
 
 - nom: revenu net de cotisations
+  résumé: Avant impôt
   période: flexible
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: |
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
   formule:
     somme:
       - contrat salarié . salaire . net
       - indépendant . revenu net de cotisations
       - auto entrepreneur . revenu net de cotisations
 
-- nom: revenu net d'impôt
-  titre: Revenu net de cotisations et d'impôt
-  période: flexible
-  formule: revenu net de cotisations - impôt . impôt sur le revenu à payer
-
-- nom: revenu net
-  titre: Revenu net
+- nom: revenu net après impôt
   format: euros
-  résumé: Après impôt sur le revenu
+  résumé: Versé sur le compte bancaire
   période: flexible
   question: Quel revenu voulez-vous toucher ?
   description: |
-    Il s'agit du revenu net de cotisations et d'impôts.
+    Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
-  formule: revenu net d'impôt - entreprise . charges non déductibles
+  formule: revenu net de cotisations - impôt
 
 - espace: entreprise
   nom: année d'activité
@@ -2935,22 +2936,14 @@
 
 - espace: entreprise
   nom: chiffre d'affaires
-  titre: chiffre d'affaires H.T.
-  question: Quel est votre chiffre d'affaires envisagé (H.T.) ?
+  titre: chiffre d'affaire (H.T.)
+  question: Quel est votre chiffre d'affaires envisagé ?
   résumé: Le montant des ventes réalisées
   période: flexible
   format: euros
-  formule:
-    variations:
-      - si: auto entrepreneur
-        alors:
-          inversion numérique:
-            avec:
-              - revenu net
-      - sinon: rémunération totale du dirigeant + charges
+  formule: rémunération totale du dirigeant + charges
 
 - espace: entreprise
-
   nom: chiffre d'affaires de société
   période: flexible
   formule:
@@ -3001,24 +2994,38 @@
 
 - espace: entreprise
   nom: rémunération totale du dirigeant
+  question: Quel montant pensez-vous dégager pour votre rémunération ?
+  résumé: Dépensé par l'entreprise
   format: euros
-  description: C'est la rémunération "super-brute" du dirigeant, qui inclut toutes les cotisations sociales à payer. C'est aussi la valeur monétaire du travail du dirigeant.
+  description:
+    C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
+    Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
+
+    On peut aussi considérer que c'est la valeur monétaire du travail du dirigeant.
   période: flexible
   formule:
-    somme:
-      - contrat salarié . rémunération . total
-      - indépendant . revenu total du dirigeant
-      - auto entrepreneur . base des cotisations
+    variations:
+      - si: indépendant
+        alors: revenu net de cotisations + indépendant . cotisations et contributions
+      - si: auto entrepreneur
+        alors:
+          inversion numérique:
+            avec:
+              - auto entrepreneur . revenu net de cotisations
+              - revenu net après impôt
+              - entreprise . chiffre d'affaires
+      - si: contrat salarié . assimilé salarié
+        alors: contrat salarié . rémunération . total
 
 - espace: entreprise
   nom: charges
   résumé: Toutes les dépenses nécessaires à l'entreprise
-  question: Quelles sont les charges H.T. de l'entreprise (hors rémunération dirigeant) ?
+  question: Quelles sont les charges de l'entreprise ?
   description: |
 
-    Ce sont les dépenses de l'entreprise engagées dans l'intérêt de celle-ci, hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur, elles ne sont pas déductibles : l'entrepreneur les paie avec son salaire personnel net de cotisation et de revenu.
+    Ce sont les dépenses de l'entreprise engagées dans l'intérêt de celle-ci, hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur, elles ne sont pas déductibles du chiffre d'affaire encaissé.
 
-    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe.
+    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe (excepté pour les auto entrepreneurs en franchise de TVA)
 
     Par exemple, les charges peuvent être :
 
@@ -3035,14 +3042,6 @@
   période: flexible
   par défaut: 0
   format: euros
-
-- espace: entreprise
-  nom: charges non déductibles
-  description: |
-    Pour l'auto-entreprise, [les charges](/documentation/entreprise/charges) ne sont pas déductibles. Par exemple, un auto-entrepreneur qui achète un ordinateur pour les besoins de sa société, le fera avec son revenu net. Il aura donc payé des cotisations sociales et l'impôt sur le revenu sur son CA avant de pouvoir l'utiliser pour s'acheter ce bien.
-  applicable si: auto entrepreneur
-  formule: charges
-  période: flexible
 
 - espace: indépendant . cotisations et contributions
   nom: réduction ACRE
@@ -3070,26 +3069,30 @@
   nom: revenu net de cotisations
   formule: revenu professionnel - cotisations et contributions . CSG et CRDS [non déductible]
   période: flexible
+  résumé: Avant impôt
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  format: euros
 
 - espace: indépendant
   nom: revenu professionnel
-  résumé: Après cotisations et charges
-  question: Quel est votre revenu professionnel ?
-  période: flexible
-  format: euros
+  titre: revenu professionnel (net imposable)
   description: |
+    C'est le revenu net de cotisations déductibles du travailleur indépendant, qui sert de base au calcul des cotisations et de l'impôt pour les indépendants.
 
-    C'est le revenu net de cotisations du travailleur indépendant.
-
-  Attention, **notre calcul est fait au régime de croisière**:
-    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait relativement réduit de cotisations sociales. Il devra ensuite régulariser cette situation par rapport au revenu qu'il a vraiment touché.
+    Attention, **notre calcul est fait au régime de croisière**:
+    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait relativement réduit de cotisations sociales. Il devra ensuite régulariser cette situation par rapport au revenu qu'il a vraiment perçu.
 
     Il faut donc voir ce calcul comme *le montant qui devra de toute façon être payé* à court terme après 2 ans d'exercice.
+
+  période: flexible
+  format: euros
   formule:
     inversion numérique:
       avec:
-        - revenu total du dirigeant
-        - revenu net
+        - indépendant . revenu net de cotisations
+        - entreprise . rémunération totale du dirigeant
+        - revenu net après impôt
         - entreprise . chiffre d'affaires
 
 - espace: entreprise
@@ -3313,7 +3316,7 @@
   formule:
     somme:
       - cotisations à payer
-      - CSG et CRDS [déductible]
+      - CSG et CRDS
       - formation professionnelle
   format: euros
   période: flexible
@@ -3638,25 +3641,6 @@
         1.1: 0%
         1.4: 3.1%
 
-- espace: indépendant
-  nom: revenu total du dirigeant
-  question: Quel est le revenu total du dirigeant ?
-  résumé: Dépensé par l'entreprise
-  format: euros
-  période: flexible
-  formule:
-    somme:
-      - revenu professionnel
-      - cotisations et contributions
-
-- espace: indépendant
-  nom: impôt et contributions non déductibles
-  période: flexible
-  formule:
-    somme:
-      - impôt . impôt sur le revenu à payer
-      - cotisations et contributions . CSG et CRDS [non déductible]
-
 - nom: auto entrepreneur
   icônes: 🚶
   par défaut: non
@@ -3697,8 +3681,10 @@
 
 - espace: auto entrepreneur
   nom: revenu net de cotisations
-  titre: Revenu net auto-entrepreneur
-  formule: base des cotisations - cotisations et contributions
+  résumé: Avant impôt
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  formule: entreprise . rémunération totale du dirigeant - cotisations et contributions
   période: flexible
   format: euros
 
@@ -3898,6 +3884,7 @@
 
 - espace: auto entrepreneur . impôt
   nom: revenu abattu
+  titre: revenu abattu auto-entrepreneur
   période: flexible
   formule: base des cotisations - abattement
 - nom: protection sociale
@@ -4115,7 +4102,7 @@
   période: année
   formule:
     le maximum de:
-      - indépendant . revenu net de cotisations
+      - indépendant . revenu professionnel
       - auto entrepreneur . impôt . revenu abattu
       - contrat salarié . rémunération . brut
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -901,7 +901,7 @@
 
 - espace: contrat salarié . avantages en nature . ntic
   nom: abonnements
-  question: Quel est le coût de l'abonnement prix en charge par l'employeur ?
+  question: Quel est le coût de l'abonnement (forfait mobile, etc.) pris en charge par l'employeur ?
   format: euros
   période: mois
   par défaut: 20
@@ -917,7 +917,7 @@
     L'employeur fournit-il gratuitement les repas ?
   par défaut: non
   description: >
-    Les tickets restaurants ne sont pas considéré comme un avantage en nature mais comme un remboursement de frais.
+    Les tickets restaurants ne sont pas considérés comme un avantage en nature mais comme un remboursement de frais.
 
 - espace: contrat salarié . avantages en nature . nourriture
   nom: montant
@@ -2594,6 +2594,10 @@
     Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été appelé par une entreprise étrangère à occuper un emploi dans une entreprise établie en France ayant un lien avec la première ou si vous avez été directement recruté à l’étranger par une entreprise établie en France, vous pouvez bénéficier du régime des impatriés.
 
     Vous devez en outre ne pas avoir été fiscalement domicilié en France les cinq années civiles précédant celle de la prise de fonctions et fixer en France votre domicile fiscal dès votre prise de fonctions.
+
+    Les impatriés sont exonérés de cotisations retraite (régime de base et complémentaire) à condition de justifier d'une contribution minimale versée par ailleurs (par exemple dans une caisse de retraite ou un fond de pension étranger). Ils n’acquièrent aucun droit pendant la durée d’exonération.
+
+  note: La durée d’application est fixée au maximum jusqu’au 31 décembre de la huitième année civile suivant la prise de fonctions dans l’entreprise d’accueil.
   références:
     impots.gouv.fr: https://www.impots.gouv.fr/portail/particulier/questions/puis-je-beneficier-du-regime-des-impatries
     bofip: http://bofip.impots.gouv.fr/bofip/5694-PGP
@@ -2716,7 +2720,7 @@
     - si: régime des impatriés
       niveau: information
       message: |
-        Pour bénéficier de l'éxonération de cotisations vieillesse, il faut remplir les conditions suivantes :
+        Pour bénéficier de l'exonération de cotisations vieillesse, il faut remplir les conditions suivantes :
         - Pouvoir justifier d'une contribution minimale versée ailleurs pour une assurance vieilllesse
         - De ne pas avoir été affiliés, au cours des cinq années civiles précédant celle de leur prise de fonctions, à un régime français obligatoire d'assurance vieillesse, sauf pour des activités accessoires, de caractère saisonnier ou pour les études.
         [Voir plus](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=F5CFB7C90D1D1F529A2CDC9FFD20BD6E.tplgfr34s_3?idSectionTA=LEGISCTA000038510929&cidTexte=LEGITEXT000006073189&dateTexte=20190626)
@@ -3952,11 +3956,14 @@
   titre: pension de retraite de base
   format: euros
   période: flexible
+  non applicable si:
+    - régime des impatriés
   formule:
     multiplication:
       plafond: plafond sécurité sociale temps plein
       taux: taux de la pension
       assiette: revenu moyen
+  note: Les impatriés bénéficient d'une exonération de cotisation vieillesse. En contrepartie, ils n'acquièrent aucun droit pendant la durée d'exonération.
   références:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F21552
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -910,8 +910,8 @@
   par défaut: 20
   suggestions:
     aucun: 0
-    téléphone classique: 20
-    téléphone international: 40
+    standard: 20
+    international: 40
 
 
 - espace: contrat salarié . avantages en nature

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1525,7 +1525,7 @@
 
 - espace: entreprise
   nom: établissement bancaire
-  description: L'entreprise est un établissements bancaires, financiers, d'assurances. Elle est non assujettie à la TVA.
+  description: L'entreprise est un établissement bancaire, financier ou d'assurance. Elle est non assujettie à la TVA.
   question: S'agit-il d'un établissement bancaire, financier, d'assurance ?
   par défaut: non
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -792,7 +792,10 @@
   titre: Rémunération brute
   format: euros
   période: flexible
-  formule: salaire . brut + avantages en nature . montant
+  formule:
+    somme:
+      - salaire . brut
+      - avantages en nature . montant
 
 - espace: contrat salarié
   nom: avantages sociaux
@@ -822,14 +825,19 @@
   titre: Avantages en nature (montant)
   description: >
     Les avantages en nature sont soumis aux cotisations et à l'impôt sur le revenu. Ils sont pris en compte pour vérifier que le salaire minimum est atteint.
+
+    Pour les avantages en nature de type NTIC (ordinateurs, smartphones, tablettes...), il y a une évaluation forfaitaire annuelle correspondant à 10% du prix d'achat. Par exemple, pour un téléphone acheté à 850€ TTC avec un abonnement de 30€ / mois, l'avantage en nature à reporter sur le bulletin de paie sera de : [10% x (850€ + (30€ x 12 mois)) ] / 12 mois, soit 10,08€
   question: Quel est le montant des avantages en nature ?
   période: flexible
   suggestions:
-    aucun: 0
-    nourriture: 80
-    véhicule: 260
+    📱 téléphone: 10
+    💻 ordinateur: 12.5
+    🍝 repas: 80
+    🚗 véhicule: 260
+
   format: euros
   par défaut: 0
+
 
 - espace: contrat salarié
   nom: indemnités salarié
@@ -2449,7 +2457,7 @@
 
 - espace: contrat salarié
   nom: régime des impatriés
-  question: Le salarié bénéficie-t'il du régime des impatriés ?
+  question: Le salarié bénéficie-t-il du régime des impatriés ?
   par défaut: non
   description: |
     Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été appelé par une entreprise étrangère à occuper un emploi dans une entreprise établie en France ayant un lien avec la première ou si vous avez été directement recruté à l’étranger par une entreprise établie en France, vous pouvez bénéficier du régime des impatriés.

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1120,13 +1120,16 @@
 
 - espace: contrat salarié
   nom: prime d'impatriation
+  description: La prime d'impatriation est une partie de la rémunération exonérée d'impôt sur le revenu.
   applicable si: régime des impatriés
   période: flexible
   format: euros
   formule:
     multiplication:
-      assiette: salaire . brut de base
+      assiette: rémunération . net de cotisations
       taux: 30%
+  références:
+    Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid
 
 - espace: contrat salarié . salaire
   nom: net

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -972,6 +972,18 @@
   formule:
     somme:
       - indemnité kilométrique vélo
+      - prime d'impatriation
+
+- espace: contrat salarié
+  nom: prime d'impatriation
+  applicable si: régime des impatriés
+  période: flexible
+  format: euros
+  formule:
+    multiplication:
+      assiette: salaire . brut de base
+      taux: 30%
+
 
 - espace: contrat salarié . salaire
   nom: net
@@ -1502,6 +1514,12 @@
   question: S'agit-il d'une association à but non lucratif ?
   par défaut: non
 
+- espace: entreprise
+  nom: établissement bancaire
+  description: L'entreprise est un établissements bancaires, financiers, d'assurances. Elle est non assujettie à la TVA.
+  question: S'agit-il d'un établissement bancaire, financier, d'assurance ?
+  par défaut: non
+
 - nom: établissement
   description: |
     Le salarié travaille dans un établissement de l'entreprise, identifié par un code SIRET.
@@ -1780,6 +1798,7 @@
 
 - espace: contrat salarié
   nom: retraite complémentaire
+  non applicable si: régime des impatriés
   cotisation:
     branche: retraite
     type de retraite: complémentaire
@@ -1817,6 +1836,8 @@
 
   références:
     calcul des cotisations: https://www.agirc-arrco.fr/ce-qui-change-au-1er-janvier-2019/vous-etes-une-entreprise-tiers-declarant/
+    régime des impatriés: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=D2C4F8F0A5E19693ADF9F440120B748A.tplgfr31s_2?idArticle=JORFARTI000038496272&cidTexte=JORFTEXT000038496102&dateTexte=29990101&categorieLien=id
+
 
 - espace: contrat salarié
   nom: AGS
@@ -2381,22 +2402,32 @@
       - entreprise . ratio alternants < 1%
 
 - espace: contrat salarié . taxe sur les salaires
-  nom: assiette
+  nom: assiette de base
   période: flexible
   formule:
     somme:
       - cotisations . assiette
       - prévoyance obligatoire cadre
       - complémentaire santé [employeur]
-
   références:
     assiette: http://bofip.impots.gouv.fr/bofip/6690-PGP.html
+
+- espace: contrat salarié . taxe sur les salaires
+  nom: assiette
+  période: flexible
+  formule:
+    allègement:
+      assiette: assiette de base
+      abattement: prime d'impatriation
+  références:
+    bofig: http://bofip.impots.gouv.fr/bofip/6691-PGP.html
+    impots.gouv.fr: https://www.impots.gouv.fr/portail/international-particulier/le-regime-des-impatries
+
 
 - espace: contrat salarié . taxe sur les salaires
   nom: barème
   références:
     barème: https://www.service-public.fr/professionnels-entreprises/vosdroits/F22576
-
   période: année
   formule:
     barème:
@@ -2416,12 +2447,25 @@
         assiette: 2300
       valeur attendue: 2627.97
 
+- espace: contrat salarié
+  nom: régime des impatriés
+  question: Le salarié bénéficie-t'il du régime des impatriés ?
+  par défaut: non
+  description: |
+    Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été appelé par une entreprise étrangère à occuper un emploi dans une entreprise établie en France ayant un lien avec la première ou si vous avez été directement recruté à l’étranger par une entreprise établie en France, vous pouvez bénéficier du régime des impatriés.
+
+    Vous devez en outre ne pas avoir été fiscalement domicilié en France les cinq années civiles précédant celle de la prise de fonctions et fixer en France votre domicile fiscal dès votre prise de fonctions.
+  références:
+    impots.gouv.fr: https://www.impots.gouv.fr/portail/particulier/questions/puis-je-beneficier-du-regime-des-impatries
+    bofip: http://bofip.impots.gouv.fr/bofip/5694-PGP
+
 - espace: entreprise . taxe sur les salaires
   nom: barème
   période: flexible
   formule: contrat salarié . taxe sur les salaires . barème * effectif
 
 - espace: entreprise . taxe sur les salaires
+  applicable si: entreprise . association non lucrative
   nom: abattement associations
   période: année
   formule: 20507
@@ -2438,17 +2482,16 @@
         taux: 75%
       abattement: abattement associations
 
-  note: |
-    Attention : l'abattement n'est valable que pour les organismes à but non lucratif.
-    Il n'est pas conditionné ici car on réserve pour l'instant la taxe sur les salaires aux associations 1901
 
 - espace: contrat salarié
   nom: taxe sur les salaires
   taxe:
     dû par: employeur
   description: La taxe sur les salaires en France est un impôt progressif créé en 1948 que certains employeurs doivent acquitter sur les salaires qu'ils distribuent.
-  applicable si: entreprise . association non lucrative
-
+  applicable si:
+    une de ces conditions:
+      - entreprise . association non lucrative
+      - entreprise . établissement bancaire
   période: flexible
   formule: entreprise . taxe sur les salaires / entreprise . effectif
 
@@ -2498,6 +2541,7 @@
     collecteur: URSSAF
     destinataire: CNAV
     # CTP: 100
+  non applicable si: régime des impatriés
   description: Cotisation au régime de retraite de base des salariés.
   période: flexible
   formule:
@@ -2529,6 +2573,9 @@
       situation:
         cotisations . assiette: 8000
       valeur attendue: 705.75
+  références:
+    régime des impatriés (loi PACTE): https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=D2C4F8F0A5E19693ADF9F440120B748A.tplgfr31s_2?idArticle=JORFARTI000038496272&cidTexte=JORFTEXT000038496102&dateTexte=29990101&categorieLien=id
+
 
 - espace: contrat salarié
   nom: forfait social

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -847,7 +847,6 @@
     L'employeur fournit-il gratuitement un outils issus des NTIC (ordinateur, téléphone, tablette, etc.) ?
   par défaut: oui
 
-
 - espace: contrat salarié . avantages en nature
   nom: autres
   question: >
@@ -863,8 +862,6 @@
   suggestions:
     🚗 véhicule: 260
   format: euros
-
-
 
 - espace: contrat salarié . avantages en nature . ntic
   nom: montant
@@ -897,10 +894,10 @@
   par défaut: 800
   # TODO : vérifier et documenter les chiffres
   suggestions:
-    📱 : 400
-    📱✨ (haut de gamme) : 850
-    💻  : 1200
-    💻 + 📱✨ : 2050
+    📱: 400
+    📱✨ (haut de gamme): 850
+    💻: 1200
+    💻 + 📱✨: 2050
 
 - espace: contrat salarié . avantages en nature . ntic
   nom: abonnements
@@ -912,7 +909,6 @@
     aucun: 0
     standard: 20
     international: 40
-
 
 - espace: contrat salarié . avantages en nature
   nom: nourriture
@@ -944,7 +940,6 @@
       - sinon: 4.85
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/avantages-en-nature/nourriture.html
-
 
 - espace: contrat salarié . avantages en nature . nourriture
   nom: repas par mois
@@ -1126,7 +1121,7 @@
   format: euros
   formule:
     multiplication:
-      assiette: rémunération . net de cotisations
+      assiette: rémunération . net imposable
       taux: 30%
   références:
     Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid
@@ -2602,6 +2597,7 @@
   références:
     impots.gouv.fr: https://www.impots.gouv.fr/portail/particulier/questions/puis-je-beneficier-du-regime-des-impatries
     bofip: http://bofip.impots.gouv.fr/bofip/5694-PGP
+    Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid
 
 - espace: entreprise . taxe sur les salaires
   nom: barème
@@ -2716,8 +2712,17 @@
       situation:
         cotisations . assiette: 8000
       valeur attendue: 705.75
+  contrôles:
+    - si: régime des impatriés
+      niveau: information
+      message: |
+        Pour bénéficier de l'éxonération de cotisations vieillesse, il faut remplir les conditions suivantes :
+        - Pouvoir justifier d'une contribution minimale versée ailleurs pour une assurance vieilllesse
+        - De ne pas avoir été affiliés, au cours des cinq années civiles précédant celle de leur prise de fonctions, à un régime français obligatoire d'assurance vieillesse, sauf pour des activités accessoires, de caractère saisonnier ou pour les études.
+        [Voir plus](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=F5CFB7C90D1D1F529A2CDC9FFD20BD6E.tplgfr34s_3?idSectionTA=LEGISCTA000038510929&cidTexte=LEGITEXT000006073189&dateTexte=20190626)
+
   références:
-    régime des impatriés (loi PACTE): https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=D2C4F8F0A5E19693ADF9F440120B748A.tplgfr31s_2?idArticle=JORFARTI000038496272&cidTexte=JORFTEXT000038496102&dateTexte=29990101&categorieLien=id
+    Article L727-2 du Code de la sécurité sociale: https://www.legifrance.gouv.fr/affichCode.do;jsessionid=F5CFB7C90D1D1F529A2CDC9FFD20BD6E.tplgfr34s_3?idSectionTA=LEGISCTA000038510929&cidTexte=LEGITEXT000006073189&dateTexte=20190626
 
 - espace: contrat salarié
   nom: forfait social
@@ -2835,12 +2840,23 @@
       valeur attendue: 7162
 
 - espace: impôt
+  nom: revenu fiscal de référence
+  période: année
+  description: le revenu fiscal de référence correspond au revenu abattu du foyer ajusté avec un mécanisme de quotient et majoré d'un certains nombre d'exonérations. Ces dernières sont réintégrées dans le calcul.
+  formule:
+    somme:
+      - revenu abattu
+      - contrat salarié . prime d'impatriation
+  références:
+    Article 1417 du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000034596743&cidTexte=LEGITEXT000006069577&categorieLien=id&dateTexte=20170505
+
+- espace: impôt
   nom: CEHR
   période: année
   note: Attention, ce barème concerne les foyers célibataires. Pour les couples, le barème est adapté pour ne pas leur appliquer la même imposition alors qu'ils sont individuellement deux fois moins riches.
   formule:
     barème:
-      assiette: revenu abattu
+      assiette: revenu fiscal de référence
       tranches:
         - en-dessous de: 250000
           taux: 0%
@@ -2852,6 +2868,7 @@
   références:
     contribution exceptionnelle sur les hauts revenus: https://www.service-public.fr/particuliers/vosdroits/F31130
     Article 223 sexies du Code général des impôts: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000025049019&cidTexte=LEGITEXT000006069577
+    Bofip.impots.gouv.fr: http://bofip.impots.gouv.fr/bofip/7804-PGP
 
 - nom: impôt sur le revenu à payer
   espace: impôt

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -13,7 +13,7 @@
     Nous avons retenu une implémentation simplifiée de cette règle : nous fixons cette indemnité à 200€ annuels, car c'est le montant maximum donnant lieu aux exonérations de cotisations sociales et d'impôt. C'est aussi un montant tout à fait accessible, correspondant approximativement à 2km aller et 2km retour pour 218 jours travaillés dans l'année. Elle peut être supérieure, mais l'employeur n'a alors aucune incitation à verser ce supplément : la part au-dessus de 200€ devient une prime classique.
   format: euros
   période: année
-  applicable si: indemnité vélo active
+  applicable si: active
   formule:
     le minimum de:
       - multiplication:
@@ -26,7 +26,7 @@
   exemples:
     - nom: active
       situation:
-        indemnité vélo active: oui
+        active: oui
       valeur attendue: 200
 
 - espace: contrat salarié . indemnité kilométrique vélo
@@ -37,7 +37,8 @@
   note: 4 km par jour sur 218 jours.
 
 - espace: contrat salarié . indemnité kilométrique vélo
-  nom: indemnité vélo active
+  nom: active
+  titre: indemnité vélo active
   question: Le salarié profite-t-il de l'indemnité kilométrique vélo pour se rendre au travail ?
   description: |
     Cette indemnité n'est pour l'instant pas obligatoire.
@@ -356,7 +357,7 @@
 - espace: contrat salarié . ATMP
   nom: taux réduit
   titre: taux réduit pour activité sans risque
-  question: L'activité de l'établissement ou du salarié est-elle sans risque ?
+  question: L'activité de l'établissement ou du salarié est-elle sans aucun risque ?
   description: |
     Ce taux correspond :
     - aux petites entreprises dont l'activité n'est pas risquée, par exemple du conseil en informatique

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -3956,8 +3956,7 @@
   titre: pension de retraite de base
   format: euros
   période: flexible
-  non applicable si:
-    - régime des impatriés
+  non applicable si: contrat salarié . régime des impatriés
   formule:
     multiplication:
       plafond: plafond sécurité sociale temps plein

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -816,29 +816,164 @@
   titre: Avantages en nature
   description: >
     Les avantages en nature sont constitués par la fourniture par l’employeur à ses salariés d’un bien ou service. La mise à disposition peut être gratuite ou moyennant une participation du salarié inférieure à leur valeur réelle
-  note: >
-    Les tickets restaurants ne sont pas considéré comme un avantage en nature mais comme un remboursement de frais.
-  question: Le salarié reçoit-il des avantages en nature (logement, véhicule, téléphone, réductions...) ?
+
+  question: Le salarié reçoit-il des avantages en nature (repas, véhicule, téléphone, réductions, logement...) ?
   par défaut: non
 
 - espace: contrat salarié . avantages en nature
   nom: montant
   titre: Avantages en nature (montant)
+  période: flexible
   description: >
     Les avantages en nature sont soumis aux cotisations et à l'impôt sur le revenu. Ils sont pris en compte pour vérifier que le salaire minimum est atteint.
 
-    Pour les avantages en nature de type NTIC (ordinateurs, smartphones, tablettes...), il y a une évaluation forfaitaire annuelle correspondant à 10% du prix d'achat. Par exemple, pour un téléphone acheté à 850€ TTC avec un abonnement de 30€ / mois, l'avantage en nature à reporter sur le bulletin de paie sera de : [10% x (850€ + (30€ x 12 mois)) ] / 12 mois, soit 10,08€
-  question: Quel est le montant des avantages en nature ?
-  période: flexible
-  suggestions:
-    📱 téléphone: 10
-    💻 ordinateur: 12.5
-    🍝 repas: 80
-    🚗 véhicule: 260
-
+  formule:
+    somme:
+      - autres
+      - nourriture . montant
+      - ntic . montant
   format: euros
-  par défaut: 0
 
+- espace: contrat salarié . avantages en nature
+  nom: ntic
+  icônes: 💻📱
+  description: >
+    L’usage privé des outils NTIC mis à disposition dans le cadre de l’activité professionnelle à titre permanent est constitutif d’un avantage en nature.
+
+    Cet avantage est inclus dans la base de calcul des cotisations de Sécurité sociale et d’assurance chômage.
+
+    La réalité de l’usage privé peut résulter soit d’un document écrit (contrat de travail, accord d’entreprise, règlement intérieur, courrier de la direction de l’entreprise autorisant le salarié à faire un usage privé des outils), soit de l’existence de factures détaillées permettant d’établir une utilisation privée.
+  question: >
+    L'employeur fournit-il gratuitement un outils issus des NTIC (ordinateur, téléphone, tablette, etc.) ?
+  par défaut: oui
+
+
+- espace: contrat salarié . avantages en nature
+  nom: autres
+  question: >
+    Y a-t-il d'autres avantages en natures (logement, véhicule, réduction...) ?
+  par défaut: non
+
+- espace: contrat salarié . avantages en nature . autres
+  nom: montant
+  période: flexible
+  question: >
+    Quel est le montant de ces autres avantages ?
+  par défaut: 0
+  suggestions:
+    🚗 véhicule: 260
+  format: euros
+
+
+
+- espace: contrat salarié . avantages en nature . ntic
+  nom: montant
+  titre: outils NTIC
+  format: euros
+  période: année
+  description: |
+    Pour les avantages en nature de type NTIC (ordinateurs, smartphones, tablettes...), il y a une évaluation forfaitaire annuelle correspondant à 10% du prix d'achat. Par exemple, pour un téléphone acheté à 850€ TTC avec un abonnement de 30€ / mois, l'avantage en nature à reporter sur le bulletin de paie sera de :
+
+    ```
+    [10% x (850€ + (30€ x 12 mois)) ] / 12 mois
+    ```
+     soit 10,08€
+  formule:
+    multiplication:
+      assiette:
+        somme:
+          - coût appareils
+          - abonnements
+      taux: 10%
+  références:
+    urssaf.fr: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-elements-a-prendre-en-compte/les-avantages-en-nature/les-outils-issus-des-nouvelles-t/dans-quel-cas-la-mise-a-disposit/levaluation-forfaitaire.html
+
+- espace: contrat salarié . avantages en nature . ntic
+  nom: coût appareils
+  question: >
+    Quel est le coût total neuf des appareils mis à disposition ?
+  format: euros
+  période: aucune
+  par défaut: 800
+  # TODO : vérifier et documenter les chiffres
+  suggestions:
+    📱 : 400
+    📱✨ (haut de gamme) : 850
+    💻  : 1200
+    💻 + 📱✨ : 2050
+
+- espace: contrat salarié . avantages en nature . ntic
+  nom: abonnements
+  question: Quel est le coût de l'abonnement prix en charge par l'employeur ?
+  format: euros
+  période: mois
+  par défaut: 20
+  suggestions:
+    aucun: 0
+    téléphone classique: 20
+    téléphone international: 40
+
+
+- espace: contrat salarié . avantages en nature
+  nom: nourriture
+  icônes: 🍝
+  question: >
+    L'employeur fournit-il gratuitement les repas ?
+  par défaut: non
+  description: >
+    Les tickets restaurants ne sont pas considéré comme un avantage en nature mais comme un remboursement de frais.
+
+- espace: contrat salarié . avantages en nature . nourriture
+  nom: montant
+  titre: nourriture
+  période: flexible
+  format: euros
+  formule:
+    multiplication:
+      assiette: montant forfaitaire d'un repas
+      facteur: repas par mois
+
+- espace: contrat salarié . avantages en nature . nourriture
+  nom: montant forfaitaire d'un repas
+  période: aucune
+  format: euros
+  formule:
+    variations:
+      - si: dans la restauration
+        alors: 3.62
+      - sinon: 4.85
+  références:
+    urssaf.fr: https://www.urssaf.fr/portail/home/taux-et-baremes/avantages-en-nature/nourriture.html
+
+
+- espace: contrat salarié . avantages en nature . nourriture
+  nom: repas par mois
+  période: mois
+  question: >
+    Combien de repas par mois sont payés par l'employeur ?
+  par défaut: 21
+  format: nombre
+  suggestions:
+    1 par jour: 21
+    2 par jour: 42
+
+- espace: contrat salarié . avantages en nature . nourriture
+  nom: dans la restauration
+  par défaut: non
+  question: Est-ce pour un salarié travaillant dans un hôtel, café, restaurant et assimilés ?
+
+# - espace: contrat salarié . avantages en nature
+#   nom: montant
+#   titre: Avantages en nature (montant)
+#   description: >
+#     Les avantages en nature sont soumis aux cotisations et à l'impôt sur le revenu. Ils sont pris en compte pour vérifier que le salaire minimum est atteint.
+
+#     Pour les avantages en nature de type NTIC (ordinateurs, smartphones, tablettes...), il y a une évaluation forfaitaire annuelle correspondant à 10% du prix d'achat. Par exemple, pour un téléphone acheté à 850€ TTC avec un abonnement de 30€ / mois, l'avantage en nature à reporter sur le bulletin de paie sera de : [10% x (850€ + (30€ x 12 mois)) ] / 12 mois, soit 10,08€
+
+#   période: flexible
+
+#   format: euros
+#   par défaut: 0
 
 - espace: contrat salarié
   nom: indemnités salarié
@@ -992,7 +1127,6 @@
     multiplication:
       assiette: salaire . brut de base
       taux: 30%
-
 
 - espace: contrat salarié . salaire
   nom: net
@@ -1847,7 +1981,6 @@
     calcul des cotisations: https://www.agirc-arrco.fr/ce-qui-change-au-1er-janvier-2019/vous-etes-une-entreprise-tiers-declarant/
     régime des impatriés: https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=D2C4F8F0A5E19693ADF9F440120B748A.tplgfr31s_2?idArticle=JORFARTI000038496272&cidTexte=JORFTEXT000038496102&dateTexte=29990101&categorieLien=id
 
-
 - espace: contrat salarié
   nom: AGS
   description: Cotisation au Régime de Garantie des Salaires
@@ -2432,7 +2565,6 @@
     bofig: http://bofip.impots.gouv.fr/bofip/6691-PGP.html
     impots.gouv.fr: https://www.impots.gouv.fr/portail/international-particulier/le-regime-des-impatries
 
-
 - espace: contrat salarié . taxe sur les salaires
   nom: barème
   références:
@@ -2490,7 +2622,6 @@
         plafond: 2040
         taux: 75%
       abattement: abattement associations
-
 
 - espace: contrat salarié
   nom: taxe sur les salaires
@@ -2584,7 +2715,6 @@
       valeur attendue: 705.75
   références:
     régime des impatriés (loi PACTE): https://www.legifrance.gouv.fr/affichTexteArticle.do;jsessionid=D2C4F8F0A5E19693ADF9F440120B748A.tplgfr31s_2?idArticle=JORFARTI000038496272&cidTexte=JORFTEXT000038496102&dateTexte=29990101&categorieLien=id
-
 
 - espace: contrat salarié
   nom: forfait social
@@ -2720,9 +2850,6 @@
     contribution exceptionnelle sur les hauts revenus: https://www.service-public.fr/particuliers/vosdroits/F31130
     Article 223 sexies du Code général des impôts: https://www.legifrance.gouv.fr/affichCode.do?idSectionTA=LEGISCTA000025049019&cidTexte=LEGITEXT000006069577
 
-
-
-
 - nom: impôt sur le revenu à payer
   espace: impôt
   titre: impôt sur le revenu
@@ -2753,7 +2880,6 @@
     Il s'agit du revenu net de cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
   formule: revenu net d'impôt - entreprise . charges non déductibles
-
 
 - espace: entreprise
   nom: année d'activité
@@ -2859,7 +2985,6 @@
       - contrat salarié . rémunération . total
       - indépendant . revenu total du dirigeant
       - auto entrepreneur . base des cotisations
-
 
 - espace: entreprise
   nom: charges
@@ -3541,8 +3666,8 @@
           toutes ces conditions:
             - entreprise . catégorie d'activité != 'libérale'
             - une de ces conditions:
-              - entreprise . catégorie d'activité . service ou vente = 'vente de biens'
-              - entreprise . catégorie d'activité . restauration ou hébergement
+                - entreprise . catégorie d'activité . service ou vente = 'vente de biens'
+                - entreprise . catégorie d'activité . restauration ou hébergement
         alors: 170000
       - sinon: 70000
 
@@ -3564,7 +3689,6 @@
   références:
     Imposition du micro-entrepreneur: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23267
   période: flexible
-
 
 - espace: auto entrepreneur . cotisations et contributions
   nom: taxe pour frais de chambre
@@ -3666,8 +3790,6 @@
                 - entreprise . catégorie d'activité = 'artisanale'
             alors: 3.50%
 
-
-
 - espace: auto entrepreneur . cotisations et contributions . cotisations
   nom: taux de cotisation
   description: |
@@ -3687,7 +3809,6 @@
   description: |
     Pour les entreprises créées avant 2019, la réduction de cotisation ACRE s'appellait ACCRE et n'était pas automatique : il fallait notamment être indemnisé par pôle-emploi et faire la demande.
   par défaut: non
-
 
 - espace: auto entrepreneur . cotisations et contributions . cotisations
   nom: taux ACRE
@@ -3839,11 +3960,10 @@
   formule:
     le minimum de:
       - somme:
-        - trimestres salarié
-        - trimestres indépendant
-        - trimestres auto entrepreneur
+          - trimestres salarié
+          - trimestres indépendant
+          - trimestres auto entrepreneur
       - 4
-
 
 - nom: trimestres salarié
   période: aucune
@@ -3878,22 +3998,21 @@
             assiette: revenu moyen [annuel]
             multiplicateur: SMIC horaire
             tranches:
-            - en-dessous de: 150
-              montant: 0
-            - de: 150
-              à: 300
-              montant: 1
-            - de: 300
-              à: 450
-              montant: 2
-            - de: 450
-              à: 600
-              montant: 3
-            - au-dessus de: 600
-              montant: 4
+              - en-dessous de: 150
+                montant: 0
+              - de: 150
+                à: 300
+                montant: 1
+              - de: 300
+                à: 450
+                montant: 2
+              - de: 450
+                à: 600
+                montant: 3
+              - au-dessus de: 600
+                montant: 4
   références:
     cnav.fr: https://www.legislation.cnav.fr/Pages/bareme.aspx?Nom=salaire_validant_un_trimestre_montant_bar
-
 
 - nom: trimestres auto entrepreneur
   applicable si: auto entrepreneur
@@ -3908,60 +4027,59 @@
           barème linéaire:
             assiette: entreprise . chiffre d'affaires [annuel]
             tranches:
-            - en-dessous de: 2880
-              montant: 0
-            - de: 2880
-              à: 5062
-              montant: 1
-            - de: 5062
-              à: 7266
-              montant: 2
-            - de: 7266
-              à: 9675
-              montant: 3
-            - au-dessus de: 9675
-              montant: 4
+              - en-dessous de: 2880
+                montant: 0
+              - de: 2880
+                à: 5062
+                montant: 1
+              - de: 5062
+                à: 7266
+                montant: 2
+              - de: 7266
+                à: 9675
+                montant: 3
+              - au-dessus de: 9675
+                montant: 4
       - si:
           une de ces conditions:
             - entreprise . catégorie d'activité . service ou vente = 'vente de biens'
             - entreprise . catégorie d'activité . restauration ou hébergement
         alors:
-         barème linéaire:
+          barème linéaire:
             assiette: entreprise . chiffre d'affaires [annuel]
             tranches:
-            - en-dessous de: 4137
-              montant: 0
-            - de: 4137
-              à: 7286
-              montant: 1
-            - de: 7286
-              à: 10426
-              montant: 2
-            - de: 10426
-              à: 20740
-              montant: 3
-            - au-dessus de: 20740
-              montant: 4
+              - en-dessous de: 4137
+                montant: 0
+              - de: 4137
+                à: 7286
+                montant: 1
+              - de: 7286
+                à: 10426
+                montant: 2
+              - de: 10426
+                à: 20740
+                montant: 3
+              - au-dessus de: 20740
+                montant: 4
       - sinon:
           barème linéaire:
             assiette: entreprise . chiffre d'affaires [annuel]
             tranches:
-            - en-dessous de: 2412
-              montant: 0
-            - de: 2412
-              à: 4239
-              montant: 1
-            - de: 4239
-              à: 6071
-              montant: 2
-            - de: 6071
-              à: 12030
-              montant: 3
-            - au-dessus de: 12030
-              montant: 4
+              - en-dessous de: 2412
+                montant: 0
+              - de: 2412
+                à: 4239
+                montant: 1
+              - de: 4239
+                à: 6071
+                montant: 2
+              - de: 6071
+                à: 12030
+                montant: 3
+              - au-dessus de: 12030
+                montant: 4
   références:
     service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23369
-
 
 - espace: protection sociale
   nom: revenu moyen
@@ -4044,8 +4162,8 @@
     multiplication:
       assiette:
         somme:
-        - indépendant . cotisations et contributions . cotisations . retraite complémentaire
-        - auto entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
+          - indépendant . cotisations et contributions . cotisations . retraite complémentaire
+          - auto entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
       facteur: 1 / prix d'achat du point
 
 - espace: protection sociale . retraite . complémentaire sécurité des indépendants
@@ -4104,7 +4222,7 @@
       - si: revenu moyen [annuel] < 3919.20
         alors: 0
       - sinon:
-          le minimum de :
+          le minimum de:
             - multiplication:
                 assiette: revenu moyen [annuel]
                 facteur: 1 / 730
@@ -4118,13 +4236,13 @@
   période: aucune
   format: euros
   formule:
-    le maximum de :
+    le maximum de:
       - 21
-      - le minimum de :
-        - multiplication:
-            assiette: revenu moyen [annuel]
-            facteur: 1 / 730
-        - 55.51
+      - le minimum de:
+          - multiplication:
+              assiette: revenu moyen [annuel]
+              facteur: 1 / 730
+          - 55.51
   reférences:
     - secu-independants.fr: https://www.secu-independants.fr/sante/indemnites-journalieres/montant-de-lindemnite
 
@@ -4132,8 +4250,7 @@
   nom: salarié
   période: aucune
   format: euros
-  notes:
-    Vu que le simulateur ne permet pas encore la conversion de période vers le jour, on multiplie le salaire moyen par 3 pour avoir le salaire trimestrielle, puis on le divise par 91.25, conformément à la fiche service-public.fr
+  notes: Vu que le simulateur ne permet pas encore la conversion de période vers le jour, on multiplie le salaire moyen par 3 pour avoir le salaire trimestrielle, puis on le divise par 91.25, conformément à la fiche service-public.fr
   applicable si: contrat salarié
   formule:
     multiplication:
@@ -4143,7 +4260,6 @@
       plafond: 1.8 * contrat salarié . SMIC temps plein
   reférences:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F3053
-
 
 - nom: assurance chômage
   espace: protection sociale
@@ -4221,7 +4337,6 @@
       - 202.78
       # TODO
       # - 0.834% * plafond sécurité sociale temps plein [annuel]
-
 
   références:
     ameli.fr: https://www.ameli.fr/paris/entreprise/cotisations/mp-tarification-calculs-baremes/compte-mp

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -668,14 +668,7 @@ contrat salarié . avantages en nature . montant:
     atteint.
   question.en: What is the monthly amount of benefits in kind?
   question.fr: Quel est le montant des avantages en nature ?
-  suggestions.en:
-    aucun: none
-    nourriture: food
-    véhicule: car
-  suggestions.fr:
-    aucun: 0
-    nourriture: 80
-    véhicule: 260
+
 contrat salarié . indemnités salarié:
   titre.en: Employee benefits
   titre.fr: indemnités salarié

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -30,7 +30,8 @@ contrat salarié . indemnité kilométrique vélo . active:
   titre.en: active bicycle allowance
   titre.fr: indemnité vélo active
   question.en: >-
-    Does the employee take advantage of the bicycle mileage allowance to commute to work?
+    Does the employee take advantage of the bicycle mileage allowance to commute
+    to work?
   question.fr: >-
     Le salarié profite-t-il de l'indemnité kilométrique vélo pour se rendre au
     travail ?
@@ -41,19 +42,17 @@ contrat salarié . indemnité kilométrique vélo . active:
     The employer has the choice to implement it in his company.
 
 
-    To benefit from the €200 compensation deducted in this calculation, the employee
-    must cycle 4km (round trip) to work each day
-    worked.
+    To benefit from the €200 compensation deducted in this calculation, the
+    employee must cycle 4km (round trip) to work each day worked.
 
 
-    This allowance can be combined with the reimbursement of transport costs
-    if it is a bike trip to a transport station.
+    This allowance can be combined with the reimbursement of transport costs if
+    it is a bike trip to a transport station.
 
 
     This allowance is exempt from social security contributions and tax on the
     income. To pay a salary bonus equivalent to his employee without this
-    device, **the employer should pay nearly 500€ for a salary
-    median**.
+    device, **the employer should pay nearly 500€ for a salary median**.
   description.fr: >
     Cette indemnité n'est pour l'instant pas obligatoire.
 
@@ -677,18 +676,17 @@ contrat salarié . avantages en nature . montant:
     atteint.
 contrat salarié . avantages en nature . ntic:
   description.en: >
-    The private use of the NICT tools made available as part of
-    the permanent professional activity constitutes an advantage in kind.
+    The private use of the NICT tools made available as part of the permanent
+    professional activity constitutes an advantage in kind.
 
     This benefit is included in the basis for calculating Security contributions
     and unemployment insurance.
 
-    The reality of private use can result either from a written document (contract
-    work, company agreement, internal regulations, correspondence from the
-    management of the company allowing the employee to make private use of the
-    tools), or the existence of detailed invoices to establish a
-    for private use.
-
+    The reality of private use can result either from a written document
+    (contract work, company agreement, internal regulations, correspondence from
+    the management of the company allowing the employee to make private use of
+    the tools), or the existence of detailed invoices to establish a for private
+    use.
   description.fr: >
     L’usage privé des outils NTIC mis à disposition dans le cadre de l’activité
     professionnelle à titre permanent est constitutif d’un avantage en nature.
@@ -702,18 +700,19 @@ contrat salarié . avantages en nature . ntic:
     outils), soit de l’existence de factures détaillées permettant d’établir une
     utilisation privée.
   question.en: >
-    Does the employer provide free tools from NICTs (computer, telephone, tablet, etc.)?
+    Does the employer provide free tools from NICTs (computer, telephone,
+    tablet, etc.)?
   question.fr: >
     L'employeur fournit-il gratuitement un outils issus des NTIC (ordinateur,
     téléphone, tablette, etc.) ?
   titre.en: nict
   titre.fr: ntic
 contrat salarié . avantages en nature . autres:
-  question.en: >
+  question.en: |
     Are there any other advantages in kind (housing, vehicle, discount...)?
   question.fr: |
     Y a-t-il d'autres avantages en natures (logement, véhicule, réduction...) ?
-  titre.en: 'others'
+  titre.en: others
   titre.fr: autres
 contrat salarié . avantages en nature . autres . montant:
   question.en: |
@@ -727,23 +726,21 @@ contrat salarié . avantages en nature . autres . montant:
   titre.en: amount
   titre.fr: montant
 contrat salarié . avantages en nature . ntic . montant:
-  titre.en: 'NICTs tools'
+  titre.en: NICTs tools
   titre.fr: outils NTIC
   description.en: >
-    For benefits in kind such as NICTs (computers, smartphones,
-    tablets...), there is an annual flat-rate assessment corresponding to
-    10% of the purchase price. For example, for a phone bought at 850€ TTC with
-    a subscription of 30€ / month, the benefit in kind to be transferred to the newsletter
-    of pay will be:
+    For benefits in kind such as NICTs (computers, smartphones, tablets...),
+    there is an annual flat-rate assessment corresponding to 10% of the purchase
+    price. For example, for a phone bought at 850€ TTC with a subscription of
+    30€ / month, the benefit in kind to be transferred to the newsletter of pay
+    will be:
 
 
     ```
 
     10% x (850€ + (30€ x 12 months)) ] / 12 months
 
-    ```
-    or 10,08€
-
+    ``` or 10,08€
   description.fr: >
     Pour les avantages en nature de type NTIC (ordinateurs, smartphones,
     tablettes...), il y a une évaluation forfaitaire annuelle correspondant à
@@ -773,17 +770,19 @@ contrat salarié . avantages en nature . ntic . coût appareils:
     "\U0001F4F1✨ (haut de gamme)": 850
     "\U0001F4BB": 1200
     "\U0001F4BB + \U0001F4F1✨": 2050
-  titre.en: 'devices cost'
+  titre.en: devices cost
   titre.fr: coût appareils
 contrat salarié . avantages en nature . ntic . abonnements:
   question.en: What is the cost of the subscription price charged by the employer?
-  question.fr: Quel est le coût de l'abonnement prix en charge par l'employeur ?
-  suggestions.fr:
-    aucun: 0
-    standard: 20
-    international: 40
+  question.fr: >-
+    Quel est le coût de l'abonnement (forfait mobile, etc.) pris en charge par
+    l'employeur ?
   suggestions.en:
     none: 0
+    standard: 20
+    international: 40
+  suggestions.fr:
+    aucun: 0
     standard: 20
     international: 40
   titre.en: subscription
@@ -794,14 +793,15 @@ contrat salarié . avantages en nature . nourriture:
   question.fr: |
     L'employeur fournit-il gratuitement les repas ?
   description.en: >
-    Lunch vouchers("tickets restaurants") are not considered as a benefit in kind but as a reimbursement of expenses.
+    Lunch vouchers("tickets restaurants") are not considered as a benefit in
+    kind but as a reimbursement of expenses.
   description.fr: >
-    Les tickets restaurants ne sont pas considéré comme un avantage en nature
+    Les tickets restaurants ne sont pas considérés comme un avantage en nature
     mais comme un remboursement de frais.
-  titre.en: 'food'
+  titre.en: food
   titre.fr: nourriture
 contrat salarié . avantages en nature . nourriture . montant:
-  titre.en: 'food'
+  titre.en: food
   titre.fr: nourriture
 ? contrat salarié . avantages en nature . nourriture . montant forfaitaire d'un repas
 : titre.en: fixed amount of a meal
@@ -820,12 +820,11 @@ contrat salarié . avantages en nature . nourriture . repas par mois:
   titre.en: meal per month
   titre.fr: repas par mois
 contrat salarié . avantages en nature . nourriture . dans la restauration:
-  question.en: >-
-    Is it for an employee working in a hotel, café, restaurant and similar?
+  question.en: 'Is it for an employee working in a hotel, café, restaurant and similar?'
   question.fr: >-
     Est-ce pour un salarié travaillant dans un hôtel, café, restaurant et
     assimilés ?
-  titre.en:  in the catering business
+  titre.en: in the catering business
   titre.fr: dans la restauration
 contrat salarié . indemnités salarié:
   titre.en: Employee benefits
@@ -900,6 +899,11 @@ contrat salarié . rémunération . net imposable . exonérations:
   titre.en: exemptions
   titre.fr: exonérations
 contrat salarié . prime d'impatriation:
+  description.en: >-
+    The impatriation bonus is a part of the remuneration exempt from income tax.
+  description.fr: >-
+    La prime d'impatriation est une partie de la rémunération exonérée d'impôt
+    sur le revenu.
   titre.en: impatriation bonus
   titre.fr: prime d'impatriation
 contrat salarié . salaire . net:
@@ -1136,11 +1140,12 @@ entreprise . association non lucrative:
   titre.fr: association non lucrative
 entreprise . établissement bancaire:
   description.en: >-
-    The company is a banking, financial or insurance institution. It is not subject to VAT.
+    The company is a banking, financial or insurance institution. It is not
+    subject to VAT.
   description.fr: >-
     L'entreprise est un établissement bancaire, financier ou d'assurance. Elle
     est non assujettie à la TVA.
-  question.en: Is it a banking, financial or insurance institution?
+  question.en: 'Is it a banking, financial or insurance institution?'
   question.fr: "S'agit-il d'un établissement bancaire, financier, d'assurance ?"
   titre.en: banking institution
   titre.fr: établissement bancaire
@@ -1622,18 +1627,18 @@ contrat salarié . régime des impatriés:
   question.en: Does the employee benefit from the impatriate scheme?
   question.fr: Le salarié bénéficie-t-il du régime des impatriés ?
   description.en: >
-    If you are an employee or a director with the 'assimilé-salarié' social and fiscal scheme,
-    and if you have been called upon by a foreign company to take up employment in a
-    company established in France with a link to the first or if you have
-    been directly recruited abroad by a company established in France,
-    you can benefit from the impatriate scheme.
+    If you are an employee or a director with the 'assimilé-salarié' social and
+    fiscal scheme, and if you have been called upon by a foreign company to take
+    up employment in a company established in France with a link to the first or
+    if you have been directly recruited abroad by a company established in
+    France, you can benefit from the impatriate scheme.
 
 
     In addition, you must not have been domiciled in France for tax purposes on
-    five calendar years preceding that in which he takes up his duties and set in
-    France your tax domicile as soon as you take up your duties.
+    five calendar years preceding that in which he takes up his duties and set
+    in France your tax domicile as soon as you take up your duties.
   description.fr: >
-    Si vous êtes salarié ou dirigeant assimilé-salarié, et si vous avez été
+    Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été
     appelé par une entreprise étrangère à occuper un emploi dans une entreprise
     établie en France ayant un lien avec la première ou si vous avez été
     directement recruté à l’étranger par une entreprise établie en France, vous
@@ -1643,6 +1648,12 @@ contrat salarié . régime des impatriés:
     Vous devez en outre ne pas avoir été fiscalement domicilié en France les
     cinq années civiles précédant celle de la prise de fonctions et fixer en
     France votre domicile fiscal dès votre prise de fonctions.
+
+
+    Les impatriés sont exonérés de cotisations retraite (régime de base et
+    complémentaire) à condition de justifier d'une contribution minimale versée
+    par ailleurs (par exemple dans une caisse de retraite ou un fond de pension
+    étranger). Ils n’acquièrent aucun droit pendant la durée d’exonération.
   titre.en: impatriate scheme
   titre.fr: régime des impatriés
 entreprise . taxe sur les salaires . barème:
@@ -1673,6 +1684,23 @@ contrat salarié . versement transport:
 contrat salarié . vieillesse:
   description.en: Contribution to the basic pension plan of employees.
   description.fr: Cotisation au régime de retraite de base des salariés.
+  contrôles.fr:
+    - si: régime des impatriés
+      niveau: information
+      message: >
+        Pour bénéficier de l'exonération de cotisations vieillesse, il faut
+        remplir les conditions suivantes :
+
+        - Pouvoir justifier d'une contribution minimale versée ailleurs pour une
+        assurance vieilllesse
+
+        - De ne pas avoir été affiliés, au cours des cinq années civiles
+        précédant celle de leur prise de fonctions, à un régime français
+        obligatoire d'assurance vieillesse, sauf pour des activités accessoires,
+        de caractère saisonnier ou pour les études.
+
+        [Voir
+        plus](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=F5CFB7C90D1D1F529A2CDC9FFD20BD6E.tplgfr34s_3?idSectionTA=LEGISCTA000038510929&cidTexte=LEGITEXT000006073189&dateTexte=20190626)
   titre.en: Basic pension contribution
   titre.fr: vieillesse
 contrat salarié . forfait social:
@@ -1697,7 +1725,7 @@ impôt:
     Cet ensemble de formules est un modèle ultra-simplifié de l'impôt sur le
     revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
   titre.en: income tax
-  titre.fr: impôt
+  titre.fr: impôt sur le revenu
 impôt . revenu abattu:
   description.en: >
     The tax is calculated on a reduced income: it is reduced (for example by
@@ -1758,30 +1786,45 @@ impôt . impôt sur le revenu après décote:
     réduire l'impôt des bas revenus.
   titre.en: income tax after discount
   titre.fr: impôt sur le revenu après décote
+impôt . revenu fiscal de référence:
+  description.en: >-
+    The reference tax income corresponds to the household's reduced income adjusted with a quotient mechanism and increased by a certain number of exemptions.
+    The latter are reinstated in the calculation.
+  description.fr: >-
+    le revenu fiscal de référence correspond au revenu abattu du foyer ajusté  avec un mécanisme de quotient et majoré d'un certains nombre d'exonérations.
+    Ces dernières sont réintégrées dans le calcul.
+  titre.en: reference taxable income
+  titre.fr: revenu fiscal de référence
 impôt . CEHR:
   titre.fr: CEHR
 impôt . impôt sur le revenu à payer:
   titre.en: income tax
   titre.fr: impôt sur le revenu
 revenu net de cotisations:
+  résumé.en: 'Before taxes'
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
-revenu net d'impôt:
-  titre.en: Net income after contributions and taxes
-  titre.fr: Revenu net de cotisations et d'impôt
-revenu net:
-  titre.en: Net income
-  titre.fr: Revenu net
-  résumé.en: After income tax
-  résumé.fr: Après impôt sur le revenu
-  question.en: How much income do you plan to receive ?
+revenu net après impôt:
+  résumé.en: Paid into the bank account
+  résumé.fr: Versé sur le compte bancaire
+  question.en: What income do you want to receive?
   question.fr: Quel revenu voulez-vous toucher ?
   description.en: |
     This is the income net of contributions and taxes.
     In other words, that's what you get in the end from your bank account.
   description.fr: |
-    Il s'agit du revenu net de cotisations et d'impôts.
+    Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
+  titre.en: Net income after tax
+  titre.fr: revenu net après impôt
 entreprise . année d'activité:
   question.en: How old is the company in years of activity?
   question.fr: Quel est l'âge de l'entreprise en année d'activité ?
@@ -1821,10 +1864,10 @@ entreprise . année d'activité . régime de croisière:
   titre.en: fourth year or more
   titre.fr: régime de croisière
 entreprise . chiffre d'affaires:
-  titre.en: Turnover (excluding VAT)
-  titre.fr: chiffre d'affaires H.T.
-  question.en: What is your expected turnover (excluding tax)?
-  question.fr: Quel est votre chiffre d'affaires envisagé (H.T.) ?
+  titre.en: Turnover
+  titre.fr: chiffre d'affaire (H.T.)
+  question.en: What is your expected turnover ?
+  question.fr: Quel est votre chiffre d'affaires envisagé ?
   résumé.en: The amount of sales made
   résumé.fr: Le montant des ventes réalisées
 entreprise . chiffre d'affaires de société:
@@ -1862,23 +1905,29 @@ entreprise . charges dont rémunération dirigeant:
   titre.en: expenses of which executive compensation
   titre.fr: charges dont rémunération dirigeant
 entreprise . rémunération totale du dirigeant:
+  question.en: How much do you think you will make available for your remuneration?
+  question.fr: Quel montant pensez-vous dégager pour votre rémunération ?
+  résumé.en: Spent by the company
+  résumé.fr: Dépensé par l'entreprise
   description.en: >-
-    This is the "super gross" remuneration of the manager, which includes all
-    the social security contributions to be paid. It is also the monetary value
-    of the work of the leader.
+    This is what the company spends in total for the director income.
+    This "super gross" remuneration includes all social security contributions to be paid.
+
+    It can also be considered as the monetary value of the director's work.
   description.fr: >-
-    C'est la rémunération "super-brute" du dirigeant, qui inclut toutes les
-    cotisations sociales à payer. C'est aussi la valeur monétaire du travail du
+    C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
+    Cette rémunération "super-brute" inclut toutes les cotisations sociales à
+    payer.
+
+    On peut aussi considérer que c'est la valeur monétaire du travail du
     dirigeant.
-  titre.en: Total compensation of the executive
+  titre.en: Director total income
   titre.fr: rémunération totale du dirigeant
 entreprise . charges:
   résumé.en: All the expenses necessary for the company"
   résumé.fr: Toutes les dépenses nécessaires à l'entreprise
   question.en: What are the company's expenses before tax (excluding remuneration manager)?
-  question.fr: >-
-    Quelles sont les charges H.T. de l'entreprise (hors rémunération dirigeant)
-    ?
+  question.fr: Quelles sont les charges de l'entreprise ?
   description.en: >
     These are the company's expenses incurred in the company's interest,
     excluding executive compensation. For companies and businesses excluding
@@ -1916,12 +1965,11 @@ entreprise . charges:
     hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto
     entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise
     ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur,
-    elles ne sont pas déductibles : l'entrepreneur les paie avec son salaire
-    personnel net de cotisation et de revenu.
+    elles ne sont pas déductibles du chiffre d'affaire encaissé.
 
 
-    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors
-    taxe.
+    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe
+    (excepté pour les auto entrepreneurs en franchise de TVA)
 
 
     Par exemple, les charges peuvent être :
@@ -1945,21 +1993,6 @@ entreprise . charges:
     charge sans immobilisation.
   titre.en: expenses
   titre.fr: charges
-entreprise . charges non déductibles:
-  description.en: >
-    For the auto-enterprise,[the charges](/documentation/entreprise/charges) are
-    not deductible. For example, an auto-entrepreneur who buys a computer for
-    the needs of his company, will do so with his net income. He will therefore
-    have paid social security contributions and income tax on its turnover
-    before you can use it to buy this property.
-  description.fr: >
-    Pour l'auto-entreprise, [les charges](/documentation/entreprise/charges) ne
-    sont pas déductibles. Par exemple, un auto-entrepreneur qui achète un
-    ordinateur pour les besoins de sa société, le fera avec son revenu net. Il
-    aura donc payé des cotisations sociales et l'impôt sur le revenu sur son CA
-    avant de pouvoir l'utiliser pour s'acheter ce bien.
-  titre.en: non-deductible expenses
-  titre.fr: charges non déductibles
 indépendant . cotisations et contributions . réduction ACRE:
   titre.en: ACRE reduction
   titre.fr: réduction ACRE
@@ -1967,20 +2000,44 @@ indépendant . cotisations et contributions . réduction ACRE . taux ACRE:
   titre.en: ACRE rate
   titre.fr: taux ACRE
 indépendant . revenu net de cotisations:
+  résumé.en: Before taxes
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >-
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >-
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
 indépendant . revenu professionnel:
-  résumé.en: After contributions and expenses
-  résumé.fr: Après cotisations et charges
-  question.en: What is your professional income ?
-  question.fr: Quel est votre revenu professionnel ?
-  description.en: |
-    C'est le revenu net de cotisations du travailleur indépendant.
-  description.fr: |
-
-    C'est le revenu net de cotisations du travailleur indépendant.
   titre.en: Professional income
-  titre.fr: revenu professionnel
+  titre.fr: revenu professionnel (net imposable)
+  description.en: >
+    It is the net income of the self-employed person from deductible contributions that is used as the basis for calculating contributions and taxes for the self-employed.
+
+    Attention, **our calculation is valid for a standard scheme**:
+
+    The self-employed person who starts out will pay a fixed contributions during his first months. He will then have to regularize this situation in relation to the income he actually received.
+
+    This calculation should therefore be seen as *the amount that should in any case be paid* in the short term after several months of activity.
+
+  description.fr: >
+    C'est le revenu net de cotisations déductibles du travailleur indépendant,
+    qui sert de base au calcul des cotisations et de l'impôt pour les
+    indépendants.
+
+
+    Attention, **notre calcul est fait au régime de croisière**:
+
+    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait
+    relativement réduit de cotisations sociales. Il devra ensuite régulariser
+    cette situation par rapport au revenu qu'il a vraiment perçu.
+
+
+    Il faut donc voir ce calcul comme *le montant qui devra de toute façon être
+    payé* à court terme après 2 ans d'exercice.
 entreprise . catégorie d'activité:
   question.en: What is your category of activity?
   question.fr: Quelle est votre catégorie d'activité ?
@@ -2157,7 +2214,8 @@ entreprise . catégorie d'activité . libérale règlementée:
     - si: libérale règlementée
       niveau: avertissement
       message: >
-        Attention, the simulator is not yet complete for the regulated liberal professions.
+        Attention, the simulator is not yet complete for the regulated liberal
+        professions.
   contrôles.fr:
     - si: libérale règlementée
       niveau: avertissement
@@ -2245,7 +2303,11 @@ indépendant . cotisations et contributions:
   titre.fr: cotisations et contributions
 entreprise . rattachement libéral règlementé:
   description.en: >
-    The unregulated liberal companies created were linked to the regulated ones for the calculation of social security contributions. Since 2018 this is no longer the case for auto-entrepreneurs (2019 for sole proprietorships). They are now attached to the artisan-merchants, so they depend on the social security of the self-employed ("indépendant").
+    The unregulated liberal companies created were linked to the regulated ones
+    for the calculation of social security contributions. Since 2018 this is no
+    longer the case for auto-entrepreneurs (2019 for sole proprietorships). They
+    are now attached to the artisan-merchants, so they depend on the social
+    security of the self-employed ("indépendant").
   description.fr: >
     Les entreprises libérales non règlementées créées étaient rattachées aux
     règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est
@@ -2320,16 +2382,6 @@ indépendant . cotisations et contributions . formation professionnelle:
 ? indépendant . cotisations et contributions . cotisations . allocations familiales
 : titre.en: family allowances
   titre.fr: allocations familiales
-indépendant . revenu total du dirigeant:
-  question.en: What is the total income of the executive?
-  question.fr: Quel est le revenu total du dirigeant ?
-  résumé.en: Spent by the company
-  résumé.fr: Dépensé par l'entreprise
-  titre.en: total income of the executive
-  titre.fr: revenu total du dirigeant
-indépendant . impôt et contributions non déductibles:
-  titre.en: taxes and non-deductible contributions
-  titre.fr: impôt et contributions non déductibles
 auto entrepreneur:
   question.en: Is the activity carried out in a auto-enterprise?
   question.fr: L'activité est-elle exercée en auto-entreprise ?
@@ -2382,8 +2434,17 @@ auto entrepreneur . plafond:
   titre.en: upper limit
   titre.fr: plafond
 auto entrepreneur . revenu net de cotisations:
-  titre.en: Auto-entrepreneur net income
-  titre.fr: Revenu net auto-entrepreneur
+  résumé.en: Before taxes
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >-
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >-
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
+  titre.en: Net contribution income
+  titre.fr: revenu net de cotisations
 auto entrepreneur . cotisations et contributions:
   titre.en: Contributions
   titre.fr: cotisations et contributions
@@ -2454,15 +2515,17 @@ entreprise . ACCRE obtenu:
   titre.en: ACCRE obtained
   titre.fr: ACCRE obtenu
 auto entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-  titre.en: >
+  titre.en: |
     "ACRE" rate
   titre.fr: taux ACRE
 auto entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
-  titre.en: >
+  titre.en: |
     "ACRE" reduction
   titre.fr: réduction ACRE
   description.en: >-
-      In some cases, this rate may reduce the amount of social security contributions paid by the auto-entrepreneur to help him/her in his/her first year of activity.
+    In some cases, this rate may reduce the amount of social security
+    contributions paid by the auto-entrepreneur to help him/her in his/her first
+    year of activity.
   description.fr: >-
     Ce taux peut dans certains cas réduire le montant des cotisations sociales
     de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
@@ -2490,7 +2553,7 @@ auto entrepreneur . impôt:
   titre.fr: impôt
 auto entrepreneur . impôt . revenu abattu:
   titre.en: reduced income
-  titre.fr: revenu abattu
+  titre.fr: revenu abattu auto-entrepreneur
 protection sociale:
   description.en: >
     Social protection in France is composed of 5 main branches: sickness,
@@ -2592,7 +2655,8 @@ protection sociale . retraite . complémentaire sécurité des indépendants:
   titre.fr: prix d'achat du point
 protection sociale . santé:
   résumé.en: >-
-    Covers most everyday health care and 100% of serious illnesses such as hospital stays.
+    Covers most everyday health care and 100% of serious illnesses such as
+    hospital stays.
   résumé.fr: >-
     Couvre la plupart des soins de santé de la vie quotidienne et 100 % des
     maladies graves comme les séjours à l'hôpital.

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -26,22 +26,34 @@ contrat salarié . indemnité kilométrique vélo . distance annuelle:
     rendre à son travail.
   titre.en: annual distance
   titre.fr: distance annuelle
-contrat salarié . indemnité kilométrique vélo . indemnité vélo active:
-  question.en: >
-    Does the employee take advantage of the kilometric bicycle allowance to go
-    to work ?
+contrat salarié . indemnité kilométrique vélo . active:
+  titre.en: active bicycle allowance
+  titre.fr: indemnité vélo active
+  question.en: >-
+    Does the employee take advantage of the bicycle mileage allowance to commute to work?
   question.fr: >-
     Le salarié profite-t-il de l'indemnité kilométrique vélo pour se rendre au
     travail ?
   description.en: >
-    The employer has the choice to enable his employees to take advantage of
-    this new financial aid.
-
-    What sets it appart from a salary bonus is that it is exonerated from social
-    contributions and income tax up to 200€.
+    This allowance is not mandatory at this time.
 
 
-    To reach 200€, the employee must cycle approximately 4km per day.
+    The employer has the choice to implement it in his company.
+
+
+    To benefit from the €200 compensation deducted in this calculation, the employee
+    must cycle 4km (round trip) to work each day
+    worked.
+
+
+    This allowance can be combined with the reimbursement of transport costs
+    if it is a bike trip to a transport station.
+
+
+    This allowance is exempt from social security contributions and tax on the
+    income. To pay a salary bonus equivalent to his employee without this
+    device, **the employer should pay nearly 500€ for a salary
+    median**.
   description.fr: >
     Cette indemnité n'est pour l'instant pas obligatoire.
 
@@ -63,8 +75,6 @@ contrat salarié . indemnité kilométrique vélo . indemnité vélo active:
     revenu. Pour verser une prime de salaire équivalente à son salarié sans ce
     dispositif, **l'employeur devrait débourser près de 500€ pour un salaire
     médian**.
-  titre.en: allowance enabled
-  titre.fr: indemnité vélo active
 contrat salarié . CDD . CIF:
   description.en: >-
     Contribution to the financing of individual training leave, specific to
@@ -139,7 +149,7 @@ contrat salarié . ATMP . taux réduit:
   titre.en: reduced rate for risk-free activity
   titre.fr: taux réduit pour activité sans risque
   question.en: Is the activity of the establishment or employee without risk ?
-  question.fr: L'activité de l'établissement ou du salarié est-elle sans risque ?
+  question.fr: L'activité de l'établissement ou du salarié est-elle sans aucun risque ?
   description.en: |
     This rate corresponds to:
       - small companies whose activity is not risky, for example IT consulting
@@ -473,7 +483,7 @@ contrat salarié:
     semaines consécutives dans l'année.
 
     - CDI : La signature d’un contrat de travail n’est pas obligatoire dans
-    certains cas. C’est le cas du Contrat de travail à Durée Indéterminée,
+    certains cas. C’est le cas du Contrat de travail à Durée Ind��terminée,
     considéré comme la forme normale et générale de la relation de travail entre
     un salarié et un employeur (Art. L1221-2 du Code du travail).
   titre.en: employment contract
@@ -602,7 +612,6 @@ contrat salarié . salaire . brut de base:
       message: >
         Le salaire mensuel saisi est élevé. Ne vous êtes-vous pas trompé de
         période de calcul ?
-
 contrat salarié . salaire . brut de base . équivalent temps plein:
   titre.en: Full-time equivalent gross salary
   titre.fr: Salaire brut équivalent temps plein
@@ -654,8 +663,8 @@ contrat salarié . avantages en nature:
     Does the employee receive benefits in kind (housing, vehicle, telephone,
     discounts, etc.)?
   question.fr: >-
-    Le salarié reçoit-il des avantages en nature (logement, véhicule, téléphone,
-    réductions...) ?
+    Le salarié reçoit-il des avantages en nature (repas, véhicule, téléphone,
+    réductions, logement...) ?
 contrat salarié . avantages en nature . montant:
   titre.en: Benefits in kind (amount)
   titre.fr: Avantages en nature (montant)
@@ -666,9 +675,158 @@ contrat salarié . avantages en nature . montant:
     Les avantages en nature sont soumis aux cotisations et à l'impôt sur le
     revenu. Ils sont pris en compte pour vérifier que le salaire minimum est
     atteint.
-  question.en: What is the monthly amount of benefits in kind?
-  question.fr: Quel est le montant des avantages en nature ?
+contrat salarié . avantages en nature . ntic:
+  description.en: >
+    The private use of the NICT tools made available as part of
+    the permanent professional activity constitutes an advantage in kind.
 
+    This benefit is included in the basis for calculating Security contributions
+    and unemployment insurance.
+
+    The reality of private use can result either from a written document (contract
+    work, company agreement, internal regulations, correspondence from the
+    management of the company allowing the employee to make private use of the
+    tools), or the existence of detailed invoices to establish a
+    for private use.
+
+  description.fr: >
+    L’usage privé des outils NTIC mis à disposition dans le cadre de l’activité
+    professionnelle à titre permanent est constitutif d’un avantage en nature.
+
+    Cet avantage est inclus dans la base de calcul des cotisations de Sécurité
+    sociale et d’assurance chômage.
+
+    La réalité de l’usage privé peut résulter soit d’un document écrit (contrat
+    de travail, accord d’entreprise, règlement intérieur, courrier de la
+    direction de l’entreprise autorisant le salarié à faire un usage privé des
+    outils), soit de l’existence de factures détaillées permettant d’établir une
+    utilisation privée.
+  question.en: >
+    Does the employer provide free tools from NICTs (computer, telephone, tablet, etc.)?
+  question.fr: >
+    L'employeur fournit-il gratuitement un outils issus des NTIC (ordinateur,
+    téléphone, tablette, etc.) ?
+  titre.en: nict
+  titre.fr: ntic
+contrat salarié . avantages en nature . autres:
+  question.en: >
+    Are there any other advantages in kind (housing, vehicle, discount...)?
+  question.fr: |
+    Y a-t-il d'autres avantages en natures (logement, véhicule, réduction...) ?
+  titre.en: 'others'
+  titre.fr: autres
+contrat salarié . avantages en nature . autres . montant:
+  question.en: |
+    How much is the amount of these other benefits?
+  question.fr: |
+    Quel est le montant de ces autres avantages ?
+  suggestions.en:
+    "\U0001F697 vehicle": 260
+  suggestions.fr:
+    "\U0001F697 véhicule": 260
+  titre.en: amount
+  titre.fr: montant
+contrat salarié . avantages en nature . ntic . montant:
+  titre.en: 'NICTs tools'
+  titre.fr: outils NTIC
+  description.en: >
+    For benefits in kind such as NICTs (computers, smartphones,
+    tablets...), there is an annual flat-rate assessment corresponding to
+    10% of the purchase price. For example, for a phone bought at 850€ TTC with
+    a subscription of 30€ / month, the benefit in kind to be transferred to the newsletter
+    of pay will be:
+
+
+    ```
+
+    10% x (850€ + (30€ x 12 months)) ] / 12 months
+
+    ```
+    or 10,08€
+
+  description.fr: >
+    Pour les avantages en nature de type NTIC (ordinateurs, smartphones,
+    tablettes...), il y a une évaluation forfaitaire annuelle correspondant à
+    10% du prix d'achat. Par exemple, pour un téléphone acheté à 850€ TTC avec
+    un abonnement de 30€ / mois, l'avantage en nature à reporter sur le bulletin
+    de paie sera de :
+
+
+    ```
+
+    [10% x (850€ + (30€ x 12 mois)) ] / 12 mois
+
+    ```
+     soit 10,08€
+contrat salarié . avantages en nature . ntic . coût appareils:
+  question.en: |
+    What is the total new cost of the equipment provided?
+  question.fr: |
+    Quel est le coût total neuf des appareils mis à disposition ?
+  suggestions.en:
+    "\U0001F4F1": 400
+    "\U0001F4F1✨ (high-end model)": 850
+    "\U0001F4BB": 1200
+    "\U0001F4BB + \U0001F4F1✨": 2050
+  suggestions.fr:
+    "\U0001F4F1": 400
+    "\U0001F4F1✨ (haut de gamme)": 850
+    "\U0001F4BB": 1200
+    "\U0001F4BB + \U0001F4F1✨": 2050
+  titre.en: 'devices cost'
+  titre.fr: coût appareils
+contrat salarié . avantages en nature . ntic . abonnements:
+  question.en: What is the cost of the subscription price charged by the employer?
+  question.fr: Quel est le coût de l'abonnement prix en charge par l'employeur ?
+  suggestions.fr:
+    aucun: 0
+    standard: 20
+    international: 40
+  suggestions.en:
+    none: 0
+    standard: 20
+    international: 40
+  titre.en: subscription
+  titre.fr: abonnements
+contrat salarié . avantages en nature . nourriture:
+  question.en: |
+    Does the employer provide free meals?
+  question.fr: |
+    L'employeur fournit-il gratuitement les repas ?
+  description.en: >
+    Lunch vouchers("tickets restaurants") are not considered as a benefit in kind but as a reimbursement of expenses.
+  description.fr: >
+    Les tickets restaurants ne sont pas considéré comme un avantage en nature
+    mais comme un remboursement de frais.
+  titre.en: 'food'
+  titre.fr: nourriture
+contrat salarié . avantages en nature . nourriture . montant:
+  titre.en: 'food'
+  titre.fr: nourriture
+? contrat salarié . avantages en nature . nourriture . montant forfaitaire d'un repas
+: titre.en: fixed amount of a meal
+  titre.fr: montant forfaitaire d'un repas
+contrat salarié . avantages en nature . nourriture . repas par mois:
+  question.en: |
+    How many meals per month are paid for by the employer?
+  question.fr: |
+    Combien de repas par mois sont payés par l'employeur ?
+  suggestions.en:
+    1 per day: 21
+    2 per day: 42
+  suggestions.fr:
+    1 par jour: 21
+    2 par jour: 42
+  titre.en: meal per month
+  titre.fr: repas par mois
+contrat salarié . avantages en nature . nourriture . dans la restauration:
+  question.en: >-
+    Is it for an employee working in a hotel, café, restaurant and similar?
+  question.fr: >-
+    Est-ce pour un salarié travaillant dans un hôtel, café, restaurant et
+    assimilés ?
+  titre.en:  in the catering business
+  titre.fr: dans la restauration
 contrat salarié . indemnités salarié:
   titre.en: Employee benefits
   titre.fr: indemnités salarié
@@ -702,7 +860,7 @@ contrat salarié . SMIC temps plein:
   titre.en: full-time mimimum wage (SMIC)
   titre.fr: SMIC temps plein
 SMIC horaire:
-  titre.en: 'hourly minimum wage (SMIC)'
+  titre.en: hourly minimum wage (SMIC)
   titre.fr: SMIC horaire
 contrat salarié . SMIC:
   titre.en: minimum wage (SMIC)
@@ -741,6 +899,9 @@ contrat salarié . rémunération . net imposable . base:
 contrat salarié . rémunération . net imposable . exonérations:
   titre.en: exemptions
   titre.fr: exonérations
+contrat salarié . prime d'impatriation:
+  titre.en: impatriation bonus
+  titre.fr: prime d'impatriation
 contrat salarié . salaire . net:
   titre.en: Net salary
   titre.fr: Salaire net
@@ -973,6 +1134,16 @@ entreprise . association non lucrative:
   question.fr: S'agit-il d'une association à but non lucratif ?
   titre.en: non-profit organisation
   titre.fr: association non lucrative
+entreprise . établissement bancaire:
+  description.en: >-
+    The company is a banking, financial or insurance institution. It is not subject to VAT.
+  description.fr: >-
+    L'entreprise est un établissement bancaire, financier ou d'assurance. Elle
+    est non assujettie à la TVA.
+  question.en: Is it a banking, financial or insurance institution?
+  question.fr: "S'agit-il d'un établissement bancaire, financier, d'assurance ?"
+  titre.en: banking institution
+  titre.fr: établissement bancaire
 établissement:
   description.en: >-
     The employee works in one of the company's establishment, identified by a
@@ -1438,12 +1609,42 @@ contrat salarié . contribution supplémentaire à l'apprentissage:
 contrat salarié . taxe d'apprentissage . csa au taux majoré:
   titre.en: CSA at the higher rate
   titre.fr: CSA au taux majoré
+contrat salarié . taxe sur les salaires . assiette de base:
+  titre.en: basis
+  titre.fr: assiette de base
 contrat salarié . taxe sur les salaires . assiette:
   titre.en: base
   titre.fr: assiette
 contrat salarié . taxe sur les salaires . barème:
   titre.en: scale
   titre.fr: barème
+contrat salarié . régime des impatriés:
+  question.en: Does the employee benefit from the impatriate scheme?
+  question.fr: Le salarié bénéficie-t-il du régime des impatriés ?
+  description.en: >
+    If you are an employee or a director with the 'assimilé-salarié' social and fiscal scheme,
+    and if you have been called upon by a foreign company to take up employment in a
+    company established in France with a link to the first or if you have
+    been directly recruited abroad by a company established in France,
+    you can benefit from the impatriate scheme.
+
+
+    In addition, you must not have been domiciled in France for tax purposes on
+    five calendar years preceding that in which he takes up his duties and set in
+    France your tax domicile as soon as you take up your duties.
+  description.fr: >
+    Si vous êtes salarié ou dirigeant assimilé-salarié, et si vous avez été
+    appelé par une entreprise étrangère à occuper un emploi dans une entreprise
+    établie en France ayant un lien avec la première ou si vous avez été
+    directement recruté à l’étranger par une entreprise établie en France, vous
+    pouvez bénéficier du régime des impatriés.
+
+
+    Vous devez en outre ne pas avoir été fiscalement domicilié en France les
+    cinq années civiles précédant celle de la prise de fonctions et fixer en
+    France votre domicile fiscal dès votre prise de fonctions.
+  titre.en: impatriate scheme
+  titre.fr: régime des impatriés
 entreprise . taxe sur les salaires . barème:
   titre.en: scale
   titre.fr: barème
@@ -1522,7 +1723,7 @@ impôt . revenu abattu par défaut:
     lump-sum allowance. However, anyone can opt for the declaration of its *real
     costs*, which will replace this default package.
   description.fr: >-
-    Dans le cas général, l'impôt est calculé après l'application d'un
+    Dans le cas général, l'impôt est calculé apr��s l'application d'un
     abattement forfaitaire fixe. Chacun peut néanmoins opter pour la déclaration
     de ses *frais réels*, qui viendront remplacer ce forfait par défaut.
   titre.en: default reduced income
@@ -1540,6 +1741,8 @@ impôt . impôt sur le revenu:
     Voici le fameux barème de l'impôt sur le revenu. C'est un barème marginal à
     5 tranches.
 
+    Une contribution sur les hauts revenus ajoute deux tranches supplémentaires.
+
 
     Attention : pour un revenu de 100 000€ annuels, le contribuable ne paiera 41
     000€ d'impôt (le taux de la 4ème tranche est 41%) ! Ces 41% sont appliqués
@@ -1555,6 +1758,8 @@ impôt . impôt sur le revenu après décote:
     réduire l'impôt des bas revenus.
   titre.en: income tax after discount
   titre.fr: impôt sur le revenu après décote
+impôt . CEHR:
+  titre.fr: CEHR
 impôt . impôt sur le revenu à payer:
   titre.en: income tax
   titre.fr: impôt sur le revenu
@@ -1623,27 +1828,30 @@ entreprise . chiffre d'affaires:
   résumé.en: The amount of sales made
   résumé.fr: Le montant des ventes réalisées
 entreprise . chiffre d'affaires de société:
-  titre.en: 'company turnover'
+  titre.en: company turnover
   titre.fr: chiffre d'affaires de société
 entreprise . rémunération du dirigeant:
   description.en: >
-    This is the portion of revenue after expenses that is allocated to the executive's compensation. The higher this share, the higher the executive's compensation increases, and the lower the company's profit.
+    This is the portion of revenue after expenses that is allocated to the
+    executive's compensation. The higher this share, the higher the executive's
+    compensation increases, and the lower the company's profit.
   description.fr: >
     C'est la part du chiffre d'affaires après charges qui est allouée à la
     rémunération du dirigeant. Plus cette part est élevée, plus la rémunération
     du dirigeant augmente, et plus le bénéfice de l'entreprise diminue.
   question.en: >-
-    How much of the after-charge revenue is allocated to the executive's compensation?
+    How much of the after-charge revenue is allocated to the executive's
+    compensation?
   question.fr: >-
     Quelle part du chiffre d'affaires après charge est allouée à la rémunération
     du dirigeant ?
-  titre.en: 'executive compensation'
+  titre.en: executive compensation
   titre.fr: rémunération du dirigeant
 entreprise . bénéfice:
-  titre.en: 'profit'
+  titre.en: profit
   titre.fr: bénéfice
 entreprise . résultat net:
-  résumé.en: 'What remains after corporate income tax'
+  résumé.en: What remains after corporate income tax
   résumé.fr: Ce qu'il reste après impôt sur les sociétés
   titre.en: net result
   titre.fr: résultat net
@@ -1945,6 +2153,11 @@ entreprise . catégorie d'activité . libérale règlementée:
 
     > Exemples de professions non-règlementées : développeur, historien,
     urbaniste...
+  contrôles.en:
+    - si: libérale règlementée
+      niveau: avertissement
+      message: >
+        Attention, the simulator is not yet complete for the regulated liberal professions.
   contrôles.fr:
     - si: libérale règlementée
       niveau: avertissement
@@ -2032,18 +2245,14 @@ indépendant . cotisations et contributions:
   titre.fr: cotisations et contributions
 entreprise . rattachement libéral règlementé:
   description.en: >
-    !!Les entreprises libérales non règlementées créées étaient rattachées aux
-    règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est
-    plus le cas pour les auto-entrepreneur (2019 pour les entreprise
-    individuelles). Elles sont maintenant rattachées aux artisans-commerçants,
-    donc dépendent de la sécurité sociale des indépendants.
+    The unregulated liberal companies created were linked to the regulated ones for the calculation of social security contributions. Since 2018 this is no longer the case for auto-entrepreneurs (2019 for sole proprietorships). They are now attached to the artisan-merchants, so they depend on the social security of the self-employed ("indépendant").
   description.fr: >
     Les entreprises libérales non règlementées créées étaient rattachées aux
     règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est
     plus le cas pour les auto-entrepreneur (2019 pour les entreprise
     individuelles). Elles sont maintenant rattachées aux artisans-commerçants,
     donc dépendent de la sécurité sociale des indépendants.
-  titre.en: '!!rattachement libéral règlementé'
+  titre.en: linked with regulated liberal
   titre.fr: rattachement libéral règlementé
 indépendant . cotisations et contributions . cotisations . maladie:
   titre.en: health insurance
@@ -2112,9 +2321,9 @@ indépendant . cotisations et contributions . formation professionnelle:
 : titre.en: family allowances
   titre.fr: allocations familiales
 indépendant . revenu total du dirigeant:
-  question.en: 'What is the total income of the executive?'
+  question.en: What is the total income of the executive?
   question.fr: Quel est le revenu total du dirigeant ?
-  résumé.en: 'Spent by the company'
+  résumé.en: Spent by the company
   résumé.fr: Dépensé par l'entreprise
   titre.en: total income of the executive
   titre.fr: revenu total du dirigeant
@@ -2130,7 +2339,7 @@ auto entrepreneur:
      simplify administrative management, in particular by replacing all the
      social contributions by a single monthly levy.
   description.fr: >
-    L'auto-entreprise est une entreprise individuelle simplifiée. À l'origine
+    L'auto-entreprise est une entreprise individuelle simplifi��e. À l'origine
     connu sous l'appellation « auto-entrepreneur », le régime de «
     micro-entrepreneur » est un régime de travailleur indépendant créé pour
     simplifier la gestion administrative, notamment en remplaçant toutes les
@@ -2215,10 +2424,11 @@ auto entrepreneur . cotisations et contributions . cotisations:
   titre.fr: cotisations
 ? auto entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
 : description.en: >-
-    The total amount that is allocated to the supplementary pension, useful to estimate the total amount of the retirement pension for auto-entrepreneurs
+    The total amount that is allocated to the supplementary pension, useful to
+    estimate the total amount of the retirement pension for auto-entrepreneurs
   description.fr: >-
     Le montant total qui est alloué à la retraite complémentaire, utile pour
-    caluler la retraite des auto entrepreneurs
+    estimer le montant total de la pension de retraite des auto-entrepreneurs
   titre.en: supplementary pension
   titre.fr: retraite complémentaire
 ? auto entrepreneur . cotisations et contributions . cotisations . taux de cotisation
@@ -2244,14 +2454,15 @@ entreprise . ACCRE obtenu:
   titre.en: ACCRE obtained
   titre.fr: ACCRE obtenu
 auto entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-  titre.en: '!!taux ACRE'
+  titre.en: >
+    "ACRE" rate
   titre.fr: taux ACRE
 auto entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
-  titre.en: '!!réduction ACRE'
+  titre.en: >
+    "ACRE" reduction
   titre.fr: réduction ACRE
   description.en: >-
-    !!Ce taux peut dans certains cas réduire le montant des cotisations sociales
-    de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
+      In some cases, this rate may reduce the amount of social security contributions paid by the auto-entrepreneur to help him/her in his/her first year of activity.
   description.fr: >-
     Ce taux peut dans certains cas réduire le montant des cotisations sociales
     de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
@@ -2294,7 +2505,9 @@ protection sociale:
   titre.en: social welfare
   titre.fr: protection sociale
 protection sociale . retraite:
-  résumé.en: Guarantees on average 60 to 70% of the last income from employment after age 65.
+  résumé.en: >-
+    Guarantees on average 60 to 70% of the last income from employment after age
+    65.
   résumé.fr: Garantit en moyenne 60 à 70 % du dernier revenu d'activité après 65 ans.
   description.en: "All employees in France contribute throughout their working lives to benefit from a pension plan as soon as they are old enough to stop working their activity.\n\nThe pension system is currently based on the principle of the \"distribution\". This means that asset contributions finance retirement pensions.\n\n## Retirement in France in a few figures\n  - **2094 € / month**: Average standard of living for people over 65 (compared to the rest of the population, it is the highest in the OECD \U0001F947)\n  - **25 years**: the average number of years spent in retirement (the highest in the OECD)\n  - **75%**: the replacement rate as a percentage of net salary after full annuities\n\nPensions are the highest of social security contributions. It can be considered a deferred salary, since your contributions will provide you with income when you retire.\n"
   description.fr: "Tous les salariés en France cotisent tout au long de leur vie professionnelle pour bénéficier d’un régime de retraite dès lors qu’ils ont l’âge de cesser leur activité.\n\nLe système des retraites est actuellement fondé sur le principe de la « répartition ». Cela veut dire que les cotisations des actifs financent les pensions des retraités.\n\n## La retraite en France en quelques chiffres\n  - ** 2094 € / mois** :  Niveau de vie moyen des plus de 65 ans (en comparaison du reste de la population, c'est le plus élevé de l'OCDE \U0001F947)\n  - **25 ans** : le nombre d'années passées en moyenne à la retraite (le plus élevé de l'OCDE \U0001F947)\n  - **75 %** : le taux de remplacement en pourcentage du salaire net à taux plein\n\nLa retraite est la plus élevée des cotisations sociales. Elle peut être considérée comme un salaire différé, puisque vos cotisations vous assurerons un revenu futur.\n\nSimulez et gérez votre retraite sur [info-retraite.fr](https://www.info-retraite.fr/portail-info/home.html).\n"
@@ -2305,10 +2518,11 @@ protection sociale . retraite . base:
   titre.fr: pension de retraite de base
 protection sociale . retraite . base . taux de la pension:
   description.en: >-
-    The rate applied, with a discount or surcharge depending on the number of quarters contributed.
+    The rate applied, with a discount or surcharge depending on the number of
+    quarters contributed.
   description.fr: >-
-    Le taux appliqué, avec décote ou surcote en fonction du nombre de trimestre
-    cotisé.
+    Le taux appliqué, avec décote ou surcote en fonction du nombre de trimestres
+    cotisés.
   titre.en: rate of the pension
   titre.fr: taux de la pension
 protection sociale . retraite . trimestres validés par an:
@@ -2325,7 +2539,9 @@ protection sociale . retraite . trimestres validés par an . trimestres salarié
   titre.fr: barème trimestres générique
 ? protection sociale . retraite . trimestres validés par an . trimestres auto entrepreneur
 : description.en: >-
-    Minimum turnover thresholds for the validation of quarters for retirement as a self-employed entrepreneur. Below the minimum amount, you will only have access to the solidarity allowance.
+    Minimum turnover thresholds for the validation of quarters for retirement as
+    a self-employed entrepreneur. Below the minimum amount, you will only have
+    access to the solidarity allowance.
   description.fr: >-
     Les seuils de chiffre d'affaires minimum pour la validation des trimestres
     pour la retraite en auto entrepreneur. En-dessous du montant minimum, vous
@@ -2334,38 +2550,39 @@ protection sociale . retraite . trimestres validés par an . trimestres salarié
   titre.fr: trimestres auto entrepreneur
 protection sociale . revenu moyen:
   description.en: >-
-    The income used to calculate the amount of retirement pensions and daily social security allowances during a work stoppage.
+    The income used to calculate the amount of retirement pensions and daily
+    social security allowances during a work stoppage.
   description.fr: >-
     Le revenu utilisé pour le calcul du montant des pensions de retraite et des
     indemnités journalières de sécurité sociale lors d'un arrêt de travail.
-  titre.en: 'average income'
+  titre.en: average income
   titre.fr: revenu moyen
 protection sociale . retraite . mois cotisés:
-  titre.en: 'contributed months'
+  titre.en: contributed months
   titre.fr: mois cotisés
 protection sociale . retraite . complémentaire salarié:
-  titre.en: 'supplementary pension for employees'
+  titre.en: supplementary pension for employees
   titre.fr: complémentaire salarié
 protection sociale . retraite . complémentaire salarié . valeur du point:
-  titre.en: 'value of the point'
+  titre.en: value of the point
   titre.fr: valeur du point
 protection sociale . retraite . complémentaire salarié . points acquis:
-  titre.en: 'acquired points'
+  titre.en: acquired points
   titre.fr: points acquis
 protection sociale . retraite . complémentaire salarié . points acquis par mois:
-  titre.en: 'acquired points per month'
+  titre.en: acquired points per month
   titre.fr: points acquis par mois
 protection sociale . retraite . complémentaire salarié . prix d'achat du point:
-  titre.en: 'buying cost of the point'
+  titre.en: buying cost of the point
   titre.fr: prix d'achat du point
 protection sociale . retraite . complémentaire sécurité des indépendants:
-  titre.en: 'supplementary pension for self-employed'
+  titre.en: supplementary pension for self-employed
   titre.fr: complémentaire sécurité des indépendants
 ? protection sociale . retraite . complémentaire sécurité des indépendants . valeur du point
-: titre.en: 'value of the point'
+: titre.en: value of the point
   titre.fr: valeur du point
 ? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis
-: titre.en: 'acquired points'
+: titre.en: acquired points
   titre.fr: points acquis
 ? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis par mois
 : titre.en: acquired points per month
@@ -2375,8 +2592,7 @@ protection sociale . retraite . complémentaire sécurité des indépendants:
   titre.fr: prix d'achat du point
 protection sociale . santé:
   résumé.en: >-
-    !!Couvre la plupart des soins de santé de la vie quotidienne et 100 % des
-    maladies graves comme les séjours à l'hôpital.
+    Covers most everyday health care and 100% of serious illnesses such as hospital stays.
   résumé.fr: >-
     Couvre la plupart des soins de santé de la vie quotidienne et 100 % des
     maladies graves comme les séjours à l'hôpital.
@@ -2386,28 +2602,26 @@ protection sociale . santé:
   titre.fr: santé
 protection sociale . santé . indemnités journalières:
   description.en: >-
-    Daily allowances are paid to you by the Health Insurance to compensate for your income during a work stoppage. They are calculated on the basis of your gross income and paid every 14 days on average.
-  description.fr: >
+    Daily allowances are paid to you by the Health Insurance to compensate for
+    your income during a work stoppage. They are calculated on the basis of your
+    gross income and paid every 14 days on average.
+  description.fr: >-
     Les indemnités journalières vous sont versées par l'Assurance Maladie pour
-    compenser
-
-    votre revenu pendant un arrêt de travail. Elles sont calculées à partir de
-    votre revenu
-
-    brut et versées tous les 14 jours en moyenne.
-  titre.en: 'Daily allowances'
+    compenser votre revenu pendant un arrêt de travail. Elles sont calculées à
+    partir de votre revenu brut et versées tous les 14 jours en moyenne.
+  titre.en: Daily allowances
   titre.fr: indemnités journalières
 protection sociale . santé . indemnités journalières . auto entrepreneur:
-  titre.en: 'auto entrepreneur'
+  titre.en: auto entrepreneur
   titre.fr: auto entrepreneur
 protection sociale . santé . indemnités journalières . indépendant:
-  titre.en: 'self employed'
+  titre.en: self employed
   titre.fr: indépendant
 protection sociale . santé . indemnités journalières . salarié:
-  titre.en: 'employee'
+  titre.en: employee
   titre.fr: salarié
 protection sociale . assurance chômage:
-  résumé.en: 'Provides income for workers looking for a new job.'
+  résumé.en: Provides income for workers looking for a new job.
   résumé.fr: Assure un revenu aux travailleurs à la recherche d'un nouvel emploi.
   description.en: >
     Since 1958, the Unemployment Insurance has been protecting all private and
@@ -2454,7 +2668,8 @@ protection sociale . assurance chômage:
   titre.fr: assurance chômage
 protection sociale . famille:
   résumé.en: >
-    Provides services in support of families: childcare, housing assistance, etc.
+    Provides services in support of families: childcare, housing assistance,
+    etc.
   résumé.fr: >
     Assure des prestations en soutien aux familles : garde d'enfants, aide au
     logement...
@@ -2503,8 +2718,7 @@ protection sociale . accidents du travail et maladies professionnelles:
   titre.en: Work accidents / occupational diseases
   titre.fr: accidents du travail et maladies professionnelles
 protection sociale . formation:
-  résumé.en: >-
-    Gives employees the opportunity to take vocationnal training.
+  résumé.en: Gives employees the opportunity to take vocationnal training.
   résumé.fr: Donne aux employés la possibilité de suivre des formations professionnelles.
   description.en: >
     Vocational training enables each person, regardless of their status, to
@@ -2546,8 +2760,7 @@ protection sociale . autres:
   titre.en: other
   titre.fr: autres
 protection sociale . transport:
-  résumé.en: >-
-    Keeps the price of a public transit ticket low
+  résumé.en: Keeps the price of a public transit ticket low
   résumé.fr: Permet de maintenir le prix d'un billet de transport en commun à un bas prix
   description.en: >
     This contribution is paid in full to the [mobility

--- a/source/règles/sasu.yaml
+++ b/source/règles/sasu.yaml
@@ -58,6 +58,6 @@
   période: flexible
   formule: chiffre affaires * répartition salaire sur dividendes
 
-- nom: revenu net
+- nom: revenu net après impôt
   période: flexible
   formule: contrat salarié . salaire . net après impôt + dividendes . net

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -280,26 +280,27 @@ export let nextStepsSelector = createSelector(
 	[
 		currentMissingVariablesByTargetSelector,
 		state => state.simulation?.config.questions,
-		state => state.conversationSteps.foldedSteps,
-		state => state.simulation?.config['questions non prioritaires']
+		state => state.conversationSteps.foldedSteps
 	],
-	(mv, questions, foldedSteps, lessImportantQuestions = []) => {
+	(
+		mv,
+		{
+			'non prioritaires': notPriority = [],
+			uniquement: only,
+			'liste noire': blacklist = []
+		} = {},
+		foldedSteps = []
+	) => {
 		let nextSteps = difference(getNextSteps(mv), foldedSteps)
-		if (questions) {
-			nextSteps = intersection(nextSteps, [
-				...questions,
-				...lessImportantQuestions
-			])
+
+		if (only) nextSteps = intersection(nextSteps, [...only, ...notPriority])
+		if (blacklist) {
+			nextSteps = difference(nextSteps, blacklist)
 		}
+
 		nextSteps = sortBy(similarity(last(foldedSteps)), nextSteps)
-		if (lessImportantQuestions.length) {
-			nextSteps = sortBy(
-				question => lessImportantQuestions.indexOf(question),
-				nextSteps
-			)
-		}
-		if (questions && questions.blacklist) {
-			nextSteps = difference(nextSteps, questions.blacklist)
+		if (notPriority) {
+			nextSteps = sortBy(question => notPriority.indexOf(question), nextSteps)
 		}
 		return nextSteps
 	}

--- a/test/indépendants.test.js
+++ b/test/indépendants.test.js
@@ -3,7 +3,7 @@ import Syso from '../source/engine/index'
 
 describe('indeps', function() {
 	it('should compute income for indépendant', function() {
-		let values = Syso.evaluate(['revenu net'], {
+		let values = Syso.evaluate(['revenu net après impôt'], {
 			"entreprise . chiffre d'affaires": 70000,
 			'entreprise . charges': 1000,
 			indépendant: 'oui',

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -64,7 +64,7 @@ describe('library', function() {
 		)
 
 		let [revenuDisponible, dividendes] = Syso.evaluate(
-			['revenu net', 'dividendes . net'],
+			['revenu net après impôt', 'dividendes . net'],
 			{
 				'contrat salarié . salaire . net après impôt': salaireNetAprèsImpôt,
 				'chiffre affaires': CA


### PR DESCRIPTION
Comme demandé par la DSS, j'ai implementé une première version des exonérations lié au régime des impatriés : 
- Exonération de cotisation vieillesse et complémentaire
- Exonération d'impot à hauteur de 30% du revenu brut 
- Exonération de taxe sur les salaire à hauteur de 30% du revenu brut

Pour un très haut cadre d'une banque londonienne à 30 000€ brut mensuel, cela fait 5 906€ en moins en terme d'impots / cotisations, soit 30% de différence sur le net après impôts.