### PR TITLE
Stages et contrats d'apprentissage

### DIFF
--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -3,7 +3,7 @@ import { goToQuestion } from 'Actions/actions'
 import { T } from 'Components'
 import withLanguage from 'Components/utils/withLanguage'
 import { compose, contains, filter, reject, toPairs } from 'ramda'
-import React, { Fragment } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
 import {
@@ -18,6 +18,7 @@ type OwnProps = {
 type Props = OwnProps & {
 	goToQuestion: string => void,
 	location: Location,
+	currentQuestion: string,
 	nextSteps: Array<string>,
 	quickLinksToHide: Array<string>,
 	show: boolean
@@ -25,6 +26,7 @@ type Props = OwnProps & {
 
 const QuickLinks = ({
 	goToQuestion,
+	currentQuestion,
 	nextSteps,
 	quickLinks,
 	quickLinksToHide
@@ -41,18 +43,17 @@ const QuickLinks = ({
 	return (
 		!!links.length && (
 			<span>
-				<small>
-					<T k="quicklinks.autres">Autres questions :</T>
-				</small>
+				<small>Questions :</small>
 				{links.map(([label, dottedName]) => (
-					<Fragment key={dottedName}>
-						<button
-							className="ui__ link-button"
-							css="margin: 0 0.4rem !important"
-							onClick={() => goToQuestion(dottedName)}>
-							<T k={'quicklinks.' + label}>{label}</T>
-						</button>
-					</Fragment>
+					<button
+						key={dottedName}
+						className={`ui__ link-button ${
+							dottedName === currentQuestion ? 'active' : ''
+						}`}
+						css="margin: 0 0.4rem !important"
+						onClick={() => goToQuestion(dottedName)}>
+						<T k={'quicklinks.' + label}>{label}</T>
+					</button>
 				))}{' '}
 				{/* <button className="ui__ link-button">Voir la liste</button> */}
 			</span>
@@ -66,12 +67,10 @@ export default (compose(
 	connect(
 		(state, props) => ({
 			key: props.language,
+			currentQuestion: currentQuestionSelector(state),
 			nextSteps: nextStepsSelector(state),
 			quickLinks: state.simulation?.config.questions?.["à l'affiche"],
-			quickLinksToHide: [
-				...state.conversationSteps.foldedSteps,
-				currentQuestionSelector(state)
-			]
+			quickLinksToHide: state.conversationSteps.foldedSteps
 		}),
 		{
 			goToQuestion

--- a/source/components/QuickLinks.js
+++ b/source/components/QuickLinks.js
@@ -2,12 +2,14 @@
 import { goToQuestion } from 'Actions/actions'
 import { T } from 'Components'
 import withLanguage from 'Components/utils/withLanguage'
-import { compose, contains, reject, toPairs } from 'ramda'
+import { compose, contains, filter, reject, toPairs } from 'ramda'
 import React, { Fragment } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router'
-import { currentQuestionSelector } from 'Selectors/analyseSelectors'
-
+import {
+	currentQuestionSelector,
+	nextStepsSelector
+} from 'Selectors/analyseSelectors'
 import type { Location } from 'react-router'
 
 type OwnProps = {
@@ -16,16 +18,23 @@ type OwnProps = {
 type Props = OwnProps & {
 	goToQuestion: string => void,
 	location: Location,
+	nextSteps: Array<string>,
 	quickLinksToHide: Array<string>,
 	show: boolean
 }
 
-const QuickLinks = ({ goToQuestion, quickLinks, quickLinksToHide }: Props) => {
+const QuickLinks = ({
+	goToQuestion,
+	nextSteps,
+	quickLinks,
+	quickLinksToHide
+}: Props) => {
 	if (!quickLinks) {
 		return null
 	}
 	const links = compose(
 		toPairs,
+		filter(dottedName => contains(dottedName, nextSteps)),
 		reject(dottedName => contains(dottedName, quickLinksToHide))
 	)(quickLinks)
 
@@ -57,6 +66,7 @@ export default (compose(
 	connect(
 		(state, props) => ({
 			key: props.language,
+			nextSteps: nextStepsSelector(state),
 			quickLinks: state.simulation?.config.questions?.["à l'affiche"],
 			quickLinksToHide: [
 				...state.conversationSteps.foldedSteps,

--- a/source/components/RuleLink.js
+++ b/source/components/RuleLink.js
@@ -19,7 +19,8 @@ const RuleLink = ({
 	title,
 	colours: { colour },
 	style,
-	sitePaths
+	sitePaths,
+	children
 }: Props) => {
 	const newPath =
 		sitePaths.documentation.index + '/' + encodeRuleName(dottedName)
@@ -29,7 +30,7 @@ const RuleLink = ({
 			to={newPath}
 			className="rule-link"
 			style={{ color: colour, ...style }}>
-			{title || nameLeaf(dottedName)}
+			{children || title || nameLeaf(dottedName)}
 		</Link>
 	)
 }

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -67,7 +67,7 @@
 	text-decoration: none;
 }
 #targetSelection .optionTitle a:hover,
-#targetSelection #aidesGlimpse a:hover {
+#targetSelection .aidesGlimpse a:hover {
 	text-decoration: underline;
 }
 
@@ -91,6 +91,19 @@
 	font-size: 125%;
 	margin-left: 0.6rem;
 	text-align: right;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+}
+
+#targetSelection .aidesGlimpse {
+	font-size: 70%;
+	display: flex;
+}
+#targetSelection .aidesGlimpse a {
+	display: inline-block;
+	margin: -0.25rem 0;
+	text-decoration: none;
 }
 
 #targetSelection .editable:not(.attractClick) {

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -41,9 +41,7 @@ questions:
 situation:
   auto entrepreneur: non
   indépendant: non
-  contrat salarié: oui
   contrat salarié . assimilé salarié: oui
-  contrat salarié . CDD: non
   contrat salarié . temps partiel: non
   contrat salarié . ATMP . taux réduit: oui
   entreprise . association non lucrative: non

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -44,5 +44,4 @@ situation:
   contrat salarié . assimilé salarié: oui
   contrat salarié . temps partiel: non
   contrat salarié . ATMP . taux réduit: oui
-  entreprise . association non lucrative: non
   période: année

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -14,10 +14,8 @@ questions:
     Contrat: contrat salarié
     Cadre: contrat salarié . statut cadre . choix statut cadre
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
-    CDD: contrat salarié . CDD
     Impôt: impôt . méthode de calcul
     Temps partiel: contrat salarié . temps de travail . temps partiel
-    Stage: contrat salarié . stage
 
     Commune: établissement . localisation
     JEI: contrat salarié . statut JEI

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -11,6 +11,7 @@ objectifs secondaires:
 
 questions:
   à l'affiche:
+    Contrat: contrat salarié
     Cadre: contrat salarié . statut cadre . choix statut cadre
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
     CDD: contrat salarié . CDD
@@ -30,7 +31,6 @@ questions:
     - contrat salarié . complémentaire santé . part employeur
     - contrat salarié . régime des impatriés
 situation:
-  contrat salarié: oui
   contrat salarié . assimilé salarié: non
   indépendant: non
   auto entrepreneur: non

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -1,5 +1,6 @@
 objectifs:
   - contrat salarié . rémunération . total
+  - contrat salarié . aides employeur
   - contrat salarié . rémunération . brut de base . équivalent temps plein
   - contrat salarié . rémunération . brut de base
   - contrat salarié . rémunération . net
@@ -16,7 +17,6 @@ questions:
     Heures supplémentaires: contrat salarié . temps de travail . heures supplémentaires
     Impôt: impôt . méthode de calcul
     Temps partiel: contrat salarié . temps de travail . temps partiel
-
     Commune: établissement . localisation
     JEI: contrat salarié . statut JEI
     Avantages: contrat salarié . rémunération . avantages en nature

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -16,6 +16,7 @@ questions:
     CDD: contrat salarié . CDD
     Impôt: impôt . méthode de calcul
     Temps partiel: contrat salarié . temps de travail . temps partiel
+    Stage: contrat salarié . stage
 
     Commune: établissement . localisation
     JEI: contrat salarié . statut JEI

--- a/source/components/ui/Button/button.css
+++ b/source/components/ui/Button/button.css
@@ -140,6 +140,9 @@
 	color: rgb(41, 117, 209);
 	color: var(--colour);
 }
+.ui__.link-button.active {
+	font-weight: bold;
+}
 
 .ui__.dashed-button::before {
 	padding: 0.8rem 0;

--- a/source/engine/parseReference.js
+++ b/source/engine/parseReference.js
@@ -39,6 +39,7 @@ export let parseReference = (rules, rule, parsedRules, filter) => ({
 			variableHasCond =
 				variable['applicable si'] != null ||
 				variable['non applicable si'] != null ||
+				variable.isDisabledBy.length > 1 ||
 				findParentDependency(parsedRules, variable),
 			situationValue = getSituationValue(situation, dottedName, variable),
 			needsEvaluation =

--- a/source/engine/parseReference.js
+++ b/source/engine/parseReference.js
@@ -1,10 +1,9 @@
 // Reference to a variable
 import parseRule from 'Engine/parseRule'
 import React from 'react'
-import { Trans } from 'react-i18next'
-import { evaluateNode, makeJsx, rewriteNode } from './evaluation'
+import { evaluateNode, rewriteNode } from './evaluation'
 import { getSituationValue } from './getSituationValue'
-import { Leaf, Node } from './mecanismViews/common'
+import { Leaf } from './mecanismViews/common'
 import {
 	disambiguateRuleReference,
 	findParentDependency,

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -234,8 +234,9 @@ export let findParentDependency = (rules, rule) => {
 		reject(isNil),
 		find(
 			//Find the first "calculable" parent
-			({ question, unit, formule }) =>
+			({ question, unit, formule, name }) =>
 				(question && !unit && !formule) ||
+				(question && formule?.['une possibilité'] !== undefined) ||
 				(typeof formule === 'string' && formule.includes(' = ')) //implicitly, the format is boolean
 		)
 	)(parentDependencies)

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -234,7 +234,9 @@ export let findParentDependency = (rules, rule) => {
 		reject(isNil),
 		find(
 			//Find the first "calculable" parent
-			({ question, unit, formule }) => question && !unit && !formule //implicitly, the format is boolean
+			({ question, unit, formule }) =>
+				(question && !unit && !formule) ||
+				(typeof formule === 'string' && formule.includes(' = ')) //implicitly, the format is boolean
 		)
 	)(parentDependencies)
 }

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -124,7 +124,6 @@ quicklinks:
   Temps partiel: Part time
   Type d'activité: Activity type
   Charges: Expenses
-  autres: 'Other questions:'
   Impôt: Tax
 Mes réponses: My answers
 Prochaines questions: Next questions

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -765,6 +765,7 @@
       possibilités:
         - niveau bac ou moins
         - niveau supérieur au bac
+  par défaut: niveau supérieur au bac
 
 - espace: contrat salarié . apprentissage . diplôme préparé
   nom: niveau bac ou moins

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -756,6 +756,61 @@
     - statut JEI
     - régime des impatriés
 
+- espace: contrat salarié . apprentissage
+  nom: diplôme préparé
+  question: Quel type de diplôme l'apprenti prépare-t-il ?
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - niveau bac ou moins
+        - niveau supérieur au bac
+
+- espace: contrat salarié . apprentissage . diplôme préparé
+  nom: niveau bac ou moins
+  titre: Diplôme d'un niveau inférieur ou égal au bac
+  formule: diplôme préparé = 'niveau bac ou moins'
+  description: Concerne les diplôme de niveau V (CAP, BEP, CTM...) et de niveau IV (Bac Pro, BP, BTM)
+
+- espace: contrat salarié . apprentissage . diplôme préparé
+  nom: niveau supérieur au bac
+  titre: Diplôme d'un niveau supérieur au bac
+  formule: diplôme préparé = 'niveau supérieur au bac'
+  description: Concerne les diplôme de niveau I (Master, Ingénieur, Grandes écoles...), de niveau II (License, BMS...), et de niveau III (BTS, SUT, BM, ...)
+
+- espace: contrat salarié . apprentissage
+  nom: ancienneté
+  question: Depuis combien de temps l'apprenti est-il employé ?
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - moins d'un an
+        - moins de deux ans
+        - moins de trois ans
+        - moins de quatre ans
+  par défaut: moins d'un an
+  contrôles:
+    - si: moins de quatre ans
+      niveau: information
+      message: La durée maximale du contrat peut être portée à 4 ans lorsque la qualité de travailleur handicapé est reconnue à l'apprenti.
+
+- espace: contrat salarié . apprentissage . ancienneté
+  nom: moins d'un an
+  formule: ancienneté = 'moins d'un an'
+
+- espace: contrat salarié . apprentissage . ancienneté
+  nom: moins de deux ans
+  formule: ancienneté = 'moins de deux ans'
+
+- espace: contrat salarié . apprentissage . ancienneté
+  nom: moins de trois ans
+  formule: ancienneté = 'moins de trois ans'
+
+- espace: contrat salarié . apprentissage . ancienneté
+  nom: moins de quatre ans
+  formule: ancienneté = 'moins de quatre ans'
+
 - espace: contrat salarié
   nom: stage
   description: |
@@ -1176,7 +1231,7 @@
 - espace: contrat salarié
   nom: SMIC temps plein
   période: mois
-  formule: 
+  formule:
     multiplication:
       assiette: temps de travail . base légale * période . semaines par mois
       facteur: SMIC horaire
@@ -1812,9 +1867,34 @@
   description: |
     Ces aides sont appelées différées, car elles ne consistent pas en une simple réduction des cotisations mensuelles : elles interviendront a posteriori par exemple sous forme de crédit d'impôt.
 
-    Le simulateur n'intègre pas les innombrables aides disponibles en France. Découvrez-les sur le [portail officiel](http://www.aides-entreprises.fr).
-  formule: 0
+    Le simulateur n'intègre pas toutes les innombrables aides disponibles en France. Découvrez-les sur le [portail officiel](http://www.aides-entreprises.fr).
+  formule:
+    somme:
+      - aide à l'embauche d'apprentis
   note:
+
+- espace: contrat salarié . aides employeur
+  nom: aide à l'embauche d'apprentis
+  description: |
+    Depuis 2019 une aide à l'embauche unique remplace quatre précédents dispositifs. Le montant de l'aide dépend de l'ancienneté du contrat.
+
+    Une fois les démarches d'enregistrement effectuées, l'aide est versée automatiquement tous les mois.
+  applicable si:
+    toutes ces conditions:
+      - entreprise . effectif < 250
+      - apprentissage
+      - contrat salarié . apprentissage . diplôme préparé . niveau bac ou moins
+  période: année
+  unité: €
+  formule:
+    variations:
+      - si: apprentissage . ancienneté = 'moins d'un an'
+        alors: 4125
+      - si: apprentissage . ancienneté = 'moins de deux ans'
+        alors: 2000
+      - sinon: 1200
+  références:
+    Fiche service-public.fr: https://www.service-public.fr/professionnels-entreprises/vosdroits/F23556
 
 - espace: contrat salarié
   nom: salaire
@@ -3173,15 +3253,15 @@
   formule:
     somme:
       - variations:
-        - si: méthode de calcul . barème standard
-          alors: impôt sur le revenu à payer
-        - si: méthode de calcul . taux neutre
-          alors: impôt sur le revenu au taux neutre
-        - si: méthode de calcul . taux personnalisé
-          alors:
-            multiplication:
-              assiette: revenu imposable
-              taux: taux personnalisé
+          - si: méthode de calcul . barème standard
+            alors: impôt sur le revenu à payer
+          - si: méthode de calcul . taux neutre
+            alors: impôt sur le revenu au taux neutre
+          - si: méthode de calcul . taux personnalisé
+            alors:
+              multiplication:
+                assiette: revenu imposable
+                taux: taux personnalisé
       - CEHR
       - auto entrepreneur . impôt . versement libératoire . montant
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1885,6 +1885,10 @@
       - entreprise . effectif < 250
       - apprentissage
       - contrat salarié . apprentissage . diplôme préparé . niveau bac ou moins
+      
+      # HACK: "apprentissage . ancienneté" n'est pas détecté par le moteur dans les dépendances ("missingVariables") de cette aide.
+      # On l'ajoute ici uniquement pour faire remonter la question au bon niveau, mais ça ne devrait pas être nécessaire.
+      - apprentissage . ancienneté
   période: année
   unité: €
   formule:

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -25,6 +25,7 @@
       possibilités:
         - CDI
         - CDD
+        - apprentissage
         - stage
   par défaut: CDI
   description: |
@@ -741,6 +742,15 @@
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
 
 - espace: contrat salarié
+  nom: apprentissage
+  description: |
+    Le contrat d'apprentissage est un contrat de travail écrit à durée limitée (CDD) ou à durée indéterminée (CDI) entre un salarié et un employeur. Il permet à l'apprenti de suivre une formation en alternance en entreprise sous la responsabilité d'un maître d'apprentissage et en centre de formation des apprentis (CFA) pendant 1 à 3 ans.
+  formule: contrat salarié = 'apprentissage'
+  rend non applicable:
+    - CSG
+    - CRDS
+
+- espace: contrat salarié
   nom: stage
   description: |
     Un employeur qui accueille un stagiaire doit lui verser une gratification minimale. Celle-ci est en partie exonérée de cotisations sociales.
@@ -763,13 +773,16 @@
   références:
     Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
 
-- espace: contrat salarié . stage
-  nom: gratification exonérée d'impôt
+- espace: contrat salarié
+  nom: exonération d'impôt des stagiaires et apprentis
   description: |
     Les salaires versés aux apprentis ainsi que les gratifications de stages sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
   références:
     Article 81 bis du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029236245&cidTexte=LEGITEXT000006069577
-  applicable si: stage
+  applicable si:
+    une de ces conditions:
+      - apprentissage
+      - stage
   période: flexible
   formule: SMIC
 
@@ -803,6 +816,23 @@
       assiette: rémunération . brut
       abattement: indemnité kilométrique vélo + stage . gratification minimale
 
+- espace: contrat salarié . cotisations . assiette
+  nom: salariale
+  titre: Assiette des cotisations sociales
+  description: |
+    Les apprentis bénéficient d'une exonération de cotisations sociales jusqu'à 79% du SMIC.
+  références:
+    URSSAF: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-a-la/le-contrat-dapprentissage/exonerations.html
+  période: flexible
+  formule:
+    variations:
+      - si: apprentissage
+        alors:
+          allègement:
+            assiette: cotisations . assiette
+            abattement: 79% * SMIC
+      - sinon: cotisations . assiette
+
 - espace: contrat salarié . rémunération
   nom: brut de base
   titre: Salaire brut
@@ -824,6 +854,7 @@
           - rémunération . assiette de vérification du SMIC [mensuel] < SMIC [mensuel]
           - assimilé salarié != oui
           - stage != oui
+          - apprentissage != oui
       niveau: avertissement
       message: |
         Le salaire saisi est inférieur au SMIC.
@@ -1231,7 +1262,7 @@
         somme:
           - indemnité kilométrique vélo
           - prime d'impatriation
-          - stage . gratification exonérée d'impôt
+          - exonération d'impôt des stagiaires et apprentis
           - heures supplémentaires défiscalisées
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
@@ -2184,6 +2215,7 @@
 
         - attributs:
             dû par: salarié
+          assiette: cotisations . assiette . salariale
           tranches:
             - en-dessous de: 1
               taux: 0.86%
@@ -2245,6 +2277,7 @@
 
         - attributs:
             dû par: salarié
+          assiette: cotisations . assiette . salariale
           tranches:
             - en-dessous de: 1
               taux: 3.15%
@@ -3012,6 +3045,7 @@
       composantes:
         - attributs:
             dû par: salarié
+          assiette: cotisations . assiette . salariale
           composantes:
             - nom: non plafonnée
               taux: 0.4%
@@ -3137,7 +3171,7 @@
 - espace: impôt . méthode de calcul
   nom: barème standard
   titre: avec le barème standard
-  description: Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal se base pour calculer votre taux d'imposition. Pour l'instant, ne prend en compte que l'abattement 10%, le barème et la décôte.
+  description: Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal se base pour calculer votre taux d'imposition. Pour l'instant, ne prend en compte que l'abattement 10%, le barème et la décote.
   formule: impôt . méthode de calcul = 'barème standard'
 
 - espace: impôt

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -749,12 +749,13 @@
 
 - espace: contrat salarié
   nom: gratification exonerée d'impôt
+  description: |
+    Les salaires versés aux apprentis ainsi que les gratifications de stages sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
+  références:
+    Article 81 bis du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029236245&cidTexte=LEGITEXT000006069577
   applicable si: stage
   période: flexible
-  formule:
-    le minimum de:
-      - contrat salarié . rémunération . net imposable . base
-      - SMIC
+  formule: SMIC
 
 - espace: contrat salarié
   nom: CDD
@@ -781,7 +782,10 @@
     L'assiette des cotisations sociales est la base de calcul d'un grand nombre de cotisations sur le travail salarié. Elle comprend notamment les rémunérations en espèces (salaire de base, indemnité, primes...) et les avantages en nature (logement, véhicule...).
   référence: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul.html
   période: flexible
-  formule: rémunération . brut - indemnité kilométrique vélo - stage . gratification minimale
+  formule:
+    allègement:
+      assiette: rémunération . brut
+      abattement: indemnité kilométrique vélo + stage . gratification minimale
 
 - espace: contrat salarié . rémunération
   nom: brut de base

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1940,6 +1940,16 @@
       API: localisation
       chemin: departement . nom
 
+- espace: établissement . localisation
+  nom: outre-mer
+  applicable si:
+    une de ces conditions:
+      - établissement . localisation . département = 'Guadeloupe'
+      - établissement . localisation . département = 'Martinique'
+      - établissement . localisation . département = 'Guyane'
+      - établissement . localisation . département = 'La Réunion'
+      - établissement . localisation . département = 'Mayotte'
+
 - espace: contrat salarié
   nom: temps de travail
   unité: heures
@@ -2674,17 +2684,27 @@
   nom: formation professionnelle
   cotisation:
     dû par: employeur
-    collecteur: OPCA
+    collecteur: OPCO
     branche: formation
     # TODO majoration pour les entreprises de travail temporaire
     #
-  description: Cette contribution obligatoire est à verser à l'OPCA désigné par la branche conventionnelle de l'entreprise, ou à défaut à un OPCA interprofessionnel.
+  description: Cette contribution obligatoire est collectée par l'OPCO (opérateurs de compétences) désigné par la branche conventionnelle de l'entreprise, ou à défaut à un OPCO interprofessionnel.
   note: |
     Une part supplémentaire peut-être obligatoire en fonction des accords collectifs d'une entreprise.
 
     > Par exemple pour la convention collective Syntec, un supplément de 0.025% est obligatoire.
 
+    Le taux est porté à 1,3 % pour les entreprises de travail temporaire. Par ailleurs en cas de franchissement du seuil d'effectifs de 10 salariés, des taux spécifiques s'appliquent afin de limiter la hausse de la contribution à la formation professionnelle :
+
+    - taux de **0,55 %** pour le franchissement en année **N, N+1 et N+2**
+    - taux de **0,70 %** pour le franchissement en année **N+3**  (1,3 % pour les entreprises de travail temporaire)
+    - taux de **0,90 %** pour le franchissement en année **N+4** (1,3 % pour les entreprises de travail temporaire)
+    - taux de **1 %** pour le franchissement en année **N+5** (1,3 % pour les entreprises de travail temporaire)
   période: flexible
+  non applicable si:
+    toutes ces conditions:
+      - entreprise . effectif < 11
+      - apprentissage
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2696,6 +2716,8 @@
             taux: 1%
   références:
     fiche Ministère du travail: https://travail-emploi.gouv.fr/formation-professionnelle/entreprises-et-formation/article/participation-financiere-des-entreprises-au-developpement-de-la-formation
+    Bercy infos: https://www.economie.gouv.fr/entreprises/contribution-formation-professionnelle
+    Taux réduit: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000037387044&cidTexte=LEGITEXT000006072050&dateTexte=20190101
 
 - espace: contrat salarié
   nom: maladie
@@ -2818,11 +2840,14 @@
 - espace: contrat salarié
   nom: taxe d'apprentissage
   cotisation:
-    destinataire: Organisme Collecteur de Taxe d'Apprentissage (OCTA)
+    destinataire: Opérateurs de compétences (OPCO)
     branche: formation
     dû par: employeur
   description: La taxe d'apprentissage permet de financer par les entreprises les dépenses de l'apprentissage et des formations technologiques et professionnelles
-
+  non applicable si:
+    toutes ces conditions:
+      - entreprise . effectif < 11
+      - apprentissage
   références:
     description: https://www.service-public.fr/professionnels-entreprises/vosdroits/F22574
     csa: http://www.opcalia.com/employeurs/financer-la-formation-et-lapprentissage/taxe-dapprentissage/contribution-supplementaire-a-lapprentissage-csa/
@@ -2831,23 +2856,42 @@
   période: flexible
   formule:
     somme:
-      - taxe d'apprentissage de base
-      - contribution supplémentaire à l'apprentissage
+      - base
+      - contribution supplémentaire
 
-- espace: contrat salarié
-  nom: taxe d'apprentissage de base
+- espace: contrat salarié . taxe d'apprentissage
+  nom: assiette
+  titre: assiette de la taxe d'apprentissage
+  période: flexible
+  description: Le salaire des apprentis est partiellement exonéré dans la base de calcul de la taxe d'apprentissage.
+  formule:
+    variations:
+      - si: apprentissage
+        alors:
+          allègement:
+            assiette: cotisations . assiette
+            abattement:
+              variations:
+                - si: établissement . localisation . outre-mer
+                  alors: 20% * SMIC
+                - sinon: 11% * SMIC
+      - sinon: cotisations . assiette
+
+- espace: contrat salarié . taxe d'apprentissage
+  nom: base
+  titre: taxe d'apprentissage de base
   période: flexible
   formule:
     multiplication:
-      assiette: cotisations . assiette
+      assiette: assiette
       taux:
         variations:
           - si: régime alsace moselle
             alors: 0.44%
           - sinon: 0.68%
 
-- espace: contrat salarié
-  nom: contribution supplémentaire à l'apprentissage
+- espace: contrat salarié . taxe d'apprentissage
+  nom: contribution supplémentaire
 
   applicable si:
     toutes ces conditions:
@@ -2857,7 +2901,7 @@
   période: flexible
   formule:
     multiplication:
-      assiette: cotisations . assiette
+      assiette: assiette
 
       # exception:
       #   si: régime géographique = Alsace-Moselle

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -19,7 +19,6 @@
 - nom: contrat salarié
   icônes: 📄
   question: De quel type de contrat s'agit-il ?
-  non applicable si: assimilé salarié
   formule:
     une possibilité:
       choix obligatoire: oui
@@ -41,10 +40,15 @@
       message: |
         Rappelez-vous qu'un CDD doit toujours correspondre à un besoin temporaire de l'entreprise.
         [Code du travail - Article L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
+    - si: stage
+      niveau: avertissement
+      message: |
+        Une convention de stage **n'est pas un contrat de travail**, et ne peut pas être conclue pour réaliser une tâche régulière correspondant à un poste de travail permanent, ou à un accroissement temporaire de l'activité de l'entreprise. [Code de l'éducation - Article L124-7](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029234119&cidTexte=LEGITEXT000006071191)
+
+        Par ailleurs, une entreprise de moins de 20 salariés ne peut pas accueillir plus de **3&nbsp;stagiaires**, et pas plus de **15% de l’effectif** pour les entreprises de plus de 20 salariés.
 
 - espace: contrat salarié
   nom: CDI
-  question: test
   formule: contrat salarié = 'CDI'
 
 - espace: contrat salarié
@@ -724,11 +728,14 @@
   question: Le salarié est-il considéré comme "assimilé salarié" ?
   par défaut: non
   rend non applicable:
+    - contrat salarié
     - chômage
     - réduction générale
     - AGS
     - APEC
     - contribution au dialogue social
+    - temps de travail . temps partiel
+    - temps de travail . heures supplémentaires
     - statut JEI
   références:
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
@@ -738,17 +745,26 @@
   description: |
     Un employeur qui accueille un stagiaire doit lui verser une gratification minimale. Celle-ci est en partie exonérée de cotisations sociales.
   formule: contrat salarié = 'stage'
-  références:
-    Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
+  rend non applicable:
+    - statut JEI
+    - réduction générale
+    - contribution d'équilibre général
+    - retraite complémentaire
+    - chômage
+    - complémentaire santé
+    - contribution au dialogue social
+    - temps de travail . temps partiel
 
 - espace: contrat salarié . stage
   nom: gratification minimale
   applicable si: stage
   période: flexible
   formule: 15% * plafond sécurité sociale temps plein
+  références:
+    Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
 
-- espace: contrat salarié
-  nom: gratification exonerée d'impôt
+- espace: contrat salarié . stage
+  nom: gratification exonérée d'impôt
   description: |
     Les salaires versés aux apprentis ainsi que les gratifications de stages sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
   références:
@@ -1215,7 +1231,7 @@
         somme:
           - indemnité kilométrique vélo
           - prime d'impatriation
-          - gratification exonerée d'impôt
+          - stage . gratification exonérée d'impôt
           - heures supplémentaires défiscalisées
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
@@ -1919,7 +1935,6 @@
 
 - espace: contrat salarié . temps de travail
   nom: temps partiel
-  non applicable si: assimilé salarié
   période: aucune
   question: Le contrat est-il à temps partiel ?
   description: |
@@ -1958,7 +1973,6 @@
   question: Combien d'heures supplémentaires (non récupérées en repos) sont effectuées par mois ?
   par défaut: 0
   unité: heures
-  non applicable si: assimilé salarié
   période: mois
   suggestions:
     aucune: 0
@@ -2044,7 +2058,6 @@
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-au-s/jeunes-entreprises-innovantes/quelle-exoneration.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
-  non applicable si: stage
   période: mois
   formule:
     # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
@@ -2070,7 +2083,6 @@
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
   applicable si: cotisations . assiette <= plafond de l'assiette
-  non applicable si: stage
   période: flexible
   formule:
     le minimum de:
@@ -2154,7 +2166,6 @@
     type de retraite: complémentaire
     destinataire: AGIRC-ARRCO
   période: flexible
-  non applicable si: stage
   formule:
     barème:
       assiette: cotisations . assiette
@@ -2209,7 +2220,6 @@
 
 - espace: contrat salarié
   nom: retraite complémentaire
-  non applicable si: stage
   cotisation:
     branche: retraite
     type de retraite: complémentaire
@@ -2329,7 +2339,6 @@
     calcul: http://www.pole-emploi.fr/employeur/taux-des-contributions-de-l-assurance-chomage-et-cotisations-ags-@/article.jspz?id=61567
     urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/lassurance-chomage-et-lags/les-taux.html
     changements 2017: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/contributions-patronales-dassura.html
-  non applicable si: stage
   période: flexible
   formule:
     multiplication:
@@ -2370,7 +2379,6 @@
   références:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F20739
   période: flexible
-  non applicable si: stage
   formule:
     multiplication:
       assiette: forfait
@@ -2487,7 +2495,6 @@
     - https://www.service-public.fr/professionnels-entreprises/vosdroits/F33308
 
   période: flexible
-  non applicable si: stage
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -3666,6 +3673,8 @@
 - nom: indépendant
   par défaut: non
   question: Activité à la sécurité sociale des indépendants ?
+  rend non applicable:
+    - contrat salarié
 
 - espace: indépendant . cotisations et contributions
   nom: cotisations à payer
@@ -3716,6 +3725,9 @@
           - entreprise . date de création = 'avant 2018'
           - entreprise . catégorie d'activité = 'libérale'
 
+  rend non applicable:
+    - protection sociale . retraite
+    - indépendant . cotisations et contributions . cotisations
   période: aucune
 
 - espace: indépendant . cotisations et contributions . cotisations
@@ -3761,7 +3773,6 @@
   titre: Maladie 2
   description: Cotisations pour les indemnités journalières des indépendants. Si l'état de santé des artisans, commerçants, industriels et conjoints collaborateurs nécessite un arrêt de travail, une part de leur ancien revenu leur sera versé.
   période: flexible
-  non applicable si: entreprise . rattachement libéral règlementé
   formule:
     multiplication:
       assiette: maladie . assiette
@@ -4018,6 +4029,8 @@
   question: L'activité est-elle exercée en auto-entreprise ?
   description: |
     L'auto-entreprise est une entreprise individuelle simplifiée. À l'origine connu sous l'appellation « auto-entrepreneur », le régime de « micro-entrepreneur » est un régime de travailleur indépendant créé pour simplifier la gestion administrative, notamment en remplaçant toutes les cotisations sociales par un prélèvement unique mensuel.
+  rend non applicable:
+    - contrat salarié
 
 - espace: auto entrepreneur
   nom: base des cotisations
@@ -4388,7 +4401,6 @@
     CNAV: https://www.lassuranceretraite.fr
     OCDE: https://read.oecd-ilibrary.org/social-issues-migration-health/pensions-at-a-glance-2017_pension_glance-2017-en#page135
     INSEE: https://www.insee.fr/fr/statistiques/fichier/3549496/REVPMEN18_F1.21_niv-pauv-pers-agees.pdf
-  non applicable si: entreprise . rattachement libéral règlementé
 
   unité: €
   période: flexible

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -18,14 +18,34 @@
 
 - nom: contrat salarié
   icônes: 📄
-  question: Activité salariée ?
-  par défaut: oui
+  question: De quel type de contrat s'agit-il ?
+  non applicable si: assimilé salarié
+  formule:
+    une possibilité:
+      choix obligatoire: oui
+      possibilités:
+        - CDI
+        - CDD
+        - stage
+  par défaut: CDI
   description: |
     Le contrat qui lie une entreprise (via son établissement) à un individu, qui est alors son salarié.
 
     Le contrat n'est en fait pas nécessaire dans le droit français, il est possible d'employer quelqu'un sans contrat par exemple dans les cas suivants:
     - Particuliers employeurs : Plus de 8 heures par semaine ou de plus de 4 semaines consécutives dans l'année.
     - CDI : La signature d’un contrat de travail n’est pas obligatoire dans certains cas. C’est le cas du Contrat de travail à Durée Indéterminée, considéré comme la forme normale et générale de la relation de travail entre un salarié et un employeur (Art. L1221-2 du Code du travail).
+
+  contrôles:
+    - si: CDD
+      niveau: information
+      message: |
+        Rappelez-vous qu'un CDD doit toujours correspondre à un besoin temporaire de l'entreprise.
+        [Code du travail - Article L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
+
+- espace: contrat salarié
+  nom: CDI
+  question: test
+  formule: contrat salarié = 'CDI'
 
 - espace: contrat salarié
   nom: indemnité kilométrique vélo
@@ -717,9 +737,7 @@
   nom: stage
   description: |
     Un employeur qui accueille un stagiaire doit lui verser une gratification minimale. Celle-ci est en partie exonérée de cotisations sociales.
-  question: S'agit t'il d'un stage étudiant ?
-  non applicable si: assimilé salarié
-  par défaut: non
+  formule: contrat salarié = 'stage'
   références:
     Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
 
@@ -740,12 +758,11 @@
 
 - espace: contrat salarié
   nom: CDD
-  question: Est-ce un contrat à durée déterminée (CDD) ?
+  formule: contrat salarié = 'CDD'
   description: |
     Par défaut, faire travailler quelqu'un en France établit automatiquement un CDI à temps plein.
     Certaines situations exceptionnelles permettent aux employeurs de prévoir une date de fin. Le contrat, qui est alors nécessaire, mentionne cette date de fin.
 
-  par défaut: non
   # TODO: règle de type : il faut qu'un motif et une durée soient sélectionnés pour qu'un contrat soit un CDD. Cela revient à dire que les variables CDD et motif sont obligatoires *dans le contexte* de leur attache
   #   implique:
   #     - emploi temporaire
@@ -757,13 +774,6 @@
   #   références:
   #     Code du travail - Article L1242-1
   #
-  contrôles:
-    - si: CDD
-      niveau: information
-      message: |
-        Rappelez-vous qu'un CDD doit toujours correspondre à un besoin temporaire de l'entreprise.
-        [Code du travail - Article L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
-
 - espace: contrat salarié . cotisations
   nom: assiette
   titre: Assiette des cotisations sociales

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -732,6 +732,7 @@
     - contrat salarié
     - chômage
     - réduction générale
+    - allocations familiales . taux réduit
     - AGS
     - APEC
     - contribution au dialogue social
@@ -764,6 +765,7 @@
     - statut cadre
     - statut JEI
     - réduction générale
+    - allocations familiales . taux réduit
     - contribution d'équilibre général
     - retraite complémentaire
     - chômage
@@ -2081,7 +2083,8 @@
     Le statut de jeune entreprise innovante (JEI) a été créé par la loi de finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au moins de leurs charges à de la Recherche et Développement de bénéficier de certaines exonérations.
   par défaut: non
   rend non applicable:
-    - contrat salarié . réduction générale
+    - réduction générale
+    - allocations familiales . taux réduit
 
 - espace: contrat salarié . statut JEI
   nom: exonération de cotisations
@@ -2325,17 +2328,18 @@
       assiette: cotisations . assiette
       taux:
         variations:
-          - si:
-              toutes ces conditions:
-                - cotisations . assiette < plafond de réduction
-                - statut JEI != oui
-                - assimilé salarié != oui
+          - si: taux réduit
             alors: 3.45%
           - sinon: 5.25%
   références:
     calcul: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/la-cotisation-dallocations-famil.html
 
 - espace: contrat salarié . allocations familiales
+  nom: taux réduit
+  période: flexible
+  formule: cotisations . assiette < plafond de réduction
+
+- espace: contrat salarié . allocations familiales . taux réduit
   nom: plafond de réduction
   titre: Plafond de la réduction des allocations familiales
   période: flexible

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -714,6 +714,31 @@
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
 
 - espace: contrat salarié
+  nom: stage
+  description: |
+    Un employeur qui accueille un stagiaire doit lui verser une gratification minimale. Celle-ci est en partie exonérée de cotisations sociales.
+  question: S'agit t'il d'un stage étudiant ?
+  non applicable si: assimilé salarié
+  par défaut: non
+  références:
+    Gratification minimale: https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131
+
+- espace: contrat salarié . stage
+  nom: gratification minimale
+  applicable si: stage
+  période: flexible
+  formule: 15% * plafond sécurité sociale temps plein
+
+- espace: contrat salarié
+  nom: gratification exonerée d'impôt
+  applicable si: stage
+  période: flexible
+  formule:
+    le minimum de:
+      - contrat salarié . rémunération . net imposable . base
+      - SMIC
+
+- espace: contrat salarié
   nom: CDD
   question: Est-ce un contrat à durée déterminée (CDD) ?
   description: |
@@ -746,7 +771,7 @@
     L'assiette des cotisations sociales est la base de calcul d'un grand nombre de cotisations sur le travail salarié. Elle comprend notamment les rémunérations en espèces (salaire de base, indemnité, primes...) et les avantages en nature (logement, véhicule...).
   référence: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/la-base-de-calcul.html
   période: flexible
-  formule: rémunération . brut - indemnité kilométrique vélo
+  formule: rémunération . brut - indemnité kilométrique vélo - stage . gratification minimale
 
 - espace: contrat salarié . rémunération
   nom: brut de base
@@ -768,9 +793,18 @@
         toutes ces conditions:
           - rémunération . assiette de vérification du SMIC [mensuel] < SMIC [mensuel]
           - assimilé salarié != oui
+          - stage != oui
       niveau: avertissement
       message: |
         Le salaire saisi est inférieur au SMIC.
+
+    - si:
+        toutes ces conditions:
+          - stage
+          - brut de base [mensuel] < stage . gratification minimale [mensuel]
+      niveau: avertissement
+      message: |
+        La rémunération du stage est inférieure à la [gratification minimale](https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131).
 
     - si:
         toutes ces conditions:
@@ -1167,6 +1201,7 @@
         somme:
           - indemnité kilométrique vélo
           - prime d'impatriation
+          - gratification exonerée d'impôt
           - heures supplémentaires défiscalisées
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
@@ -1995,6 +2030,7 @@
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-au-s/jeunes-entreprises-innovantes/quelle-exoneration.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
+  non applicable si: stage
   période: mois
   formule:
     # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
@@ -2020,6 +2056,7 @@
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
   applicable si: cotisations . assiette <= plafond de l'assiette
+  non applicable si: stage
   période: flexible
   formule:
     le minimum de:
@@ -2103,6 +2140,7 @@
     type de retraite: complémentaire
     destinataire: AGIRC-ARRCO
   période: flexible
+  non applicable si: stage
   formule:
     barème:
       assiette: cotisations . assiette
@@ -2157,13 +2195,13 @@
 
 - espace: contrat salarié
   nom: retraite complémentaire
+  non applicable si: stage
   cotisation:
     branche: retraite
     type de retraite: complémentaire
     destinataire: AGIRC-ARRCO
   description: |
     Cotisation de retraite complémentaire. Remplace les cotisations AGIRC et ARRCO qui étaient avant 2019 séparées.
-
   période: flexible
   formule:
     barème:
@@ -2277,7 +2315,7 @@
     calcul: http://www.pole-emploi.fr/employeur/taux-des-contributions-de-l-assurance-chomage-et-cotisations-ags-@/article.jspz?id=61567
     urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/lassurance-chomage-et-lags/les-taux.html
     changements 2017: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/contributions-patronales-dassura.html
-
+  non applicable si: stage
   période: flexible
   formule:
     multiplication:
@@ -2318,6 +2356,7 @@
   références:
     service-public.fr: https://www.service-public.fr/particuliers/vosdroits/F20739
   période: flexible
+  non applicable si: stage
   formule:
     multiplication:
       assiette: forfait
@@ -2434,6 +2473,7 @@
     - https://www.service-public.fr/professionnels-entreprises/vosdroits/F33308
 
   période: flexible
+  non applicable si: stage
   formule:
     multiplication:
       assiette: cotisations . assiette

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -738,6 +738,8 @@
     - temps de travail . temps partiel
     - temps de travail . heures supplémentaires
     - statut JEI
+    - régime des impatriés
+    - entreprise . association non lucrative
   références:
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
 
@@ -749,6 +751,9 @@
   rend non applicable:
     - CSG
     - CRDS
+    - statut cadre
+    - statut JEI
+    - régime des impatriés
 
 - espace: contrat salarié
   nom: stage
@@ -756,6 +761,7 @@
     Un employeur qui accueille un stagiaire doit lui verser une gratification minimale. Celle-ci est en partie exonérée de cotisations sociales.
   formule: contrat salarié = 'stage'
   rend non applicable:
+    - statut cadre
     - statut JEI
     - réduction générale
     - contribution d'équilibre général
@@ -764,10 +770,11 @@
     - complémentaire santé
     - contribution au dialogue social
     - temps de travail . temps partiel
+    - temps de travail . heures supplémentaires
+    - régime des impatriés
 
 - espace: contrat salarié . stage
   nom: gratification minimale
-  applicable si: stage
   période: flexible
   formule: 15% * plafond sécurité sociale temps plein
   références:

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -565,6 +565,21 @@ contrat salarié . assimilé salarié:
   question.fr: Le salarié est-il considéré comme "assimilé salarié" ?
   titre.en: Assimilated salaried
   titre.fr: assimilé salarié
+contrat salarié . apprentissage:
+  description.en: >
+    An apprenticeship contract is a written employment contract of limited
+    duration (CDD) or indefinite duration (CDI) between an employee and an
+    employer. It allows the apprentice to follow a work-study program in a
+    company under the responsibility of an apprentice master and in an
+    apprenticeship training centre (CFA) for 1 to 3 years.
+  description.fr: >
+    Le contrat d'apprentissage est un contrat de travail écrit à durée limitée
+    (CDD) ou à durée indéterminée (CDI) entre un salarié et un employeur. Il
+    permet à l'apprenti de suivre une formation en alternance en entreprise sous
+    la responsabilité d'un maître d'apprentissage et en centre de formation des
+    apprentis (CFA) pendant 1 à 3 ans.
+  titre.en: apprenticeship
+  titre.fr: apprentissage
 contrat salarié . stage:
   description.en: >
     An employer who employs an intern must pay a minimum bonus to the intern.
@@ -577,15 +592,15 @@ contrat salarié . stage:
 contrat salarié . stage . gratification minimale:
   titre.en: minimum bonus
   titre.fr: gratification minimale
-contrat salarié . stage . gratification exonérée d'impôt:
+contrat salarié . exonération d'impôt des stagiaires et apprentis:
   description.en: >
-    Les salaires versés aux apprentis ainsi que les gratifications de stages
-    sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
+    Wages paid to apprentices and internship bonuses are exempt from income tax
+    up to an annual minimum wage.
   description.fr: >
     Les salaires versés aux apprentis ainsi que les gratifications de stages
     sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
-  titre.en: tax-exempt bonus
-  titre.fr: gratification exonérée d'impôt
+  titre.en: tax exemption for interns and apprentices
+  titre.fr: exonération d'impôt des stagiaires et apprentis
 contrat salarié . CDD:
   description.en: The employment contract explicitly provides for an end date.
   description.fr: >
@@ -609,6 +624,15 @@ contrat salarié . cotisations . assiette:
     de cotisations sur le travail salarié. Elle comprend notamment les
     rémunérations en espèces (salaire de base, indemnité, primes...) et les
     avantages en nature (logement, véhicule...).
+contrat salarié . cotisations . assiette . salariale:
+  titre.en: base for the social contributions
+  titre.fr: Assiette des cotisations sociales
+  description.en: >
+    Apprentices are exempt from social security contributions up to 79% of the
+    minimum wage (SMIC).
+  description.fr: >
+    Les apprentis bénéficient d'une exonération de cotisations sociales jusqu'à
+    79% du SMIC.
 contrat salarié . rémunération . brut de base:
   titre.en: Gross salary
   titre.fr: Salaire brut
@@ -665,6 +689,7 @@ contrat salarié . rémunération . brut de base:
             [mensuel]
           - assimilé salarié != oui
           - stage != oui
+          - apprentissage != oui
       niveau: avertissement
       message: |
         Le salaire saisi est inférieur au SMIC.
@@ -2063,7 +2088,7 @@ impôt . méthode de calcul . barème standard:
   description.fr: >-
     Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal se
     base pour calculer votre taux d'imposition. Pour l'instant, ne prend en
-    compte que l'abattement 10%, le barème et la décôte.
+    compte que l'abattement 10%, le barème et la décote.
   titre.en: '!!barème standard'
   titre.fr: barème standard
 impôt . revenu imposable:

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -1,6 +1,12 @@
 période:
   titre.en: period
   titre.fr: période
+période . jours ouvrés moyen par mois:
+  titre.en: '!!jours ouvrés moyen par mois'
+  titre.fr: jours ouvrés moyen par mois
+période . semaines par mois:
+  titre.en: '!!semaines par mois'
+  titre.fr: semaines par mois
 contrat salarié:
   question.en: What kind of contract is it?
   question.fr: De quel type de contrat s'agit-il ?
@@ -189,8 +195,8 @@ contrat salarié . CDD . compensation pour congés non pris:
     compensatrice de congés payés versée par l'employeur.
   titre.en: untaken vacation compensation
   titre.fr: compensation pour congés non pris
-? contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris
-: titre.en: proportion of untaken leave
+contrat salarié . CDD . compensation pour congés non pris . proportion congés non pris:
+  titre.en: proportion of untaken leave
   titre.fr: proportion congés non pris
 contrat salarié . CDD . congés dus en jours ouvrés:
   titre.en: leave due in working days
@@ -198,8 +204,8 @@ contrat salarié . CDD . congés dus en jours ouvrés:
 contrat salarié . congés dus par mois:
   titre.en: leave due by month
   titre.fr: congés dus par mois
-? contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire
-: titre.en: salary retention bonus
+contrat salarié . CDD . compensation pour congés non pris . prime maintient de salaire:
+  titre.en: salary retention bonus
   titre.fr: prime maintient de salaire
 contrat salarié . CDD . compensation pour congés non pris . assiette mensuelle:
   titre.en: monthly basis
@@ -580,6 +586,58 @@ contrat salarié . apprentissage:
     apprentis (CFA) pendant 1 à 3 ans.
   titre.en: apprenticeship
   titre.fr: apprentissage
+contrat salarié . apprentissage . diplôme préparé:
+  question.en: What type of degree is the apprentice preparing for?
+  question.fr: Quel type de diplôme l'apprenti prépare-t-il ?
+  titre.en: degree prepared
+  titre.fr: diplôme préparé
+contrat salarié . apprentissage . diplôme préparé . niveau bac ou moins:
+  titre.en: Degree of a level less than or equal to the baccalaureate
+  titre.fr: Diplôme d'un niveau inférieur ou égal au bac
+  description.en: >-
+    !!Concerne les diplôme de niveau V (CAP, BEP, CTM...) et de niveau IV (Bac
+    Pro, BP, BTM)
+  description.fr: >-
+    Concerne les diplôme de niveau V (CAP, BEP, CTM...) et de niveau IV (Bac
+    Pro, BP, BTM)
+contrat salarié . apprentissage . diplôme préparé . niveau supérieur au bac:
+  titre.en: Degree above the baccalaureate level
+  titre.fr: Diplôme d'un niveau supérieur au bac
+  description.en: >-
+    !!Concerne les diplôme de niveau I (Master, Ingénieur, Grandes écoles...),
+    de niveau II (License, BMS...), et de niveau III (BTS, SUT, BM, ...)
+  description.fr: >-
+    Concerne les diplôme de niveau I (Master, Ingénieur, Grandes écoles...), de
+    niveau II (License, BMS...), et de niveau III (BTS, SUT, BM, ...)
+contrat salarié . apprentissage . ancienneté:
+  question.en: How long has the apprentice been employed?
+  question.fr: Depuis combien de temps l'apprenti est-il employé ?
+  contrôles.en:
+    - si: moins de quatre ans
+      niveau: information
+      message: >-
+        The maximum duration of the contract may be extended to 4 years when the
+        apprentice is recognised as a disabled worker.
+  contrôles.fr:
+    - si: moins de quatre ans
+      niveau: information
+      message: >-
+        La durée maximale du contrat peut être portée à 4 ans lorsque la qualité
+        de travailleur handicapé est reconnue à l'apprenti.
+  titre.en: age
+  titre.fr: ancienneté
+contrat salarié . apprentissage . ancienneté . moins d'un an:
+  titre.en: less than one year
+  titre.fr: moins d'un an
+contrat salarié . apprentissage . ancienneté . moins de deux ans:
+  titre.en: less than two years
+  titre.fr: moins de deux ans
+contrat salarié . apprentissage . ancienneté . moins de trois ans:
+  titre.en: less than three years
+  titre.fr: moins de trois ans
+contrat salarié . apprentissage . ancienneté . moins de quatre ans:
+  titre.en: less than four years
+  titre.fr: moins de quatre ans
 contrat salarié . stage:
   description.en: >
     An employer who employs an intern must pay a minimum bonus to the intern.
@@ -920,11 +978,11 @@ contrat salarié . rémunération . avantages en nature . nourriture:
 contrat salarié . rémunération . avantages en nature . nourriture . montant:
   titre.en: food
   titre.fr: nourriture
-? contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas
-: titre.en: fixed amount of a meal
+contrat salarié . rémunération . avantages en nature . nourriture . montant forfaitaire d'un repas:
+  titre.en: fixed amount of a meal
   titre.fr: montant forfaitaire d'un repas
-? contrat salarié . rémunération . avantages en nature . nourriture . repas par mois
-: question.en: |
+contrat salarié . rémunération . avantages en nature . nourriture . repas par mois:
+  question.en: |
     How many meals per month are paid for by the employer?
   question.fr: |
     Combien de repas par mois sont payés par l'employeur ?
@@ -938,7 +996,7 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
   titre.fr: repas par mois
 entreprise . hôtel café restaurant:
   question.en: 'Is the company a hotel, café, restaurant or similar?'
-  question.fr: "Est-ce que l'entreprise est un hôtel, café, restaurant ou assimilé ?"
+  question.fr: 'Est-ce que l''entreprise est un hôtel, café, restaurant ou assimilé ?'
   titre.en: hotel café restaurant
   titre.fr: hôtel café restaurant
 contrat salarié . indemnités salarié:
@@ -1007,11 +1065,11 @@ contrat salarié . rémunération . net imposable:
     social benefits. It's the basis used to compute income tax.
   description.fr: |
     C'est la base utilisée pour calculer l'impôt sur le revenu.
-? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées
-: titre.en: tax-free overtime hours
+contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées:
+  titre.en: tax-free overtime hours
   titre.fr: heures supplémentaires défiscalisées
-? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées . plafond brut
-: titre.en: '!!plafond brut'
+contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées . plafond brut:
+  titre.en: '!!plafond brut'
   titre.fr: plafond brut
 contrat salarié . rémunération . net imposable . base:
   titre.en: base
@@ -1078,8 +1136,8 @@ contrat salarié . rémunération . net après impôt:
 
     Pour une simulation plus complète, rendez-vous sur
     [impots.gouv.fr](https://www3.impots.gouv.fr/simulateur/calcul_impot/2018/index.htm).
-? impôt . impôt sur le revenu au taux neutre . barème Guadeloupe Réunion Martinique
-: titre.en: '!!barème Guadeloupe Réunion Martinique'
+impôt . impôt sur le revenu au taux neutre . barème Guadeloupe Réunion Martinique:
+  titre.en: '!!barème Guadeloupe Réunion Martinique'
   titre.fr: barème Guadeloupe Réunion Martinique
 impôt . impôt sur le revenu au taux neutre . barème Guyane Mayotte:
   titre.en: '!!barème Guyane Mayotte'
@@ -1146,8 +1204,8 @@ contrat salarié . rémunération . total:
 contrat salarié . cotisations . patronales . réductions de cotisations:
   titre.en: contribution reductions
   titre.fr: réductions de cotisations
-? contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires
-: titre.en: flat-rate deduction for overtime
+contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires:
+  titre.en: flat-rate deduction for overtime
   titre.fr: déduction forfaitaire pour heures supplémentaires
 contrat salarié . cotisations . patronales . à payer:
   titre.en: to be paid
@@ -1161,8 +1219,8 @@ contrat salarié . réduction ACRE . taux:
 contrat salarié . cotisations . salariales . réduction heures supplémentaires:
   titre.en: reduction for overtime hours
   titre.fr: réduction heures supplémentaires
-? contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites
-: description.en: the effective rate of the employee's pension contributions
+contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites:
+  description.en: the effective rate of the employee's pension contributions
   description.fr: >-
     le taux effectif des cotisations d'assurance vieillesse à la charge du
     salarié
@@ -1180,7 +1238,7 @@ contrat salarié . coût d'embauche:
   résumé.en: Monthly employer cost - financial aids
   résumé.fr: Coût employeur - aides
   question.en: 'What is the cost of hiring, financial aids included?'
-  question.fr: "Quel est le coût d'embauche, toutes aides incluses ?"
+  question.fr: 'Quel est le coût d''embauche, toutes aides incluses ?'
   description.en: >-
     This is what the employer will actually have to pay to the employee and the
     social security collectors in total, taking into account the available
@@ -1207,7 +1265,7 @@ contrat salarié . coût d'embauche:
   titre.fr: coût d'embauche
 contrat salarié . aides employeur:
   résumé.en: Deferred aids available to the employer.
-  résumé.fr: "Pour l'employeur, différées dans le temps"
+  résumé.fr: 'Pour l''employeur, différées dans le temps'
   description.en: >
     Some aids can be requested by the employer to help hires.
 
@@ -1220,12 +1278,29 @@ contrat salarié . aides employeur:
     exemple sous forme de crédit d'impôt.
 
 
-    Le simulateur n'intègre pas les innombrables aides disponibles en France.
-    Découvrez-les sur le [portail officiel](http://www.aides-entreprises.fr).
+    Le simulateur n'intègre pas tous les innombrables aides disponibles en
+    France. Découvrez-les sur le [portail
+    officiel](http://www.aides-entreprises.fr).
   titre.en: deferred employer aids
   titre.fr: aides employeur
+contrat salarié . aides employeur . aide à l'embauche d'apprentis:
+  description.en: >
+    Since 2019, a single hiring aid has replaced four previous schemes. The
+    amount of aid depends on the length of the contract.
+
+    Once the registration procedures have been completed, the aid is
+    automatically paid monthly.
+  description.fr: >
+    Depuis 2019 une aide à l'embauche unique remplace quatre précédents
+    dispositifs. Le montant de l'aide dépend de l'ancienneté du contrat.
+
+
+    Une fois les démarches d'enregistrement effectuées, l'aide est versée
+    automatiquement tous les mois.
+  titre.en: aid to hire apprentices
+  titre.fr: aide à l'embauche d'apprentis
 contrat salarié . salaire:
-  titre.en: '!!salaire'
+  titre.en: salary
   titre.fr: salaire
 entreprise:
   description.en: The contract binds a company and an employee
@@ -1297,7 +1372,7 @@ entreprise . établissement bancaire:
     L'entreprise est un établissement bancaire, financier ou d'assurance. Elle
     est non assujettie à la TVA.
   question.en: 'Is it a banking, financial or insurance institution?'
-  question.fr: "S'agit-il d'un établissement bancaire, financier, d'assurance ?"
+  question.fr: 'S''agit-il d''un établissement bancaire, financier, d''assurance ?'
   titre.en: banking institution
   titre.fr: établissement bancaire
 établissement:
@@ -1344,6 +1419,9 @@ entreprise . établissement bancaire:
 établissement . localisation . département:
   titre.en: department
   titre.fr: département
+établissement . localisation . outre-mer:
+  titre.en: overseas
+  titre.fr: outre-mer
 contrat salarié . temps de travail:
   description.en: >-
     In France, the legal basis for work is 35 hours/week. But a large number of
@@ -1517,10 +1595,10 @@ contrat salarié . statut JEI:
     moins de leurs charges à de la Recherche et Développement de bénéficier de
     certaines exonérations.
 contrat salarié . statut JEI . exonération de cotisations:
-  titre.en: '!!Exonération JEI'
+  titre.en: JEI Exemption
   titre.fr: Exonération JEI
   description.en: |
-    !!Exonération pour les jeunes entreprises innovantes (JEI).
+    Exemption for young innovative companies (JEI).
   description.fr: |
     Exonération pour les jeunes entreprises innovantes (JEI).
 contrat salarié . réduction générale:
@@ -1590,8 +1668,11 @@ contrat salarié . AGS:
 contrat salarié . allocations familiales:
   titre.en: Family allowances
   titre.fr: allocations familiales
-contrat salarié . allocations familiales . plafond de réduction:
-  titre.en: Upper limit on the reduction of family allowances
+contrat salarié . allocations familiales . taux réduit:
+  titre.en: reduced rate
+  titre.fr: taux réduit
+contrat salarié . allocations familiales . taux réduit . plafond de réduction:
+  titre.en: Ceiling on the reduction of family allowances
   titre.fr: Plafond de la réduction des allocations familiales
 contrat salarié . APEC:
   description.en: >-
@@ -1819,8 +1900,9 @@ contrat salarié . formation professionnelle:
     conventional branch of the company, or failing that to an OPCA
     interprofessional.
   description.fr: >-
-    Cette contribution obligatoire est à verser à l'OPCA désigné par la branche
-    conventionnelle de l'entreprise, ou à défaut à un OPCA interprofessionnel.
+    Cette contribution obligatoire est collectée par l'OPCO (opérateurs de
+    compétences) désigné par la branche conventionnelle de l'entreprise, ou à
+    défaut à un OPCO interprofessionnel.
   titre.en: professional training
   titre.fr: formation professionnelle
 contrat salarié . maladie:
@@ -1875,12 +1957,21 @@ contrat salarié . taxe d'apprentissage:
     de l'apprentissage et des formations technologiques et professionnelles
   titre.en: Apprenticeship tax
   titre.fr: taxe d'apprentissage
-contrat salarié . taxe d'apprentissage de base:
-  titre.en: Basic apprenticeship tax
+contrat salarié . taxe d'apprentissage . assiette:
+  titre.en: base of the apprenticeship tax
+  titre.fr: assiette de la taxe d'apprentissage
+  description.en: >-
+    The wages of apprentices are partially exempt in the basis for calculating
+    the apprenticeship tax.
+  description.fr: >-
+    Le salaire des apprentis est partiellement exonéré dans la base de calcul de
+    la taxe d'apprentissage.
+contrat salarié . taxe d'apprentissage . base:
+  titre.en: basic apprenticeship tax
   titre.fr: taxe d'apprentissage de base
-contrat salarié . contribution supplémentaire à l'apprentissage:
-  titre.en: Additional contribution to apprenticeship
-  titre.fr: contribution supplémentaire à l'apprentissage
+contrat salarié . taxe d'apprentissage . contribution supplémentaire:
+  titre.en: additional contribution
+  titre.fr: contribution supplémentaire
 contrat salarié . taxe d'apprentissage . csa au taux majoré:
   titre.en: CSA at the higher rate
   titre.fr: CSA au taux majoré
@@ -2048,11 +2139,13 @@ impôt . méthode de calcul:
     souhaitez comparer les résultats du simulateur à votre fiche de paie. Le
     barème standard vous donne un résultat plus précis que le taux neutre pour
     un célibataire sans enfant.
-  question.en: "!!Comment souhaitez-vous calculer l'impôt sur le revenu ?"
+  question.en: '!!Comment souhaitez-vous calculer l''impôt sur le revenu ?'
   question.fr: Comment souhaitez-vous calculer l'impôt sur le revenu ?
   titre.en: '!!méthode de calcul'
   titre.fr: méthode de calcul
 impôt . méthode de calcul . taux neutre:
+  titre.en: '!!taux neutre'
+  titre.fr: avec le taux neutre
   description.en: >-
     !!Si vous ne connaissez pas votre taux personnalisé, ou si vous voulez
     connaître votre impôt à la source dans le cas où vous avez choisi de ne pas
@@ -2065,9 +2158,9 @@ impôt . méthode de calcul . taux neutre:
     communiquer à votre taux à l'employeur, le calcul au taux neutre correspond
     à une imposition pour un célibataire sans enfants et sans autres revenus /
     charges.
-  titre.en: '!!taux neutre'
-  titre.fr: taux neutre
 impôt . méthode de calcul . taux personnalisé:
+  titre.en: '!!taux personnalisé'
+  titre.fr: avec votre taux personnalisé
   description.en: >-
     !!Vous pouvez utiliser directement le taux personnalisé communiqué par
     l'administration fiscal pour calculer votre impôt. Pour le connaître, vous
@@ -2078,9 +2171,9 @@ impôt . méthode de calcul . taux personnalisé:
     l'administration fiscal pour calculer votre impôt. Pour le connaître, vous
     pouvez-vous rendre sur votre [espace fiscal
     personnel](https://impots.gouv.fr).
-  titre.en: '!!taux personnalisé'
-  titre.fr: taux personnalisé
 impôt . méthode de calcul . barème standard:
+  titre.en: '!!barème standard'
+  titre.fr: avec le barème standard
   description.en: >-
     !!Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal
     se base pour calculer votre taux d'imposition. Pour l'instant, ne prend en
@@ -2089,8 +2182,6 @@ impôt . méthode de calcul . barème standard:
     Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal se
     base pour calculer votre taux d'imposition. Pour l'instant, ne prend en
     compte que l'abattement 10%, le barème et la décote.
-  titre.en: '!!barème standard'
-  titre.fr: barème standard
 impôt . revenu imposable:
   description.en: >
     !!C'est le revenu à prendre en compte pour calculer l'impôt avec un taux
@@ -2200,7 +2291,20 @@ revenu net après impôt:
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
   titre.en: Net income after tax
   titre.fr: revenu net après impôt
-
+entreprise . date de création:
+  question.en: '!!Quand avez-vous crée votre entreprise ?'
+  question.fr: Quand avez-vous crée votre entreprise ?
+  titre.en: '!!date de création'
+  titre.fr: date de création
+entreprise . date de création . avant 2018:
+  titre.en: '!!avant le 1er janvier 2018'
+  titre.fr: avant le 1er janvier 2018
+entreprise . date de création . avant 2019:
+  titre.en: '!!avant le 1er janvier 2019'
+  titre.fr: avant le 1er janvier 2019
+entreprise . date de création . après 2019:
+  titre.en: '!!après le 1er janvier 2019'
+  titre.fr: après le 1er janvier 2019
 entreprise . chiffre d'affaires:
   titre.en: Turnover
   titre.fr: chiffre d'affaires (H.T.)
@@ -2493,7 +2597,7 @@ entreprise . catégorie d'activité . artisanale:
   titre.fr: artisanale
 entreprise . catégorie d'activité . service ou vente:
   question.en: 'Is it a service activity, or the purchase and sale of goods?'
-  question.fr: "Est-ce une activité de prestation de service, ou de l'achat-vente de biens ?"
+  question.fr: 'Est-ce une activité de prestation de service, ou de l''achat-vente de biens ?'
   titre.en: service or sale
   titre.fr: service ou vente
 entreprise . catégorie d'activité . service ou vente . vente de biens:
@@ -2593,8 +2697,8 @@ entreprise . catégorie d'activité . libérale règlementée:
         ne sont pas encore intégrées.
   titre.en: regulated liberal
   titre.fr: libérale règlementée
-? entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée
-: titre.en: type of regulated liberal activity
+entreprise . catégorie d'activité . libérale règlementée . type d'activité libérale règlementée:
+  titre.en: type of regulated liberal activity
   titre.fr: type d'activité libérale règlementée
 entreprise . rattachée à la CIPAV:
   question.en: Is the regulated liberal profession attached to the CIPAV?
@@ -2674,14 +2778,14 @@ entreprise . rattachement libéral règlementé:
 indépendant . cotisations et contributions . cotisations . maladie:
   titre.en: health insurance
   titre.fr: maladie
-? indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée
-: titre.en: health insurance for regulated liberal
+indépendant . cotisations et contributions . cotisations . maladie . libérale règlementée:
+  titre.en: health insurance for regulated liberal
   titre.fr: maladie libérale règlementée
 indépendant . cotisations et contributions . cotisations . maladie . assiette:
   titre.en: health insurance basis
   titre.fr: assiette maladie
-? indépendant . cotisations et contributions . cotisations . indemnités journalières maladie
-: titre.en: health insurance 2
+indépendant . cotisations et contributions . cotisations . indemnités journalières maladie:
+  titre.en: health insurance 2
   titre.fr: Maladie 2
   description.en: >-
     Contributions for the daily allowances of self-employed people. If the state
@@ -2692,38 +2796,38 @@ indépendant . cotisations et contributions . cotisations . maladie . assiette:
     santé des artisans, commerçants, industriels et conjoints collaborateurs
     nécessite un arrêt de travail, une part de leur ancien revenu leur sera
     versé.
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux
-: titre.en: 'craftsmen, traders, liberal'
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux:
+  titre.en: 'craftsmen, traders, liberal'
   titre.fr: artisans commerçants libéraux
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable
-: titre.en: variable rate
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux variable:
+  titre.en: variable rate
   titre.fr: taux variable
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA
-: titre.en: RSA rate
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA:
+  titre.en: RSA rate
   titre.fr: taux RSA
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable
-: titre.en: variable part RSA rate
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux RSA part variable:
+  titre.en: variable part RSA rate
   titre.fr: taux RSA part variable
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction
-: titre.en: upper reduction threshold
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . seuil supérieur de réduction:
+  titre.en: upper reduction threshold
   titre.fr: seuil supérieur de réduction
-? indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux
-: titre.en: rate
+indépendant . cotisations et contributions . cotisations . maladie . artisans commerçants libéraux . taux:
+  titre.en: rate
   titre.fr: taux
 indépendant . cotisations et contributions . cotisations . retraite de base:
   titre.en: pension
   titre.fr: retraite de base
-? indépendant . cotisations et contributions . cotisations . retraite de base . assiette
-: titre.en: pension basis
+indépendant . cotisations et contributions . cotisations . retraite de base . assiette:
+  titre.en: pension basis
   titre.fr: assiette retraite de base
-? indépendant . cotisations et contributions . cotisations . retraite complémentaire
-: titre.en: supplementary pension
+indépendant . cotisations et contributions . cotisations . retraite complémentaire:
+  titre.en: supplementary pension
   titre.fr: retraite complémentaire
 indépendant . cotisations et contributions . cotisations . invalidité et décès:
   titre.en: disability and death
   titre.fr: invalidité et décès
-? indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette
-: titre.en: disability and death basis
+indépendant . cotisations et contributions . cotisations . invalidité et décès . assiette:
+  titre.en: disability and death basis
   titre.fr: assiette invalidité et décès
 indépendant . cotisations et contributions . CSG et CRDS:
   titre.en: CSG and CRDS
@@ -2734,8 +2838,8 @@ indépendant . cotisations et contributions . CSG et CRDS . assiette:
 indépendant . cotisations et contributions . formation professionnelle:
   titre.en: professional training
   titre.fr: formation professionnelle
-? indépendant . cotisations et contributions . cotisations . allocations familiales
-: titre.en: family allowances
+indépendant . cotisations et contributions . cotisations . allocations familiales:
+  titre.en: family allowances
   titre.fr: allocations familiales
 auto entrepreneur:
   question.en: Is the activity carried out in a auto-enterprise?
@@ -2804,11 +2908,17 @@ auto entrepreneur . revenu net de cotisations:
 auto entrepreneur . cotisations et contributions:
   titre.en: Contributions
   titre.fr: cotisations et contributions
-auto entrepreneur . cotisations et contributions . taxe pour frais de chambre:
-  titre.en: tax for chamber fees
-  titre.fr: taxe pour frais de chambre
-? auto entrepreneur . cotisations et contributions . contribution formation professionnelle
-: titre.en: Contribution to vocational training
+auto entrepreneur . cotisations et contributions . TFC:
+  titre.en: '!!Taxes pour frais de chambre'
+  titre.fr: Taxes pour frais de chambre
+auto entrepreneur . cotisations et contributions . TFC . commerce:
+  titre.en: '!!taxe pour frais de chambre de commerce'
+  titre.fr: taxe pour frais de chambre de commerce
+auto entrepreneur . cotisations et contributions . TFC . métiers:
+  titre.en: '!!taxe pour frais de chambre des métiers'
+  titre.fr: taxe pour frais de chambre des métiers
+auto entrepreneur . cotisations et contributions . contribution formation professionnelle:
+  titre.en: Contribution to vocational training
   titre.fr: Contribution à la formation professionnelle
 auto entrepreneur . cotisations et contributions . cotisations:
   description.en: >
@@ -2839,8 +2949,8 @@ auto entrepreneur . cotisations et contributions . cotisations:
     l'ACRE, une réduction de cotisations, dégressive sur 3 ans.
   titre.en: contributions
   titre.fr: cotisations
-? auto entrepreneur . cotisations et contributions . cotisations . retraite complémentaire
-: description.en: >-
+auto entrepreneur . cotisations et contributions . cotisations . retraite complémentaire:
+  description.en: >-
     The total amount that is allocated to the supplementary pension, useful to
     estimate the total amount of the retirement pension for auto-entrepreneurs
   description.fr: >-
@@ -2848,8 +2958,8 @@ auto entrepreneur . cotisations et contributions . cotisations:
     estimer le montant total de la pension de retraite des auto-entrepreneurs
   titre.en: supplementary pension
   titre.fr: retraite complémentaire
-? auto entrepreneur . cotisations et contributions . cotisations . taux de cotisation
-: description.en: >
+auto entrepreneur . cotisations et contributions . cotisations . taux de cotisation:
+  description.en: >
     The social contributions of the self-employed are simplified: there is no
     than a single line whose rate depends on the category of activity.
   description.fr: >
@@ -2857,19 +2967,67 @@ auto entrepreneur . cotisations et contributions . cotisations:
     qu'une ligne unique dont le taux dépend de la catégorie d'activité.
   titre.en: contribution rate
   titre.fr: taux de cotisation
-entreprise . ACCRE obtenu:
-  question.en: Did you obtain the ACCRE when you started your business?
-  question.fr: Avez-vous obtenu l'ACCRE lors de votre création d'entreprise ?
+entreprise . ACRE:
   description.en: >
-    For companies created before 2019, the ACRE contribution reduction was
-    called ACCRE and was not automatic: it was necessary to be compensated by
-    employment centre and make the request.
+    !!L'aide à la création ou à la reprise d'une entreprise (Acre) consiste en
+    une exonération partielle de charges sociales, dite exonération de début
+    d'activité.
+
+
+    *Durée*:
+
+    - **12 mois** pour les sociétés et entreprises individuelles
+
+    - **3 ans** pour les auto-entreprises
+
+
+    *Conditions d'obtention*:
+
+    - Pour les entreprises créées après 2019, la réduction est automatique, sauf
+    si vous avez déjà obtenu l'ACCRE dans les trois années précédentes
+
+    - Pour les entreprises créées avant 2019, la réduction de cotisation
+    s'appelait ACCRE était soumise à conditions et n'était pas automatique : il
+    fallait en faire la demande.
   description.fr: >
-    Pour les entreprises créées avant 2019, la réduction de cotisation ACRE
-    s'appelait ACCRE et n'était pas automatique : il fallait notamment être
-    indemnisé par pôle-emploi et faire la demande.
-  titre.en: ACCRE obtained
-  titre.fr: ACCRE obtenu
+    L'aide à la création ou à la reprise d'une entreprise (Acre) consiste en une
+    exonération partielle de charges sociales, dite exonération de début
+    d'activité.
+
+
+    *Durée*:
+
+    - **12 mois** pour les sociétés et entreprises individuelles
+
+    - **3 ans** pour les auto-entreprises
+
+
+    *Conditions d'obtention*:
+
+    - Pour les entreprises créées après 2019, la réduction est automatique, sauf
+    si vous avez déjà obtenu l'ACCRE dans les trois années précédentes
+
+    - Pour les entreprises créées avant 2019, la réduction de cotisation
+    s'appelait ACCRE était soumise à conditions et n'était pas automatique : il
+    fallait en faire la demande.
+  question.en: '!!Votre entreprise bénéficie-t''elle de l''ACRE (anciennement ACCRE) ?'
+  question.fr: Votre entreprise bénéficie-t'elle de l'ACRE (anciennement ACCRE) ?
+  titre.en: '!!ACRE'
+  titre.fr: ACRE
+entreprise . ACRE . année:
+  question.en: '!!Quel est l''âge de l''entreprise ?'
+  question.fr: Quel est l'âge de l'entreprise ?
+  titre.en: '!!année'
+  titre.fr: année
+entreprise . ACRE . année . moins d'un an:
+  titre.en: '!!moins d''un an'
+  titre.fr: moins d'un an
+entreprise . ACRE . année . moins de deux ans:
+  titre.en: '!!moins de deux ans'
+  titre.fr: moins de deux ans
+entreprise . ACRE . année . moins de trois ans:
+  titre.en: '!!moins de trois ans'
+  titre.fr: moins de trois ans
 auto entrepreneur . cotisations et contributions . cotisations . taux ACRE:
   titre.en: |
     "ACRE" rate
@@ -2888,6 +3046,9 @@ auto entrepreneur . cotisations et contributions . cotisations . réduction ACRE
 auto entrepreneur . cotisations et contributions . cotisations . plafond ACRE:
   titre.en: ACRE upper limit
   titre.fr: plafond ACRE
+auto entrepreneur . impôt:
+  titre.en: tax
+  titre.fr: impôt
 auto entrepreneur . impôt . abattement:
   titre.en: allowance
   titre.fr: abattement
@@ -2904,9 +3065,67 @@ auto entrepreneur . impôt . abattement . taux inversé:
 auto entrepreneur . impôt . abattement . taux:
   titre.en: tax allowance rate
   titre.fr: taux d'abattement de l'impôt
-auto entrepreneur . impôt:
-  titre.en: tax
-  titre.fr: impôt
+auto entrepreneur . impôt . versement libératoire:
+  description.en: >
+    !!Avec l'option pour le versement libératoire, l’impôt sur le revenu est
+    payé en même temps que vos cotisations (par mois ou par trimestre) avec
+    application d’un taux spécifique en fonction de votre activité. Pour en
+    bénéficier, votre revenu fiscal de référence ne doit pas excéder 27 086 € en
+    2018
+  description.fr: >
+    Avec l'option pour le versement libératoire, l’impôt sur le revenu est payé
+    en même temps que vos cotisations (par mois ou par trimestre) avec
+    application d’un taux spécifique en fonction de votre activité. Pour en
+    bénéficier, votre revenu fiscal de référence ne doit pas excéder 27 086 € en
+    2018
+  question.en: '!!Bénéficiez-vous du versement libératoire de l''impôt sur le revenu ?'
+  question.fr: Bénéficiez-vous du versement libératoire de l'impôt sur le revenu ?
+  contrôles.en: '!![object Object]'
+  contrôles.fr:
+    - si:
+        toutes ces conditions:
+          - 'impôt . revenu fiscal de référence [annuel] > 27086'
+          - versement libératoire
+      message: >-
+        Le versement libératoire n'est pas disponible si les revenus de votre
+        ménage sont supérieurs à 27 086 € par part en 2018
+      niveau: info
+  titre.en: '!!versement libératoire'
+  titre.fr: versement libératoire
+auto entrepreneur . impôt . versement libératoire . montant:
+  titre.en: '!!versement libératoire auto entrepreneur'
+  titre.fr: versement libératoire auto entrepreneur
+  description.en: >
+    !!Si vous avez opté pour le versement libératoire, l’impôt sur le revenu est
+    payé en même temps que vos cotisations (par mois ou par trimestre) avec
+    application d’un taux spécifique en fonction de votre activité :
+
+
+    - 1% si l’activité est l’achat/revente, la vente à consommer sur place et la
+    prestation d’hébergement (BIC)
+
+    - 1,7% si l’activité est une activité de services relevant des bénéfices
+    industriels et commerciaux (BIC)
+
+    - 2,2% pour les autres prestations de services relevants des bénéfices non
+    commerciaux (BNC)
+  description.fr: >
+    Si vous avez opté pour le versement libératoire, l’impôt sur le revenu est
+    payé en même temps que vos cotisations (par mois ou par trimestre) avec
+    application d’un taux spécifique en fonction de votre activité :
+
+
+    - 1% si l’activité est l’achat/revente, la vente à consommer sur place et la
+    prestation d’hébergement (BIC)
+
+    - 1,7% si l’activité est une activité de services relevant des bénéfices
+    industriels et commerciaux (BIC)
+
+    - 2,2% pour les autres prestations de services relevants des bénéfices non
+    commerciaux (BNC)
+auto entrepreneur . impôt . revenu imposable:
+  titre.en: '!!revenu imposable'
+  titre.fr: revenu imposable
 auto entrepreneur . impôt . revenu abattu:
   titre.en: reduced income
   titre.fr: revenu abattu auto-entrepreneur
@@ -2950,14 +3169,14 @@ protection sociale . retraite . trimestres validés par an:
 protection sociale . retraite . trimestres validés par an . trimestres salarié:
   titre.en: employee quarters
   titre.fr: trimestres salarié
-? protection sociale . retraite . trimestres validés par an . trimestres indépendant
-: titre.en: self-employed quarters
+protection sociale . retraite . trimestres validés par an . trimestres indépendant:
+  titre.en: self-employed quarters
   titre.fr: trimestres indépendant
-? protection sociale . retraite . trimestres validés par an . barème trimestres générique
-: titre.en: generic quarters scale
+protection sociale . retraite . trimestres validés par an . barème trimestres générique:
+  titre.en: generic quarters scale
   titre.fr: barème trimestres générique
-? protection sociale . retraite . trimestres validés par an . trimestres auto entrepreneur
-: description.en: >-
+protection sociale . retraite . trimestres validés par an . trimestres auto entrepreneur:
+  description.en: >-
     Minimum turnover thresholds for the validation of quarters for retirement as
     a self-employed entrepreneur. Below the minimum amount, you will only have
     access to the solidarity allowance.
@@ -2997,17 +3216,17 @@ protection sociale . retraite . complémentaire salarié . prix d'achat du point
 protection sociale . retraite . complémentaire sécurité des indépendants:
   titre.en: supplementary pension for self-employed
   titre.fr: complémentaire sécurité des indépendants
-? protection sociale . retraite . complémentaire sécurité des indépendants . valeur du point
-: titre.en: value of the point
+protection sociale . retraite . complémentaire sécurité des indépendants . valeur du point:
+  titre.en: value of the point
   titre.fr: valeur du point
-? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis
-: titre.en: acquired points
+protection sociale . retraite . complémentaire sécurité des indépendants . points acquis:
+  titre.en: acquired points
   titre.fr: points acquis
-? protection sociale . retraite . complémentaire sécurité des indépendants . points acquis par mois
-: titre.en: acquired points per month
+protection sociale . retraite . complémentaire sécurité des indépendants . points acquis par mois:
+  titre.en: acquired points per month
   titre.fr: points acquis par mois
-? protection sociale . retraite . complémentaire sécurité des indépendants . prix d'achat du point
-: titre.en: buying cost of the point
+protection sociale . retraite . complémentaire sécurité des indépendants . prix d'achat du point:
+  titre.en: buying cost of the point
   titre.fr: prix d'achat du point
 protection sociale . santé:
   résumé.en: >-

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -1278,7 +1278,7 @@ contrat salarié . aides employeur:
     exemple sous forme de crédit d'impôt.
 
 
-    Le simulateur n'intègre pas tous les innombrables aides disponibles en
+    Le simulateur n'intègre pas toutes les innombrables aides disponibles en
     France. Découvrez-les sur le [portail
     officiel](http://www.aides-entreprises.fr).
   titre.en: deferred employer aids
@@ -1724,7 +1724,9 @@ contrat salarié . complémentaire santé . part employeur:
     minimum
   question.en: What is the part of the complementary health insurance paid by the employer?
   question.fr: Quel est la part de la complémentaire santé payée par l'employeur ?
-  suggestions.en: '!![object Object]'
+  suggestions.en:
+    50%: 0.5
+    100%: 1
   suggestions.fr:
     50%: 0.5
     100%: 1
@@ -3080,7 +3082,15 @@ auto entrepreneur . impôt . versement libératoire:
     2018
   question.en: '!!Bénéficiez-vous du versement libératoire de l''impôt sur le revenu ?'
   question.fr: Bénéficiez-vous du versement libératoire de l'impôt sur le revenu ?
-  contrôles.en: '!![object Object]'
+  contrôles.en:
+    - si:
+        toutes ces conditions:
+          - 'impôt . revenu fiscal de référence [annuel] > 27086'
+          - versement libératoire
+      message: >-
+        !!Le versement libératoire n'est pas disponible si les revenus de votre
+        ménage sont supérieurs à 27 086 € par part en 2018
+      niveau: info
   contrôles.fr:
     - si:
         toutes ces conditions:

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -2,8 +2,8 @@ période:
   titre.en: period
   titre.fr: période
 contrat salarié:
-  question.en: Employed activity ?
-  question.fr: Activité salariée ?
+  question.en: What kind of contract is it?
+  question.fr: De quel type de contrat s'agit-il ?
   description.en: >
     The contract that binds a company (via its establishment) to an individual,
     who is then his employee.
@@ -27,8 +27,54 @@ contrat salarié:
     certains cas. C’est le cas du Contrat de travail à Durée Indéterminée,
     considéré comme la forme normale et générale de la relation de travail entre
     un salarié et un employeur (Art. L1221-2 du Code du travail).
+  contrôles.en:
+    - si: CDD
+      niveau: information
+      message: >
+        Remember that a fixed-term contract (CDD) must always correspond to a
+        temporary need of the company.
+
+        [Code du travail - Article
+        L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
+    - si: stage
+      niveau: avertissement
+      message: >
+        An internship agreement **is not an employment contract**, and cannot
+        not be concluded to perform a regular task corresponding to a permanent
+        position, or a temporary increase of the company's activity. [Education
+        Code - Article
+        L124-7](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029234119&cidTexte=LEGITEXT000006071191)
+
+        In addition, a company with less than 20 employees may not accommodate
+        more than **3** trainees**, and no more than **15% of the number of
+        employees** for companies with more than 20 employees.
+  contrôles.fr:
+    - si: CDD
+      niveau: information
+      message: >
+        Rappelez-vous qu'un CDD doit toujours correspondre à un besoin
+        temporaire de l'entreprise.
+
+        [Code du travail - Article
+        L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
+    - si: stage
+      niveau: avertissement
+      message: >
+        Une convention de stage **n'est pas un contrat de travail**, et ne peut
+        pas être conclue pour réaliser une tâche régulière correspondant à un
+        poste de travail permanent, ou à un accroissement temporaire de
+        l'activité de l'entreprise. [Code de l'éducation - Article
+        L124-7](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000029234119&cidTexte=LEGITEXT000006071191)
+
+
+        Par ailleurs, une entreprise de moins de 20 salariés ne peut pas
+        accueillir plus de **3&nbsp;stagiaires**, et pas plus de **15% de
+        l’effectif** pour les entreprises de plus de 20 salariés.
   titre.en: employment contract
   titre.fr: contrat salarié
+contrat salarié . CDI:
+  titre.en: CDI
+  titre.fr: CDI
 contrat salarié . indemnité kilométrique vélo:
   description.en: >-
     Employer's incitation to the use of bicycles for commuting. This financial
@@ -57,8 +103,7 @@ contrat salarié . indemnité kilométrique vélo . distance annuelle:
   titre.en: annual distance
   titre.fr: distance annuelle
 contrat salarié . indemnité kilométrique vélo . distance journalière:
-  description.en: >-
-    A low estimate of the distance an employee bikes to work.
+  description.en: A low estimate of the distance an employee bikes to work.
   description.fr: >-
     Une estimation basse de la distance parcourue à vélo par un salarié pour se
     rendre à son travail.
@@ -445,6 +490,9 @@ contrat salarié . CDD . congés non pris:
     contrat. Or il se peut que l'entreprise le contraigne à n'en prendre que 4,
     donc 2,25 jours ne seront pas pris. Ils seront payés par l'employeur à la
     fin du contrat.
+  suggestions.en:
+    '3': 3
+    '10': 10
   suggestions.fr:
     '3': 3
     '10': 10
@@ -517,9 +565,28 @@ contrat salarié . assimilé salarié:
   question.fr: Le salarié est-il considéré comme "assimilé salarié" ?
   titre.en: Assimilated salaried
   titre.fr: assimilé salarié
+contrat salarié . stage:
+  description.en: >
+    An employer who employs an intern must pay a minimum bonus to the intern.
+    This bonus is partly exempt from social security contributions.
+  description.fr: >
+    Un employeur qui accueille un stagiaire doit lui verser une gratification
+    minimale. Celle-ci est en partie exonérée de cotisations sociales.
+  titre.en: internship
+  titre.fr: stage
+contrat salarié . stage . gratification minimale:
+  titre.en: minimum bonus
+  titre.fr: gratification minimale
+contrat salarié . stage . gratification exonérée d'impôt:
+  description.en: >
+    Les salaires versés aux apprentis ainsi que les gratifications de stages
+    sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
+  description.fr: >
+    Les salaires versés aux apprentis ainsi que les gratifications de stages
+    sont exonérés d'impôt sur le revenu dans la limite d'un SMIC annuel.
+  titre.en: tax-exempt bonus
+  titre.fr: gratification exonérée d'impôt
 contrat salarié . CDD:
-  question.en: Is it a fixed-term contract (CDD) ?
-  question.fr: Est-ce un contrat à durée déterminée (CDD) ?
   description.en: The employment contract explicitly provides for an end date.
   description.fr: >
     Par défaut, faire travailler quelqu'un en France établit automatiquement un
@@ -528,21 +595,6 @@ contrat salarié . CDD:
     Certaines situations exceptionnelles permettent aux employeurs de prévoir
     une date de fin. Le contrat, qui est alors nécessaire, mentionne cette date
     de fin.
-  contrôles.en:
-    - si: CDD
-      niveau: information
-      message: >
-        Remember that a fixed-term contract must always correspond to a
-        temporary need of the company.
-  contrôles.fr:
-    - si: CDD
-      niveau: information
-      message: >
-        Rappelez-vous qu'un CDD doit toujours correspondre à un besoin
-        temporaire de l'entreprise.
-
-        [Code du travail - Article
-        L1242-1](https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000006901194&cidTexte=LEGITEXT000006072050)
   titre.en: Fixed term (CDD)
   titre.fr: CDD
 contrat salarié . cotisations . assiette:
@@ -612,9 +664,18 @@ contrat salarié . rémunération . brut de base:
             rémunération . assiette de vérification du SMIC [mensuel] < SMIC
             [mensuel]
           - assimilé salarié != oui
+          - stage != oui
       niveau: avertissement
       message: |
         Le salaire saisi est inférieur au SMIC.
+    - si:
+        toutes ces conditions:
+          - stage
+          - 'brut de base [mensuel] < stage . gratification minimale [mensuel]'
+      niveau: avertissement
+      message: >
+        La rémunération du stage est inférieure à la [gratification
+        minimale](https://www.service-public.fr/professionnels-entreprises/vosdroits/F32131).
     - si:
         toutes ces conditions:
           - 'brut de base [mensuel] > 10000'
@@ -638,15 +699,17 @@ contrat salarié . rémunération . brut de base . équivalent temps plein:
     SMIC: 1522
 contrat salarié . rémunération . heures supplémentaires . taux horaire:
   description.en: >-
-    The hourly rate used to calculate overtime compensation. It includes benefits in kind.
+    The hourly rate used to calculate overtime compensation. It includes
+    benefits in kind.
   description.fr: >-
     Le taux horaire utilisé pour calculer la rémunération liée au heures
     supplémentaires. Il intègre les avantages en nature.
   titre.en: hourly rate
   titre.fr: taux horaire
 contrat salarié . rémunération . assiette de vérification du SMIC:
-  description.en: |
-    This is the salary taken into account to verify that the minimum wage is reached.
+  description.en: >
+    This is the salary taken into account to verify that the minimum wage is
+    reached.
   description.fr: |
     C'est le salaire pris en compte pour vérifier que le SMIC est atteint.
   titre.en: minimum wage verification base
@@ -663,7 +726,7 @@ contrat salarié . rémunération . brut:
 contrat salarié . rémunération . heures supplémentaires:
   titre.en: overtime compensation
   titre.fr: rémunération heures supplémentaires
-  description.en:
+  description.en: Overtime compensation
   description.fr: La rémunération relative aux heures supplémentaires
 contrat salarié . avantages sociaux:
   description.en: >-
@@ -849,7 +912,7 @@ contrat salarié . rémunération . avantages en nature . nourriture . montant:
   titre.en: meal per month
   titre.fr: repas par mois
 entreprise . hôtel café restaurant:
-  question.en: Is the company a hotel, café, restaurant or similar?
+  question.en: 'Is the company a hotel, café, restaurant or similar?'
   question.fr: "Est-ce que l'entreprise est un hôtel, café, restaurant ou assimilé ?"
   titre.en: hotel café restaurant
   titre.fr: hôtel café restaurant
@@ -923,8 +986,8 @@ contrat salarié . rémunération . net imposable:
 : titre.en: tax-free overtime hours
   titre.fr: heures supplémentaires défiscalisées
 ? contrat salarié . rémunération . net imposable . heures supplémentaires défiscalisées . plafond brut
-: titre.en:
-  titre.fr: gross cap
+: titre.en: '!!plafond brut'
+  titre.fr: plafond brut
 contrat salarié . rémunération . net imposable . base:
   titre.en: base
   titre.fr: base
@@ -990,26 +1053,41 @@ contrat salarié . rémunération . net après impôt:
 
     Pour une simulation plus complète, rendez-vous sur
     [impots.gouv.fr](https://www3.impots.gouv.fr/simulateur/calcul_impot/2018/index.htm).
-impôt . taux neutre . barème Guadeloupe Réunion Martinique:
-  titre.en: Guadeloupe/Reunion Island/Martinique scale
+? impôt . impôt sur le revenu au taux neutre . barème Guadeloupe Réunion Martinique
+: titre.en: '!!barème Guadeloupe Réunion Martinique'
   titre.fr: barème Guadeloupe Réunion Martinique
-impôt . taux neutre . barème Guyane Mayotte:
-  titre.en: Guyana/Mayotte scale
+impôt . impôt sur le revenu au taux neutre . barème Guyane Mayotte:
+  titre.en: '!!barème Guyane Mayotte'
   titre.fr: barème Guyane Mayotte
-
-impôt . taux neutre:
-  titre.en: neutral income tax
-  titre.fr: Impôt sur le revenu au taux neutre
-  description.en: >-
-    This is the scale to be applied to the monthly taxable salary to obtain the
-    tax to be paid monthly for employees who do not want to reveal their taxe
-    rate to their company (this rate may reveal, for example, significant wealth
-    income).
+impôt . impôt sur le revenu au taux neutre:
+  description.en: >
+    !!C'est le barème à appliquer sur le salaire mensuel imposable pour obtenir
+    l'impôt à payer mensuellement pour les salariés qui ne veulent pas révéler à
+    leur entreprise leur taux d'imposition (ce taux peut révéler par exemple des
+    revenus du patrimoine importants).
   description.fr: >
     C'est le barème à appliquer sur le salaire mensuel imposable pour obtenir
     l'impôt à payer mensuellement pour les salariés qui ne veulent pas révéler à
     leur entreprise leur taux d'imposition (ce taux peut révéler par exemple des
     revenus du patrimoine importants).
+  titre.en: '!!impôt sur le revenu au taux neutre'
+  titre.fr: impôt sur le revenu au taux neutre
+impôt . taux personnalisé:
+  question.en: '!!Quel est votre taux de prélèvement à la source ?'
+  question.fr: Quel est votre taux de prélèvement à la source ?
+  description.en: >
+    !!Votre taux moyen d'imposition personnalisé, que vous pouvez retrouver sur
+    :
+      - une fiche de paie
+      - un avis d'imposition
+      - votre espace personnel [impots.gouv.fr](https://impots.gouv.fr)
+  description.fr: |
+    Votre taux moyen d'imposition personnalisé, que vous pouvez retrouver sur :
+      - une fiche de paie
+      - un avis d'imposition
+      - votre espace personnel [impots.gouv.fr](https://impots.gouv.fr)
+  titre.en: '!!taux personnalisé'
+  titre.fr: taux personnalisé
 contrat salarié . coût du travail:
   titre.en: labor cost
   titre.fr: coût du travail
@@ -1059,8 +1137,7 @@ contrat salarié . cotisations . salariales . réduction heures supplémentaires
   titre.en: reduction for overtime hours
   titre.fr: réduction heures supplémentaires
 ? contrat salarié . cotisations . salariales . réduction heures supplémentaires . taux des cotisations réduites
-: description.en: >-
-    the effective rate of the employee's pension contributions
+: description.en: the effective rate of the employee's pension contributions
   description.fr: >-
     le taux effectif des cotisations d'assurance vieillesse à la charge du
     salarié
@@ -1122,6 +1199,9 @@ contrat salarié . aides employeur:
     Découvrez-les sur le [portail officiel](http://www.aides-entreprises.fr).
   titre.en: deferred employer aids
   titre.fr: aides employeur
+contrat salarié . salaire:
+  titre.en: '!!salaire'
+  titre.fr: salaire
 entreprise:
   description.en: The contract binds a company and an employee
   description.fr: |
@@ -1158,17 +1238,22 @@ entreprise . effectif:
   titre.fr: effectif
 entreprise . ratio alternants:
   question.en: >-
-    What is the proportion of work-study contracts in the average workforce of the company?
+    What is the proportion of work-study contracts in the average workforce of
+    the company?
   question.fr: >-
     Quelle est la fraction de contrats d'alternance dans l'effectif moyen de
     l'entreprise ?
   titre.en: work-study employees ratio
   titre.fr: Fraction d'alternants
   description.en: >
-    This fraction determines the additional contribution for learning for the companies concerned.
+    This fraction determines the additional contribution for learning for the
+    companies concerned.
   description.fr: >
     Cette fraction détermine la contribution supplémentaire pour l'apprentissage
     pour les entreprises concernées.
+  suggestions.en:
+    1%: 0.01
+    5%: 0.05
   suggestions.fr:
     1%: 0.01
     5%: 0.05
@@ -1236,7 +1321,10 @@ entreprise . établissement bancaire:
   titre.fr: département
 contrat salarié . temps de travail:
   description.en: >-
-    In France, the legal basis for work is 35 hours/week. But a large number of existing provisions make it possible to vary this number. You can find them on the dedicated page [service-public.fr (french)](https://www.service-public.fr/particuliers/vosdroits/N458).
+    In France, the legal basis for work is 35 hours/week. But a large number of
+    existing provisions make it possible to vary this number. You can find them
+    on the dedicated page [service-public.fr
+    (french)](https://www.service-public.fr/particuliers/vosdroits/N458).
   description.fr: >-
     En France, la base légale du travail est de 35h/semaine. Mais un grand
     nombre de dispositions existantes permettent de faire varier ce nombre. Vous
@@ -1258,9 +1346,11 @@ contrat salarié . temps de travail . temps partiel:
   question.en: Is the contract part-time?
   question.fr: Le contrat est-il à temps partiel ?
   description.en: >
-    Two contracts at the same salary, one part-time and the other full-time, may give rise to different contribution amounts.
+    Two contracts at the same salary, one part-time and the other full-time, may
+    give rise to different contribution amounts.
 
-    For example, for capped contributions or exemptions depending on the minimum wage.
+    For example, for capped contributions or exemptions depending on the minimum
+    wage.
   description.fr: >
     Deux contrats au même salaire, l'un à temps partiel, l'autre à temps
     complet, peuvent donner lieu à des montants de cotisation différents.
@@ -1271,8 +1361,7 @@ contrat salarié . temps de travail . temps partiel:
   titre.en: part-time
   titre.fr: temps partiel
 contrat salarié . temps de travail . temps partiel . heures par semaine:
-  question.en: >-
-    What is the number of hours worked per week as part of part-time work?
+  question.en: What is the number of hours worked per week as part of part-time work?
   question.fr: >-
     Quel est le nombre d'heures travaillées par semaine dans le cadre du temps
     partiel ?
@@ -1280,11 +1369,12 @@ contrat salarié . temps de travail . temps partiel . heures par semaine:
     - si: heures par semaine < 24
       niveau: avertissement
       message: >
-        The minimum number of hours per week is 24 and it is only possible to go lower in some cases. [More info](https://www.service-public.fr/particuliers/vosdroits/F32428).
+        The minimum number of hours per week is 24 and it is only possible to go
+        lower in some cases. [More
+        info](https://www.service-public.fr/particuliers/vosdroits/F32428).
     - si: heures par semaine >= 35
       niveau: avertissement
-      message: >-
-        Part-time work must be below the legal working time (35 hours)
+      message: Part-time work must be below the legal working time (35 hours)
   contrôles.fr:
     - si: heures par semaine < 24
       niveau: avertissement
@@ -1297,16 +1387,18 @@ contrat salarié . temps de travail . temps partiel . heures par semaine:
       message: >-
         Un temps partiel doit être en dessous de la durée de travail légale
         (35h)
-  titre.en: 'hours per week'
+  titre.en: hours per week
   titre.fr: heures par semaine
 contrat salarié . temps de travail . quotité de travail:
-  description.en: 'Working time as a proportion of legal full time.'
+  description.en: Working time as a proportion of legal full time.
   description.fr: Temps de travail en proportion du temps complet légal.
   titre.en: work share
   titre.fr: quotité de travail
 contrat salarié . temps de travail . heures supplémentaires:
   description.en: >-
-    Any hour of work performed, at the employer's request, beyond the legal 35-hour limit (or equivalent) is considered overtime. Overtime work entitles the employee to more favourable remuneration (higher hourly rate).
+    Any hour of work performed, at the employer's request, beyond the legal
+    35-hour limit (or equivalent) is considered overtime. Overtime work entitles
+    the employee to more favourable remuneration (higher hourly rate).
   description.fr: >-
     Toute heure de travail accomplie, à la demande de l'employeur, au-delà de la
     durée légale de 35 heures (ou de la durée équivalente) est une heure
@@ -1314,8 +1406,7 @@ contrat salarié . temps de travail . heures supplémentaires:
     plus favorable (taux horaire majoré) au salarié.
   titre.en: Number of overtime hours
   titre.fr: Nombre d'heures supplémentaires
-  question.en: >-
-    How many overtime hours (not recovered in rest) are worked per month?
+  question.en: How many overtime hours (not recovered in rest) are worked per month?
   question.fr: >-
     Combien d'heures supplémentaires (non récupérées en repos) sont effectuées
     par mois ?
@@ -1327,7 +1418,6 @@ contrat salarié . temps de travail . heures supplémentaires:
     aucune: 0
     39h / semaine: 17.33
     42h / semaine: 30.33
-
   contrôles.en:
     - si:
         toutes ces conditions:
@@ -1359,14 +1449,17 @@ contrat salarié . temps de travail . heures supplémentaires:
         envoyez-nous un mail à contact@mon-entreprise.beta.gouv.fr
 contrat salarié . temps de travail . heures supplémentaires . majoration:
   description.en: >-
-    Overtime pay is subject to one or more increase rates, fixed by collective agreement or agreement of the company or establishment (or, failing that, by branch agreement or agreement). Each rate is at least set at 10%.
+    Overtime pay is subject to one or more increase rates, fixed by collective
+    agreement or agreement of the company or establishment (or, failing that, by
+    branch agreement or agreement). Each rate is at least set at 10%.
 
-    In the absence of an agreement or convention, the hourly increase rates are set at :
+    In the absence of an agreement or convention, the hourly increase rates are
+    set at :
 
-    - 25% for the first 8 hours of overtime worked in the same week (36th to 43rd hours),
+    - 25% for the first 8 hours of overtime worked in the same week (36th to
+    43rd hours),
 
     - 50% for the following hours.
-
   description.fr: >
     La rémunération des heures supplémentaires fait l'objet d'un ou plusieurs
     taux de majoration, fixés par convention ou accord collectif d'entreprise ou
@@ -1398,14 +1491,13 @@ contrat salarié . statut JEI:
     finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au
     moins de leurs charges à de la Recherche et Développement de bénéficier de
     certaines exonérations.
-contrat salarié . exonération JEI:
-  description.en: >-
-    Exemption for the companies that obtained the JEI (young innovative company)
-    status.
+contrat salarié . statut JEI . exonération de cotisations:
+  titre.en: '!!Exonération JEI'
+  titre.fr: Exonération JEI
+  description.en: |
+    !!Exonération pour les jeunes entreprises innovantes (JEI).
   description.fr: |
     Exonération pour les jeunes entreprises innovantes (JEI).
-  titre.en: JEI exemption
-  titre.fr: exonération JEI
 contrat salarié . réduction générale:
   description.en: >-
     As part of the "liability and solidarity pact", the zero-contribution URSSAF
@@ -1526,7 +1618,7 @@ contrat salarié . complémentaire santé . part employeur:
     minimum
   question.en: What is the part of the complementary health insurance paid by the employer?
   question.fr: Quel est la part de la complémentaire santé payée par l'employeur ?
-
+  suggestions.en: '!![object Object]'
   suggestions.fr:
     50%: 0.5
     100%: 1
@@ -1896,6 +1988,93 @@ impôt:
     revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
   titre.en: income tax
   titre.fr: impôt sur le revenu
+impôt . méthode de calcul:
+  description.en: >
+    !!Nous avons implémenté trois façon de calculer l'impôt sur le revenu :
+
+    - *Le taux personnalisé* : indiqué sur votre avis d'imposition
+
+    - *Le taux neutre* : pour un célibataire sans enfants
+
+    - *Le barème standard * : la formule "officielle" utilisée par
+    l'administration fiscale pour obtenir le taux d'imposition
+
+
+    En remplissant votre taux personnalisé, vous serez au plus proche de votre
+    situation réelle. Le taux neutre peut être intéressant dans le cas où vous
+    n'avez pas transmis votre taux personnalisé à l'employeur et que vous
+    souhaitez comparer les résultats du simulateur à votre fiche de paie. Le
+    barème standard vous donne un résultat plus précis que le taux neutre pour
+    un célibataire sans enfant.
+  description.fr: >
+    Nous avons implémenté trois façon de calculer l'impôt sur le revenu :
+
+    - *Le taux personnalisé* : indiqué sur votre avis d'imposition
+
+    - *Le taux neutre* : pour un célibataire sans enfants
+
+    - *Le barème standard * : la formule "officielle" utilisée par
+    l'administration fiscale pour obtenir le taux d'imposition
+
+
+    En remplissant votre taux personnalisé, vous serez au plus proche de votre
+    situation réelle. Le taux neutre peut être intéressant dans le cas où vous
+    n'avez pas transmis votre taux personnalisé à l'employeur et que vous
+    souhaitez comparer les résultats du simulateur à votre fiche de paie. Le
+    barème standard vous donne un résultat plus précis que le taux neutre pour
+    un célibataire sans enfant.
+  question.en: "!!Comment souhaitez-vous calculer l'impôt sur le revenu ?"
+  question.fr: Comment souhaitez-vous calculer l'impôt sur le revenu ?
+  titre.en: '!!méthode de calcul'
+  titre.fr: méthode de calcul
+impôt . méthode de calcul . taux neutre:
+  description.en: >-
+    !!Si vous ne connaissez pas votre taux personnalisé, ou si vous voulez
+    connaître votre impôt à la source dans le cas où vous avez choisi de ne pas
+    communiquer à votre taux à l'employeur, le calcul au taux neutre correspond
+    à une imposition pour un célibataire sans enfants et sans autres revenus /
+    charges.
+  description.fr: >-
+    Si vous ne connaissez pas votre taux personnalisé, ou si vous voulez
+    connaître votre impôt à la source dans le cas où vous avez choisi de ne pas
+    communiquer à votre taux à l'employeur, le calcul au taux neutre correspond
+    à une imposition pour un célibataire sans enfants et sans autres revenus /
+    charges.
+  titre.en: '!!taux neutre'
+  titre.fr: taux neutre
+impôt . méthode de calcul . taux personnalisé:
+  description.en: >-
+    !!Vous pouvez utiliser directement le taux personnalisé communiqué par
+    l'administration fiscal pour calculer votre impôt. Pour le connaître, vous
+    pouvez-vous rendre sur votre [espace fiscal
+    personnel](https://impots.gouv.fr).
+  description.fr: >-
+    Vous pouvez utiliser directement le taux personnalisé communiqué par
+    l'administration fiscal pour calculer votre impôt. Pour le connaître, vous
+    pouvez-vous rendre sur votre [espace fiscal
+    personnel](https://impots.gouv.fr).
+  titre.en: '!!taux personnalisé'
+  titre.fr: taux personnalisé
+impôt . méthode de calcul . barème standard:
+  description.en: >-
+    !!Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal
+    se base pour calculer votre taux d'imposition. Pour l'instant, ne prend en
+    compte que l'abattement 10%, le barème et la décôte.
+  description.fr: >-
+    Le calcul "officiel" de l'impôt, celui sur lequel l'administration fiscal se
+    base pour calculer votre taux d'imposition. Pour l'instant, ne prend en
+    compte que l'abattement 10%, le barème et la décôte.
+  titre.en: '!!barème standard'
+  titre.fr: barème standard
+impôt . revenu imposable:
+  description.en: >
+    !!C'est le revenu à prendre en compte pour calculer l'impôt avec un taux
+    moyen d'imposition (neutre ou personnalisé).
+  description.fr: >
+    C'est le revenu à prendre en compte pour calculer l'impôt avec un taux moyen
+    d'imposition (neutre ou personnalisé).
+  titre.en: '!!revenu imposable'
+  titre.fr: revenu imposable
 impôt . revenu abattu:
   description.en: >
     The tax is calculated on a reduced income: it is reduced (for example by
@@ -1947,15 +2126,15 @@ impôt . impôt sur le revenu:
     uniquement à la part de ses revenus supérieure à 72 617€.
   titre.en: income tax
   titre.fr: impôt sur le revenu
-impôt . impôt sur le revenu après décote:
+impôt . impôt sur le revenu à payer:
   description.en: >-
-    A discount is applied after the income tax rate, for reduce taxes on low
-    incomes.
+    !!Une décote est appliquée après le barème de l'impôt sur le revenu, pour
+    réduire l'impôt des bas revenus.
   description.fr: >-
     Une décote est appliquée après le barème de l'impôt sur le revenu, pour
     réduire l'impôt des bas revenus.
-  titre.en: income tax after discount
-  titre.fr: impôt sur le revenu après décote
+  titre.en: income tax
+  titre.fr: impôt sur le revenu à payer
 impôt . revenu fiscal de référence:
   description.en: >-
     The reference tax income corresponds to the household's reduced income
@@ -1970,9 +2149,6 @@ impôt . revenu fiscal de référence:
 impôt . CEHR:
   titre.en: CEHR
   titre.fr: CEHR
-impôt . impôt sur le revenu à payer:
-  titre.en: income tax
-  titre.fr: impôt sur le revenu
 revenu net de cotisations:
   résumé.en: Before taxes
   résumé.fr: Avant impôt

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -282,7 +282,8 @@ export let nextStepsSelector = createSelector(
 	[
 		currentMissingVariablesByTargetSelector,
 		state => state.simulation?.config.questions,
-		state => state.conversationSteps.foldedSteps
+		state => state.conversationSteps.foldedSteps,
+		formattedSituationSelector
 	],
 	(
 		mv,
@@ -291,7 +292,8 @@ export let nextStepsSelector = createSelector(
 			uniquement: only,
 			'liste noire': blacklist = []
 		} = {},
-		foldedSteps = []
+		foldedSteps = [],
+		situation
 	) => {
 		let nextSteps = difference(getNextSteps(mv), foldedSteps)
 
@@ -300,9 +302,16 @@ export let nextStepsSelector = createSelector(
 			nextSteps = difference(nextSteps, blacklist)
 		}
 
+		// L'ajout de la réponse permet de traiter les questions dont la réponse est "une possibilité", exemple "contrat salarié . cdd"
+		let lastStep = last(foldedSteps),
+			lastStepWithAnswer = situation[lastStep]
+				? [lastStep, situation[lastStep]].join(' . ')
+				: lastStep
+
 		nextSteps = sortBy(
 			question =>
-				similarity(question, last(foldedSteps)) + notPriority.indexOf(question),
+				similarity(question, lastStepWithAnswer) +
+				notPriority.indexOf(question),
 			nextSteps
 		)
 

--- a/source/selectors/repartitionSelectors.js
+++ b/source/selectors/repartitionSelectors.js
@@ -119,8 +119,6 @@ const répartition = (analysis): ?Répartition => {
 	const autresCotisations = cotisations['protection sociale . autres']
 	if (autresCotisations) {
 		CSG = autresCotisations.find(propEq('dottedName', 'contrat salarié . CSG'))
-		if (!CSG)
-			throw new Error('[répartition selector]: expect CSG not to be null')
 		cotisations['protection sociale . autres'] = without(
 			[CSG],
 			autresCotisations


### PR DESCRIPTION
J'ai vérifié la cohérence des nouvelles règles avec un exemple de fiche de paie de stagiaire et ça me semble correct.

Comme évoqué sur #563, serait-il préférable de changer la question sur le CDD en :
> De quel type de contrat s'agit-il ? [CDI] [CDD] [Stage]

?

Par ailleurs est-il possible de changer dynamiquement les labels du simulateur pour remplacer "Salaire" par "Indemnité de stage" ? Ou peut-être est-ce un signe qu'il ne faut pas ré-utiliser le simulateur salarié, et qu'il faut créer un simulateur différent exclusif pour les stagiaires — fondamentalement les stagiaires ne sont pas salariés ?