### PR TITLE
Améliore les simulateurs pour être au plus proche des attentes utilisateurs

### DIFF
--- a/cypress/integration/mon-entreprise/simulateurs.js
+++ b/cypress/integration/mon-entreprise/simulateurs.js
@@ -31,13 +31,16 @@ describe('Simulateurs test', function() {
 				: 'Self-employed income simulator'
 		)
 	})
-	it('should give an estimation for the self-employed income', function() {
+	it('donne une estimation pour le revenu des indépendants', function() {
 		cy.visit(
 			fr ? '/sécurité-sociale/indépendant' : '/social-security/self-employed'
 		)
-		salaryInput(fr ? "Chiffre d'affaires" : 'Turnover').type(100000, {
-			force: true
-		})
+		salaryInput(fr ? 'Rémunération totale' : 'Director total income').type(
+			100000,
+			{
+				force: true
+			}
+		)
 		cy.contains(fr ? 'Cotisations et contributions' : 'All contributions')
 		cy.contains(fr ? "Type d'activité" : 'Activity type').click()
 		cy.contains(

--- a/source/components/SalaryExplanation.js
+++ b/source/components/SalaryExplanation.js
@@ -2,7 +2,8 @@ import Distribution from 'Components/Distribution'
 import PaySlip from 'Components/PaySlip'
 import withTracker from 'Components/utils/withTracker'
 import { compose } from 'ramda'
-import React from 'react'
+import React, { useRef } from 'react'
+import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
 import { formValueSelector } from 'redux-form'
@@ -29,6 +30,7 @@ export default compose(
 		showDistributionFirst: !state.conversationSteps.foldedSteps.length
 	}))
 )(function SalaryExplanation({ showDistributionFirst }) {
+	const distributionRef = useRef({})
 	return (
 		<ErrorBoundary>
 			<Animate.fromTop key={showDistributionFirst}>
@@ -39,8 +41,22 @@ export default compose(
 					</>
 				) : (
 					<>
+						<div css="text-align: center">
+							<button
+								className="ui__ small simple button"
+								onClick={() =>
+									distributionRef.current.scrollIntoView({
+										behavior: 'smooth',
+										block: 'start'
+									})
+								}>
+								{emoji('📊')} Voir la répartition des cotisations
+							</button>
+						</div>
 						<PaySlipSection />
-						<DistributionSection />
+						<div ref={distributionRef}>
+							<DistributionSection />
+						</div>
 					</>
 				)}
 				<br />

--- a/source/components/SchemeComparaison.js
+++ b/source/components/SchemeComparaison.js
@@ -53,8 +53,8 @@ type SimulationResult = {
 	trimestreValidés: RègleAvecValeur,
 	indemnitésJournalières: RègleAvecMontant,
 	indemnitésJournalièresATMP?: RègleAvecMontant,
-	revenuNetAvantImpôts: RègleAvecMontant,
-	revenuNetAprèsImpôts: RègleAvecMontant,
+	revenuNetDeCotisations: RègleAvecMontant,
+	revenuNetAprèsImpôt: RègleAvecMontant,
 	plafondDépassé?: boolean
 }
 
@@ -73,7 +73,7 @@ const SchemeComparaison = ({
 }: Props) => {
 	const [showMore, setShowMore] = useState(false)
 	const [conversationStarted, setConversationStarted] = useState(
-		!!assimiléSalarié.revenuNetAprèsImpôts.montant
+		!!assimiléSalarié.revenuNetAprèsImpôt.montant
 	)
 	const startConversation = useCallback(() => setConversationStarted(true), [
 		setConversationStarted
@@ -337,17 +337,16 @@ const SchemeComparaison = ({
 						</div>
 					)}
 				</div>
-
-				{conversationStarted && !!assimiléSalarié.revenuNetAprèsImpôts.montant && (
+				{conversationStarted && !!assimiléSalarié.revenuNetAprèsImpôt.montant && (
 					<>
-						<T k="comparaisonRégimes.revenuNetApresImpots">
-							<h3 className="legend">Revenu net après impôts</h3>
+						<T k="comparaisonRégimes.revenuNetApresImpot">
+							<h3 className="legend">Revenu net après impôt</h3>
 						</T>
 						<div className="AS">
 							<Animate.appear className="ui__ plain card">
 								<RuleValueLink
 									onClick={() => setSituationBranch(0)}
-									{...assimiléSalarié.revenuNetAprèsImpôts}
+									{...assimiléSalarié.revenuNetAprèsImpôt}
 								/>
 							</Animate.appear>
 						</div>
@@ -355,7 +354,7 @@ const SchemeComparaison = ({
 							<Animate.appear className="ui__ plain card">
 								<RuleValueLink
 									onClick={() => setSituationBranch(1)}
-									{...indépendant.revenuNetAprèsImpôts}
+									{...indépendant.revenuNetAprèsImpôt}
 								/>
 							</Animate.appear>
 						</div>
@@ -370,12 +369,12 @@ const SchemeComparaison = ({
 								) : (
 									<RuleValueLink
 										onClick={() => setSituationBranch(2)}
-										{...autoEntrepreneur.revenuNetAprèsImpôts}
+										{...autoEntrepreneur.revenuNetAprèsImpôt}
 									/>
 								)}
 							</Animate.appear>
 						</div>
-						<T k="comparaisonRégimes.revenuNetAvantImpots">
+						<T k="comparaisonRégimes.revenuNetAvantImpot">
 							<h3 className="legend">
 								Revenu net de cotisations <small>(avant impôts)</small>
 							</h3>
@@ -383,13 +382,13 @@ const SchemeComparaison = ({
 						<div className="AS">
 							<RuleValueLink
 								onClick={() => setSituationBranch(0)}
-								{...assimiléSalarié.revenuNetAvantImpôts}
+								{...assimiléSalarié.revenuNetDeCotisations}
 							/>
 						</div>
 						<div className="indep">
 							<RuleValueLink
 								onClick={() => setSituationBranch(1)}
-								{...indépendant.revenuNetAvantImpôts}
+								{...indépendant.revenuNetDeCotisations}
 							/>
 						</div>
 						<div className="auto">
@@ -398,7 +397,7 @@ const SchemeComparaison = ({
 							) : (
 								<RuleValueLink
 									onClick={() => setSituationBranch(2)}
-									{...autoEntrepreneur.revenuNetAvantImpôts}
+									{...autoEntrepreneur.revenuNetDeCotisations}
 								/>
 							)}
 						</div>
@@ -628,10 +627,10 @@ export default (compose(
 					indemnitésJournalières: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
 					})('protection sociale . santé . indemnités journalières'),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Auto-entrepreneur'
 					})('auto entrepreneur . revenu net de cotisations'),
 					// $FlowFixMe
@@ -652,12 +651,12 @@ export default (compose(
 					indemnitésJournalières: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
 					})('protection sociale . santé . indemnités journalières'),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Indépendant'
-					})('indépendant . revenu professionnel')
+					})('indépendant . revenu net de cotisations')
 				},
 				assimiléSalarié: {
 					retraite: règleAvecMontantSelector(state, {
@@ -674,10 +673,10 @@ export default (compose(
 					})(
 						'protection sociale . accidents du travail et maladies professionnelles'
 					),
-					revenuNetAprèsImpôts: règleAvecMontantSelector(state, {
+					revenuNetAprèsImpôt: règleAvecMontantSelector(state, {
 						situationBranchName: 'Assimilé salarié'
-					})('revenu net'),
-					revenuNetAvantImpôts: règleAvecMontantSelector(state, {
+					})('revenu net après impôt'),
+					revenuNetDeCotisations: règleAvecMontantSelector(state, {
 						situationBranchName: 'Assimilé salarié'
 					})('contrat salarié . salaire . net')
 				}

--- a/source/components/SimulateurWarning.js
+++ b/source/components/SimulateurWarning.js
@@ -17,31 +17,22 @@ export default withLanguage(function SimulateurWarning({
 			<p>
 				{emoji('🚩 ')}
 				<strong>
-					<T k="simulateurs.warning.titre">Outil en cours de développement </T>
+					<T k="simulateurs.warning.titre">Avant de commencer...</T>
 				</strong>{' '}
 				{folded && (
 					<button
 						className="ui__ button simple small"
 						onClick={() => fold(false)}>
-						<T k="simulateurs.warning.plus">(plus d'info)</T>
+						<T k="simulateurs.warning.plus">Lire les précisions</T>
 					</button>
 				)}
 			</p>
 			<div className={`content ${folded ? '' : 'ui__ card'}`}>
 				{!folded && (
 					<ul style={{ marginLeft: '1em' }}>
-						{simulateur !== 'auto-entreprise' &&
-							simulateur !== 'assimilé-salarié' && (
-								<li>
-									<T k="simulateurs.warning.line1">
-										le chiffre d'affaires déduit des charges va à 100% dans la
-										rémunération du dirigeant
-									</T>
-								</li>
-							)}
 						<li>
-							<T k="simulateurs.warning.line2">
-								l'impôt sur le revenu est calculé pour un célibataire sans
+							<T k="simulateurs.warning.impôt">
+								L'impôt sur le revenu est calculé pour un célibataire sans
 								enfant et sans autre revenu.
 							</T>{' '}
 							{simulateur == 'auto-entreprise' && language === 'fr' && (
@@ -49,11 +40,22 @@ export default withLanguage(function SimulateurWarning({
 							)}
 						</li>
 						<li>
-							<T k="simulateurs.warning.line3">
-								les calculs sont indicatifs et ne se substituent pas aux
+							<T k="simulateurs.warning.urssaf">
+								Les calculs sont indicatifs et ne se substituent pas aux
 								décomptes réels des Urssaf, impots.gouv.fr, etc
 							</T>
 						</li>
+						{simulateur == 'auto-entreprise' && (
+							<li>
+								<T k="simulateurs.warning.auto-entrepreneur">
+									{' '}
+									les auto-entrepreneurs ne peuvent pas déduire leurs charges de
+									leur chiffre d'affaires. Il faut donc retrancher au net tous
+									les coûts liés à l'entreprise pour obtenir le revenu
+									réellement perçu.
+								</T>
+							</li>
+						)}
 					</ul>
 				)}
 

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -1,9 +1,4 @@
 objectifs:
-  - icône: 🏢
-    nom: Mon entreprise
-    objectifs:
-      - entreprise . chiffre d'affaires
-      - entreprise . charges
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
@@ -12,6 +7,11 @@ objectifs:
       - contrat salarié . salaire . net
       - impôt . neutre
       - contrat salarié . salaire . net après impôt
+  # - icône: 🏢
+  #   nom: Mon entreprise
+  #   objectifs:
+  #     - entreprise . charges
+  #     - entreprise . chiffre d'affaires
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/auto-entrepreneur.yaml
+++ b/source/components/simulationConfigs/auto-entrepreneur.yaml
@@ -1,15 +1,17 @@
 objectifs:
   - entreprise . chiffre d'affaires
-  - entreprise . charges
   - auto entrepreneur . cotisations et contributions
-  - impôt . impôt sur le revenu à payer
-  - revenu net
+  - auto entrepreneur . revenu net de cotisations
+  - impôt
+  - revenu net après impôt
 
 questions:
   à l'affiche:
     Type d'activité: entreprise . catégorie d'activité
     ACRE: entreprise . année d'activité
     Charges: entreprise . charges
+  liste noire:
+    - entreprise . charges
 
 situation:
   auto entrepreneur: oui

--- a/source/components/simulationConfigs/indépendant.yaml
+++ b/source/components/simulationConfigs/indépendant.yaml
@@ -1,17 +1,18 @@
 objectifs:
-  - icône: 🏢
-    nom: Mon entreprise
-    objectifs:
-      - entreprise . chiffre d'affaires
-      - entreprise . charges
   - icône: 👩‍💼
     nom: Mon revenu
     objectifs:
-      - indépendant . revenu total du dirigeant
+      - entreprise . rémunération totale du dirigeant
       - indépendant . cotisations et contributions
+      - indépendant . revenu net de cotisations
       - indépendant . revenu professionnel
-      - indépendant . impôt et contributions non déductibles
-      - revenu net
+      - impôt
+      - revenu net après impôt
+  # - icône: 🏢
+  #   nom: Mon entreprise
+  #   objectifs:
+  #     - entreprise . charges
+  #     - entreprise . chiffre d'affaires
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/rémunération-dirigeant.yaml
+++ b/source/components/simulationConfigs/rémunération-dirigeant.yaml
@@ -2,7 +2,8 @@ titre: |
   Calcul du revenu du travailleur indépendant ou dirigeant d'entreprise après paiement des cotisations et de l'impôt sur le revenu.
 
 objectifs:
-  - revenu net
+  - revenu net après impôt
+  - revenu net de cotisations
   - protection sociale . retraite
   - protection sociale . retraite . trimestres validés par an
   - protection sociale . santé . indemnités journalières
@@ -10,7 +11,7 @@ objectifs:
 
 questions:
   uniquement:
-    - entreprise . chiffre d'affaires
+    - entreprise . rémunération totale du dirigeant
     - entreprise . charges
     - entreprise . catégorie d'activité
     - entreprise . catégorie d'activité . service ou vente

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -597,7 +597,6 @@ newsletter:
     description: |
       Subscribe to our monthly newsletter to receive <2>official advice on starting a business</2> and access new features in advance.
 S'inscrire: Register
-simulationWarning: This is an estimate based on <2>purely theoretical data</2> on turnover, charges and the single tax base without children, excluding any other income, which <5>cannot be the responsibility of the social security bodies concerned with regard to the actual declarations and calculations.</5>
 
 Renseigner mon entreprise: Find my company
 Simulations personnalisées: Customized simulations
@@ -609,11 +608,11 @@ Comparer les trois régimes: Compare the three schemes
 simulateurs:
   inversionFail: The amount entered is too small or results in an impossible situation, try another one
   warning:
-    titre: Tool under development
-    plus: (more info)
-    line1: the turnover deducted from expenses goes to 100% in the director's remuneration
-    line2: income tax is calculated for a single person without children and without other income.
-    line3: the figures are indicative and do not replace the actual accounts of the Urssaf, impots.gouv.fr, etc
+    titre: Before starting...
+    plus: Read explanations
+    impôt: Income tax is calculated for a single person without children and without other income.
+    urssaf: The figures are indicative and do not replace the actual accounts of the Urssaf, impots.gouv.fr, etc
+    auto-entrepreneur: Self-employed entrepreneurs cannot deduct their expenses from their turnover. Therefore, all costs related to the business must be deducted on a net basis to obtain the actual income received.
   précision:
     défaut: 'Refine the simulation by answering the following questions:'
     faible: Low accuracy
@@ -730,9 +729,9 @@ comparaisonRégimes:
     <0> Optional health and pension policies deductible</0>
     <1> Yes <1>(under certain conditions)</1></1>
     <2> Yes <1>("Madelin" Law)</1></2>
-  revenuNetApresImpots: |
+  revenuNetApresImpot: |
     <0>Net income after taxes</0>
-  revenuNetAvantImpots: |
+  revenuNetAvantImpot: |
     <0>Net contribution income<1>(before income tax)</1></0>
   retraiteEstimation:
     legend: |

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -753,12 +753,12 @@
       question: Quel est le salaire ?
       titre: salaire
       avec:
-        - entreprise . chiffre d'affaires
         - rémunération . total
         - salaire . net
         - salaire . net après impôt
         - équivalent temps plein
-        - revenu net
+        - entreprise . chiffre d'affaires
+        - entreprise . rémunération totale du dirigeant
 
   références:
     Le salaire. Fixation et paiement: http://travail-emploi.gouv.fr/droit-du-travail/remuneration-et-participation-financiere/remuneration/article/le-salaire-fixation-et-paiement
@@ -2766,6 +2766,9 @@
 - nom: impôt
   icônes: 🏛️
   description: Cet ensemble de formules est un modèle ultra-simplifié de l'impôt sur le revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
+  titre: impôt sur le revenu
+  période: flexible
+  formule: impôt sur le revenu après décote
 
 - espace: impôt
   nom: revenu abattu
@@ -2882,28 +2885,26 @@
   formule: impôt sur le revenu après décote + CEHR
 
 - nom: revenu net de cotisations
+  résumé: Avant impôt
   période: flexible
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: |
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
   formule:
     somme:
       - contrat salarié . salaire . net
       - indépendant . revenu net de cotisations
       - auto entrepreneur . revenu net de cotisations
 
-- nom: revenu net d'impôt
-  titre: Revenu net de cotisations et d'impôt
-  période: flexible
-  formule: revenu net de cotisations - impôt . impôt sur le revenu à payer
-
-- nom: revenu net
-  titre: Revenu net
+- nom: revenu net après impôt
   format: euros
-  résumé: Après impôt sur le revenu
+  résumé: Versé sur le compte bancaire
   période: flexible
   question: Quel revenu voulez-vous toucher ?
   description: |
-    Il s'agit du revenu net de cotisations et d'impôts.
+    Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
-  formule: revenu net d'impôt - entreprise . charges non déductibles
+  formule: revenu net de cotisations - impôt
 
 - espace: entreprise
   nom: année d'activité
@@ -2935,22 +2936,14 @@
 
 - espace: entreprise
   nom: chiffre d'affaires
-  titre: chiffre d'affaires H.T.
-  question: Quel est votre chiffre d'affaires envisagé (H.T.) ?
+  titre: chiffre d'affaire (H.T.)
+  question: Quel est votre chiffre d'affaires envisagé ?
   résumé: Le montant des ventes réalisées
   période: flexible
   format: euros
-  formule:
-    variations:
-      - si: auto entrepreneur
-        alors:
-          inversion numérique:
-            avec:
-              - revenu net
-      - sinon: rémunération totale du dirigeant + charges
+  formule: rémunération totale du dirigeant + charges
 
 - espace: entreprise
-
   nom: chiffre d'affaires de société
   période: flexible
   formule:
@@ -3001,24 +2994,38 @@
 
 - espace: entreprise
   nom: rémunération totale du dirigeant
+  question: Quel montant pensez-vous dégager pour votre rémunération ?
+  résumé: Dépensé par l'entreprise
   format: euros
-  description: C'est la rémunération "super-brute" du dirigeant, qui inclut toutes les cotisations sociales à payer. C'est aussi la valeur monétaire du travail du dirigeant.
+  description:
+    C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
+    Cette rémunération "super-brute" inclut toutes les cotisations sociales à payer.
+
+    On peut aussi considérer que c'est la valeur monétaire du travail du dirigeant.
   période: flexible
   formule:
-    somme:
-      - contrat salarié . rémunération . total
-      - indépendant . revenu total du dirigeant
-      - auto entrepreneur . base des cotisations
+    variations:
+      - si: indépendant
+        alors: revenu net de cotisations + indépendant . cotisations et contributions
+      - si: auto entrepreneur
+        alors:
+          inversion numérique:
+            avec:
+              - auto entrepreneur . revenu net de cotisations
+              - revenu net après impôt
+              - entreprise . chiffre d'affaires
+      - si: contrat salarié . assimilé salarié
+        alors: contrat salarié . rémunération . total
 
 - espace: entreprise
   nom: charges
   résumé: Toutes les dépenses nécessaires à l'entreprise
-  question: Quelles sont les charges H.T. de l'entreprise (hors rémunération dirigeant) ?
+  question: Quelles sont les charges de l'entreprise ?
   description: |
 
-    Ce sont les dépenses de l'entreprise engagées dans l'intérêt de celle-ci, hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur, elles ne sont pas déductibles : l'entrepreneur les paie avec son salaire personnel net de cotisation et de revenu.
+    Ce sont les dépenses de l'entreprise engagées dans l'intérêt de celle-ci, hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur, elles ne sont pas déductibles du chiffre d'affaire encaissé.
 
-    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe.
+    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe (excepté pour les auto entrepreneurs en franchise de TVA)
 
     Par exemple, les charges peuvent être :
 
@@ -3035,14 +3042,6 @@
   période: flexible
   par défaut: 0
   format: euros
-
-- espace: entreprise
-  nom: charges non déductibles
-  description: |
-    Pour l'auto-entreprise, [les charges](/documentation/entreprise/charges) ne sont pas déductibles. Par exemple, un auto-entrepreneur qui achète un ordinateur pour les besoins de sa société, le fera avec son revenu net. Il aura donc payé des cotisations sociales et l'impôt sur le revenu sur son CA avant de pouvoir l'utiliser pour s'acheter ce bien.
-  applicable si: auto entrepreneur
-  formule: charges
-  période: flexible
 
 - espace: indépendant . cotisations et contributions
   nom: réduction ACRE
@@ -3070,26 +3069,30 @@
   nom: revenu net de cotisations
   formule: revenu professionnel - cotisations et contributions . CSG et CRDS [non déductible]
   période: flexible
+  résumé: Avant impôt
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  format: euros
 
 - espace: indépendant
   nom: revenu professionnel
-  résumé: Après cotisations et charges
-  question: Quel est votre revenu professionnel ?
-  période: flexible
-  format: euros
+  titre: revenu professionnel (net imposable)
   description: |
+    C'est le revenu net de cotisations déductibles du travailleur indépendant, qui sert de base au calcul des cotisations et de l'impôt pour les indépendants.
 
-    C'est le revenu net de cotisations du travailleur indépendant.
-
-  Attention, **notre calcul est fait au régime de croisière**:
-    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait relativement réduit de cotisations sociales. Il devra ensuite régulariser cette situation par rapport au revenu qu'il a vraiment touché.
+    Attention, **notre calcul est fait au régime de croisière**:
+    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait relativement réduit de cotisations sociales. Il devra ensuite régulariser cette situation par rapport au revenu qu'il a vraiment perçu.
 
     Il faut donc voir ce calcul comme *le montant qui devra de toute façon être payé* à court terme après 2 ans d'exercice.
+
+  période: flexible
+  format: euros
   formule:
     inversion numérique:
       avec:
-        - revenu total du dirigeant
-        - revenu net
+        - indépendant . revenu net de cotisations
+        - entreprise . rémunération totale du dirigeant
+        - revenu net après impôt
         - entreprise . chiffre d'affaires
 
 - espace: entreprise
@@ -3313,7 +3316,7 @@
   formule:
     somme:
       - cotisations à payer
-      - CSG et CRDS [déductible]
+      - CSG et CRDS
       - formation professionnelle
   format: euros
   période: flexible
@@ -3638,25 +3641,6 @@
         1.1: 0%
         1.4: 3.1%
 
-- espace: indépendant
-  nom: revenu total du dirigeant
-  question: Quel est le revenu total du dirigeant ?
-  résumé: Dépensé par l'entreprise
-  format: euros
-  période: flexible
-  formule:
-    somme:
-      - revenu professionnel
-      - cotisations et contributions
-
-- espace: indépendant
-  nom: impôt et contributions non déductibles
-  période: flexible
-  formule:
-    somme:
-      - impôt . impôt sur le revenu à payer
-      - cotisations et contributions . CSG et CRDS [non déductible]
-
 - nom: auto entrepreneur
   icônes: 🚶
   par défaut: non
@@ -3697,8 +3681,10 @@
 
 - espace: auto entrepreneur
   nom: revenu net de cotisations
-  titre: Revenu net auto-entrepreneur
-  formule: base des cotisations - cotisations et contributions
+  résumé: Avant impôt
+  question: Quel revenu avant impôt voulez-vous toucher ?
+  description: Il s'agit du revenu net de cotisations et de charges, avant le paiement de l'impôt sur le revenu.
+  formule: entreprise . rémunération totale du dirigeant - cotisations et contributions
   période: flexible
   format: euros
 
@@ -3898,6 +3884,7 @@
 
 - espace: auto entrepreneur . impôt
   nom: revenu abattu
+  titre: revenu abattu auto-entrepreneur
   période: flexible
   formule: base des cotisations - abattement
 - nom: protection sociale
@@ -4115,7 +4102,7 @@
   période: année
   formule:
     le maximum de:
-      - indépendant . revenu net de cotisations
+      - indépendant . revenu professionnel
       - auto entrepreneur . impôt . revenu abattu
       - contrat salarié . rémunération . brut
 

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -30,7 +30,8 @@ contrat salarié . indemnité kilométrique vélo . active:
   titre.en: active bicycle allowance
   titre.fr: indemnité vélo active
   question.en: >-
-    Does the employee take advantage of the bicycle mileage allowance to commute to work?
+    Does the employee take advantage of the bicycle mileage allowance to commute
+    to work?
   question.fr: >-
     Le salarié profite-t-il de l'indemnité kilométrique vélo pour se rendre au
     travail ?
@@ -41,19 +42,17 @@ contrat salarié . indemnité kilométrique vélo . active:
     The employer has the choice to implement it in his company.
 
 
-    To benefit from the €200 compensation deducted in this calculation, the employee
-    must cycle 4km (round trip) to work each day
-    worked.
+    To benefit from the €200 compensation deducted in this calculation, the
+    employee must cycle 4km (round trip) to work each day worked.
 
 
-    This allowance can be combined with the reimbursement of transport costs
-    if it is a bike trip to a transport station.
+    This allowance can be combined with the reimbursement of transport costs if
+    it is a bike trip to a transport station.
 
 
     This allowance is exempt from social security contributions and tax on the
     income. To pay a salary bonus equivalent to his employee without this
-    device, **the employer should pay nearly 500€ for a salary
-    median**.
+    device, **the employer should pay nearly 500€ for a salary median**.
   description.fr: >
     Cette indemnité n'est pour l'instant pas obligatoire.
 
@@ -677,18 +676,17 @@ contrat salarié . avantages en nature . montant:
     atteint.
 contrat salarié . avantages en nature . ntic:
   description.en: >
-    The private use of the NICT tools made available as part of
-    the permanent professional activity constitutes an advantage in kind.
+    The private use of the NICT tools made available as part of the permanent
+    professional activity constitutes an advantage in kind.
 
     This benefit is included in the basis for calculating Security contributions
     and unemployment insurance.
 
-    The reality of private use can result either from a written document (contract
-    work, company agreement, internal regulations, correspondence from the
-    management of the company allowing the employee to make private use of the
-    tools), or the existence of detailed invoices to establish a
-    for private use.
-
+    The reality of private use can result either from a written document
+    (contract work, company agreement, internal regulations, correspondence from
+    the management of the company allowing the employee to make private use of
+    the tools), or the existence of detailed invoices to establish a for private
+    use.
   description.fr: >
     L’usage privé des outils NTIC mis à disposition dans le cadre de l’activité
     professionnelle à titre permanent est constitutif d’un avantage en nature.
@@ -702,18 +700,19 @@ contrat salarié . avantages en nature . ntic:
     outils), soit de l’existence de factures détaillées permettant d’établir une
     utilisation privée.
   question.en: >
-    Does the employer provide free tools from NICTs (computer, telephone, tablet, etc.)?
+    Does the employer provide free tools from NICTs (computer, telephone,
+    tablet, etc.)?
   question.fr: >
     L'employeur fournit-il gratuitement un outils issus des NTIC (ordinateur,
     téléphone, tablette, etc.) ?
   titre.en: nict
   titre.fr: ntic
 contrat salarié . avantages en nature . autres:
-  question.en: >
+  question.en: |
     Are there any other advantages in kind (housing, vehicle, discount...)?
   question.fr: |
     Y a-t-il d'autres avantages en natures (logement, véhicule, réduction...) ?
-  titre.en: 'others'
+  titre.en: others
   titre.fr: autres
 contrat salarié . avantages en nature . autres . montant:
   question.en: |
@@ -727,23 +726,21 @@ contrat salarié . avantages en nature . autres . montant:
   titre.en: amount
   titre.fr: montant
 contrat salarié . avantages en nature . ntic . montant:
-  titre.en: 'NICTs tools'
+  titre.en: NICTs tools
   titre.fr: outils NTIC
   description.en: >
-    For benefits in kind such as NICTs (computers, smartphones,
-    tablets...), there is an annual flat-rate assessment corresponding to
-    10% of the purchase price. For example, for a phone bought at 850€ TTC with
-    a subscription of 30€ / month, the benefit in kind to be transferred to the newsletter
-    of pay will be:
+    For benefits in kind such as NICTs (computers, smartphones, tablets...),
+    there is an annual flat-rate assessment corresponding to 10% of the purchase
+    price. For example, for a phone bought at 850€ TTC with a subscription of
+    30€ / month, the benefit in kind to be transferred to the newsletter of pay
+    will be:
 
 
     ```
 
     10% x (850€ + (30€ x 12 months)) ] / 12 months
 
-    ```
-    or 10,08€
-
+    ``` or 10,08€
   description.fr: >
     Pour les avantages en nature de type NTIC (ordinateurs, smartphones,
     tablettes...), il y a une évaluation forfaitaire annuelle correspondant à
@@ -773,17 +770,19 @@ contrat salarié . avantages en nature . ntic . coût appareils:
     "\U0001F4F1✨ (haut de gamme)": 850
     "\U0001F4BB": 1200
     "\U0001F4BB + \U0001F4F1✨": 2050
-  titre.en: 'devices cost'
+  titre.en: devices cost
   titre.fr: coût appareils
 contrat salarié . avantages en nature . ntic . abonnements:
   question.en: What is the cost of the subscription price charged by the employer?
-  question.fr: Quel est le coût de l'abonnement prix en charge par l'employeur ?
-  suggestions.fr:
-    aucun: 0
-    standard: 20
-    international: 40
+  question.fr: >-
+    Quel est le coût de l'abonnement (forfait mobile, etc.) pris en charge par
+    l'employeur ?
   suggestions.en:
     none: 0
+    standard: 20
+    international: 40
+  suggestions.fr:
+    aucun: 0
     standard: 20
     international: 40
   titre.en: subscription
@@ -794,14 +793,15 @@ contrat salarié . avantages en nature . nourriture:
   question.fr: |
     L'employeur fournit-il gratuitement les repas ?
   description.en: >
-    Lunch vouchers("tickets restaurants") are not considered as a benefit in kind but as a reimbursement of expenses.
+    Lunch vouchers("tickets restaurants") are not considered as a benefit in
+    kind but as a reimbursement of expenses.
   description.fr: >
-    Les tickets restaurants ne sont pas considéré comme un avantage en nature
+    Les tickets restaurants ne sont pas considérés comme un avantage en nature
     mais comme un remboursement de frais.
-  titre.en: 'food'
+  titre.en: food
   titre.fr: nourriture
 contrat salarié . avantages en nature . nourriture . montant:
-  titre.en: 'food'
+  titre.en: food
   titre.fr: nourriture
 ? contrat salarié . avantages en nature . nourriture . montant forfaitaire d'un repas
 : titre.en: fixed amount of a meal
@@ -820,12 +820,11 @@ contrat salarié . avantages en nature . nourriture . repas par mois:
   titre.en: meal per month
   titre.fr: repas par mois
 contrat salarié . avantages en nature . nourriture . dans la restauration:
-  question.en: >-
-    Is it for an employee working in a hotel, café, restaurant and similar?
+  question.en: 'Is it for an employee working in a hotel, café, restaurant and similar?'
   question.fr: >-
     Est-ce pour un salarié travaillant dans un hôtel, café, restaurant et
     assimilés ?
-  titre.en:  in the catering business
+  titre.en: in the catering business
   titre.fr: dans la restauration
 contrat salarié . indemnités salarié:
   titre.en: Employee benefits
@@ -900,6 +899,11 @@ contrat salarié . rémunération . net imposable . exonérations:
   titre.en: exemptions
   titre.fr: exonérations
 contrat salarié . prime d'impatriation:
+  description.en: >-
+    The impatriation bonus is a part of the remuneration exempt from income tax.
+  description.fr: >-
+    La prime d'impatriation est une partie de la rémunération exonérée d'impôt
+    sur le revenu.
   titre.en: impatriation bonus
   titre.fr: prime d'impatriation
 contrat salarié . salaire . net:
@@ -1136,11 +1140,12 @@ entreprise . association non lucrative:
   titre.fr: association non lucrative
 entreprise . établissement bancaire:
   description.en: >-
-    The company is a banking, financial or insurance institution. It is not subject to VAT.
+    The company is a banking, financial or insurance institution. It is not
+    subject to VAT.
   description.fr: >-
     L'entreprise est un établissement bancaire, financier ou d'assurance. Elle
     est non assujettie à la TVA.
-  question.en: Is it a banking, financial or insurance institution?
+  question.en: 'Is it a banking, financial or insurance institution?'
   question.fr: "S'agit-il d'un établissement bancaire, financier, d'assurance ?"
   titre.en: banking institution
   titre.fr: établissement bancaire
@@ -1622,18 +1627,18 @@ contrat salarié . régime des impatriés:
   question.en: Does the employee benefit from the impatriate scheme?
   question.fr: Le salarié bénéficie-t-il du régime des impatriés ?
   description.en: >
-    If you are an employee or a director with the 'assimilé-salarié' social and fiscal scheme,
-    and if you have been called upon by a foreign company to take up employment in a
-    company established in France with a link to the first or if you have
-    been directly recruited abroad by a company established in France,
-    you can benefit from the impatriate scheme.
+    If you are an employee or a director with the 'assimilé-salarié' social and
+    fiscal scheme, and if you have been called upon by a foreign company to take
+    up employment in a company established in France with a link to the first or
+    if you have been directly recruited abroad by a company established in
+    France, you can benefit from the impatriate scheme.
 
 
     In addition, you must not have been domiciled in France for tax purposes on
-    five calendar years preceding that in which he takes up his duties and set in
-    France your tax domicile as soon as you take up your duties.
+    five calendar years preceding that in which he takes up his duties and set
+    in France your tax domicile as soon as you take up your duties.
   description.fr: >
-    Si vous êtes salarié ou dirigeant assimilé-salarié, et si vous avez été
+    Si vous êtes salarié ou dirigeant fiscalement assimilé, et si vous avez été
     appelé par une entreprise étrangère à occuper un emploi dans une entreprise
     établie en France ayant un lien avec la première ou si vous avez été
     directement recruté à l’étranger par une entreprise établie en France, vous
@@ -1643,6 +1648,12 @@ contrat salarié . régime des impatriés:
     Vous devez en outre ne pas avoir été fiscalement domicilié en France les
     cinq années civiles précédant celle de la prise de fonctions et fixer en
     France votre domicile fiscal dès votre prise de fonctions.
+
+
+    Les impatriés sont exonérés de cotisations retraite (régime de base et
+    complémentaire) à condition de justifier d'une contribution minimale versée
+    par ailleurs (par exemple dans une caisse de retraite ou un fond de pension
+    étranger). Ils n’acquièrent aucun droit pendant la durée d’exonération.
   titre.en: impatriate scheme
   titre.fr: régime des impatriés
 entreprise . taxe sur les salaires . barème:
@@ -1673,6 +1684,23 @@ contrat salarié . versement transport:
 contrat salarié . vieillesse:
   description.en: Contribution to the basic pension plan of employees.
   description.fr: Cotisation au régime de retraite de base des salariés.
+  contrôles.fr:
+    - si: régime des impatriés
+      niveau: information
+      message: >
+        Pour bénéficier de l'exonération de cotisations vieillesse, il faut
+        remplir les conditions suivantes :
+
+        - Pouvoir justifier d'une contribution minimale versée ailleurs pour une
+        assurance vieilllesse
+
+        - De ne pas avoir été affiliés, au cours des cinq années civiles
+        précédant celle de leur prise de fonctions, à un régime français
+        obligatoire d'assurance vieillesse, sauf pour des activités accessoires,
+        de caractère saisonnier ou pour les études.
+
+        [Voir
+        plus](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=F5CFB7C90D1D1F529A2CDC9FFD20BD6E.tplgfr34s_3?idSectionTA=LEGISCTA000038510929&cidTexte=LEGITEXT000006073189&dateTexte=20190626)
   titre.en: Basic pension contribution
   titre.fr: vieillesse
 contrat salarié . forfait social:
@@ -1697,7 +1725,7 @@ impôt:
     Cet ensemble de formules est un modèle ultra-simplifié de l'impôt sur le
     revenu, qui ne prend en compte que l'abattement 10%, le barème et la décôte.
   titre.en: income tax
-  titre.fr: impôt
+  titre.fr: impôt sur le revenu
 impôt . revenu abattu:
   description.en: >
     The tax is calculated on a reduced income: it is reduced (for example by
@@ -1758,30 +1786,45 @@ impôt . impôt sur le revenu après décote:
     réduire l'impôt des bas revenus.
   titre.en: income tax after discount
   titre.fr: impôt sur le revenu après décote
+impôt . revenu fiscal de référence:
+  description.en: >-
+    The reference tax income corresponds to the household's reduced income adjusted with a quotient mechanism and increased by a certain number of exemptions.
+    The latter are reinstated in the calculation.
+  description.fr: >-
+    le revenu fiscal de référence correspond au revenu abattu du foyer ajusté  avec un mécanisme de quotient et majoré d'un certains nombre d'exonérations.
+    Ces dernières sont réintégrées dans le calcul.
+  titre.en: reference taxable income
+  titre.fr: revenu fiscal de référence
 impôt . CEHR:
   titre.fr: CEHR
 impôt . impôt sur le revenu à payer:
   titre.en: income tax
   titre.fr: impôt sur le revenu
 revenu net de cotisations:
+  résumé.en: 'Before taxes'
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
-revenu net d'impôt:
-  titre.en: Net income after contributions and taxes
-  titre.fr: Revenu net de cotisations et d'impôt
-revenu net:
-  titre.en: Net income
-  titre.fr: Revenu net
-  résumé.en: After income tax
-  résumé.fr: Après impôt sur le revenu
-  question.en: How much income do you plan to receive ?
+revenu net après impôt:
+  résumé.en: Paid into the bank account
+  résumé.fr: Versé sur le compte bancaire
+  question.en: What income do you want to receive?
   question.fr: Quel revenu voulez-vous toucher ?
   description.en: |
     This is the income net of contributions and taxes.
     In other words, that's what you get in the end from your bank account.
   description.fr: |
-    Il s'agit du revenu net de cotisations et d'impôts.
+    Il s'agit du revenu net de charges, cotisations et d'impôts.
     Autrement dit, c'est ce que vous gagnez à la fin sur votre compte en banque.
+  titre.en: Net income after tax
+  titre.fr: revenu net après impôt
 entreprise . année d'activité:
   question.en: How old is the company in years of activity?
   question.fr: Quel est l'âge de l'entreprise en année d'activité ?
@@ -1821,10 +1864,10 @@ entreprise . année d'activité . régime de croisière:
   titre.en: fourth year or more
   titre.fr: régime de croisière
 entreprise . chiffre d'affaires:
-  titre.en: Turnover (excluding VAT)
-  titre.fr: chiffre d'affaires H.T.
-  question.en: What is your expected turnover (excluding tax)?
-  question.fr: Quel est votre chiffre d'affaires envisagé (H.T.) ?
+  titre.en: Turnover
+  titre.fr: chiffre d'affaire (H.T.)
+  question.en: What is your expected turnover ?
+  question.fr: Quel est votre chiffre d'affaires envisagé ?
   résumé.en: The amount of sales made
   résumé.fr: Le montant des ventes réalisées
 entreprise . chiffre d'affaires de société:
@@ -1862,23 +1905,29 @@ entreprise . charges dont rémunération dirigeant:
   titre.en: expenses of which executive compensation
   titre.fr: charges dont rémunération dirigeant
 entreprise . rémunération totale du dirigeant:
+  question.en: How much do you think you will make available for your remuneration?
+  question.fr: Quel montant pensez-vous dégager pour votre rémunération ?
+  résumé.en: Spent by the company
+  résumé.fr: Dépensé par l'entreprise
   description.en: >-
-    This is the "super gross" remuneration of the manager, which includes all
-    the social security contributions to be paid. It is also the monetary value
-    of the work of the leader.
+    This is what the company spends in total for the director income.
+    This "super gross" remuneration includes all social security contributions to be paid.
+
+    It can also be considered as the monetary value of the director's work.
   description.fr: >-
-    C'est la rémunération "super-brute" du dirigeant, qui inclut toutes les
-    cotisations sociales à payer. C'est aussi la valeur monétaire du travail du
+    C'est ce que l'entreprise dépense en tout pour la rémunération du dirigeant.
+    Cette rémunération "super-brute" inclut toutes les cotisations sociales à
+    payer.
+
+    On peut aussi considérer que c'est la valeur monétaire du travail du
     dirigeant.
-  titre.en: Total compensation of the executive
+  titre.en: Director total income
   titre.fr: rémunération totale du dirigeant
 entreprise . charges:
   résumé.en: All the expenses necessary for the company"
   résumé.fr: Toutes les dépenses nécessaires à l'entreprise
   question.en: What are the company's expenses before tax (excluding remuneration manager)?
-  question.fr: >-
-    Quelles sont les charges H.T. de l'entreprise (hors rémunération dirigeant)
-    ?
+  question.fr: Quelles sont les charges de l'entreprise ?
   description.en: >
     These are the company's expenses incurred in the company's interest,
     excluding executive compensation. For companies and businesses excluding
@@ -1916,12 +1965,11 @@ entreprise . charges:
     hors rémunération du dirigeant. Pour les sociétés et entreprises hors auto
     entrepreneur, ces charges sont dites déductibles du résultat : l'entreprise
     ne paiera pas de cotisations ou impôt dessus. Pour l'auto entrepreneur,
-    elles ne sont pas déductibles : l'entrepreneur les paie avec son salaire
-    personnel net de cotisation et de revenu.
+    elles ne sont pas déductibles du chiffre d'affaire encaissé.
 
 
-    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors
-    taxe.
+    Nous ne traitons pas encore la TVA : les charges sont à renseigner hors taxe
+    (excepté pour les auto entrepreneurs en franchise de TVA)
 
 
     Par exemple, les charges peuvent être :
@@ -1945,21 +1993,6 @@ entreprise . charges:
     charge sans immobilisation.
   titre.en: expenses
   titre.fr: charges
-entreprise . charges non déductibles:
-  description.en: >
-    For the auto-enterprise,[the charges](/documentation/entreprise/charges) are
-    not deductible. For example, an auto-entrepreneur who buys a computer for
-    the needs of his company, will do so with his net income. He will therefore
-    have paid social security contributions and income tax on its turnover
-    before you can use it to buy this property.
-  description.fr: >
-    Pour l'auto-entreprise, [les charges](/documentation/entreprise/charges) ne
-    sont pas déductibles. Par exemple, un auto-entrepreneur qui achète un
-    ordinateur pour les besoins de sa société, le fera avec son revenu net. Il
-    aura donc payé des cotisations sociales et l'impôt sur le revenu sur son CA
-    avant de pouvoir l'utiliser pour s'acheter ce bien.
-  titre.en: non-deductible expenses
-  titre.fr: charges non déductibles
 indépendant . cotisations et contributions . réduction ACRE:
   titre.en: ACRE reduction
   titre.fr: réduction ACRE
@@ -1967,20 +2000,44 @@ indépendant . cotisations et contributions . réduction ACRE . taux ACRE:
   titre.en: ACRE rate
   titre.fr: taux ACRE
 indépendant . revenu net de cotisations:
+  résumé.en: Before taxes
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >-
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >-
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
   titre.en: net contribution income
   titre.fr: revenu net de cotisations
 indépendant . revenu professionnel:
-  résumé.en: After contributions and expenses
-  résumé.fr: Après cotisations et charges
-  question.en: What is your professional income ?
-  question.fr: Quel est votre revenu professionnel ?
-  description.en: |
-    C'est le revenu net de cotisations du travailleur indépendant.
-  description.fr: |
-
-    C'est le revenu net de cotisations du travailleur indépendant.
   titre.en: Professional income
-  titre.fr: revenu professionnel
+  titre.fr: revenu professionnel (net imposable)
+  description.en: >
+    It is the net income of the self-employed person from deductible contributions that is used as the basis for calculating contributions and taxes for the self-employed.
+
+    Attention, **our calculation is valid for a standard scheme**:
+
+    The self-employed person who starts out will pay a fixed contributions during his first months. He will then have to regularize this situation in relation to the income he actually received.
+
+    This calculation should therefore be seen as *the amount that should in any case be paid* in the short term after several months of activity.
+
+  description.fr: >
+    C'est le revenu net de cotisations déductibles du travailleur indépendant,
+    qui sert de base au calcul des cotisations et de l'impôt pour les
+    indépendants.
+
+
+    Attention, **notre calcul est fait au régime de croisière**:
+
+    l'indépendant qui se lance paiera pendant ses 2 premières années un forfait
+    relativement réduit de cotisations sociales. Il devra ensuite régulariser
+    cette situation par rapport au revenu qu'il a vraiment perçu.
+
+
+    Il faut donc voir ce calcul comme *le montant qui devra de toute façon être
+    payé* à court terme après 2 ans d'exercice.
 entreprise . catégorie d'activité:
   question.en: What is your category of activity?
   question.fr: Quelle est votre catégorie d'activité ?
@@ -2157,7 +2214,8 @@ entreprise . catégorie d'activité . libérale règlementée:
     - si: libérale règlementée
       niveau: avertissement
       message: >
-        Attention, the simulator is not yet complete for the regulated liberal professions.
+        Attention, the simulator is not yet complete for the regulated liberal
+        professions.
   contrôles.fr:
     - si: libérale règlementée
       niveau: avertissement
@@ -2245,7 +2303,11 @@ indépendant . cotisations et contributions:
   titre.fr: cotisations et contributions
 entreprise . rattachement libéral règlementé:
   description.en: >
-    The unregulated liberal companies created were linked to the regulated ones for the calculation of social security contributions. Since 2018 this is no longer the case for auto-entrepreneurs (2019 for sole proprietorships). They are now attached to the artisan-merchants, so they depend on the social security of the self-employed ("indépendant").
+    The unregulated liberal companies created were linked to the regulated ones
+    for the calculation of social security contributions. Since 2018 this is no
+    longer the case for auto-entrepreneurs (2019 for sole proprietorships). They
+    are now attached to the artisan-merchants, so they depend on the social
+    security of the self-employed ("indépendant").
   description.fr: >
     Les entreprises libérales non règlementées créées étaient rattachées aux
     règlementées pour le calcul des cotisations sociales. Depuis 2018 ce n'est
@@ -2320,16 +2382,6 @@ indépendant . cotisations et contributions . formation professionnelle:
 ? indépendant . cotisations et contributions . cotisations . allocations familiales
 : titre.en: family allowances
   titre.fr: allocations familiales
-indépendant . revenu total du dirigeant:
-  question.en: What is the total income of the executive?
-  question.fr: Quel est le revenu total du dirigeant ?
-  résumé.en: Spent by the company
-  résumé.fr: Dépensé par l'entreprise
-  titre.en: total income of the executive
-  titre.fr: revenu total du dirigeant
-indépendant . impôt et contributions non déductibles:
-  titre.en: taxes and non-deductible contributions
-  titre.fr: impôt et contributions non déductibles
 auto entrepreneur:
   question.en: Is the activity carried out in a auto-enterprise?
   question.fr: L'activité est-elle exercée en auto-entreprise ?
@@ -2382,8 +2434,17 @@ auto entrepreneur . plafond:
   titre.en: upper limit
   titre.fr: plafond
 auto entrepreneur . revenu net de cotisations:
-  titre.en: Auto-entrepreneur net income
-  titre.fr: Revenu net auto-entrepreneur
+  résumé.en: Before taxes
+  résumé.fr: Avant impôt
+  question.en: What pre-tax income do you want to receive?
+  question.fr: Quel revenu avant impôt voulez-vous toucher ?
+  description.en: >-
+    This is the income net of contributions and expenses, before the payment of income tax.
+  description.fr: >-
+    Il s'agit du revenu net de cotisations et de charges, avant le paiement de
+    l'impôt sur le revenu.
+  titre.en: Net contribution income
+  titre.fr: revenu net de cotisations
 auto entrepreneur . cotisations et contributions:
   titre.en: Contributions
   titre.fr: cotisations et contributions
@@ -2454,15 +2515,17 @@ entreprise . ACCRE obtenu:
   titre.en: ACCRE obtained
   titre.fr: ACCRE obtenu
 auto entrepreneur . cotisations et contributions . cotisations . taux ACRE:
-  titre.en: >
+  titre.en: |
     "ACRE" rate
   titre.fr: taux ACRE
 auto entrepreneur . cotisations et contributions . cotisations . réduction ACRE:
-  titre.en: >
+  titre.en: |
     "ACRE" reduction
   titre.fr: réduction ACRE
   description.en: >-
-      In some cases, this rate may reduce the amount of social security contributions paid by the auto-entrepreneur to help him/her in his/her first year of activity.
+    In some cases, this rate may reduce the amount of social security
+    contributions paid by the auto-entrepreneur to help him/her in his/her first
+    year of activity.
   description.fr: >-
     Ce taux peut dans certains cas réduire le montant des cotisations sociales
     de l'auto-entrepreneur pour l'aider dans ses premières année d'activité.
@@ -2490,7 +2553,7 @@ auto entrepreneur . impôt:
   titre.fr: impôt
 auto entrepreneur . impôt . revenu abattu:
   titre.en: reduced income
-  titre.fr: revenu abattu
+  titre.fr: revenu abattu auto-entrepreneur
 protection sociale:
   description.en: >
     Social protection in France is composed of 5 main branches: sickness,
@@ -2592,7 +2655,8 @@ protection sociale . retraite . complémentaire sécurité des indépendants:
   titre.fr: prix d'achat du point
 protection sociale . santé:
   résumé.en: >-
-    Covers most everyday health care and 100% of serious illnesses such as hospital stays.
+    Covers most everyday health care and 100% of serious illnesses such as
+    hospital stays.
   résumé.fr: >-
     Couvre la plupart des soins de santé de la vie quotidienne et 100 % des
     maladies graves comme les séjours à l'hôpital.

--- a/source/règles/sasu.yaml
+++ b/source/règles/sasu.yaml
@@ -58,6 +58,6 @@
   période: flexible
   formule: chiffre affaires * répartition salaire sur dividendes
 
-- nom: revenu net
+- nom: revenu net après impôt
   période: flexible
   formule: contrat salarié . salaire . net après impôt + dividendes . net

--- a/test/indépendants.test.js
+++ b/test/indépendants.test.js
@@ -3,7 +3,7 @@ import Syso from '../source/engine/index'
 
 describe('indeps', function() {
 	it('should compute income for indépendant', function() {
-		let values = Syso.evaluate(['revenu net'], {
+		let values = Syso.evaluate(['revenu net après impôt'], {
 			"entreprise . chiffre d'affaires": 70000,
 			'entreprise . charges': 1000,
 			indépendant: 'oui',

--- a/test/library.test.js
+++ b/test/library.test.js
@@ -64,7 +64,7 @@ describe('library', function() {
 		)
 
 		let [revenuDisponible, dividendes] = Syso.evaluate(
-			['revenu net', 'dividendes . net'],
+			['revenu net après impôt', 'dividendes . net'],
 			{
 				'contrat salarié . salaire . net après impôt': salaireNetAprèsImpôt,
 				'chiffre affaires': CA


### PR DESCRIPTION
Suite aux retours utilisateurs rassemblé par l'Acoss (cc Agnes Nardon) :

- Uniformise les nom de tous les champs entre les différents simulateurs
- Pour la comparaison des régimes, on ne parle plus du CA, mais du montant dégagé pour la rémunération du dirigeant (plus clair)
- Supprime la notion de charge pour les auto-entrepreneur
- Tant que la simulation complète de l'entreprise n'est pas développé (cf #562), on enlève la notion de chiffre d'affaires des simulateurs de revenus. Elle est en effet triviale à calculer (rem total + charges) et laisse perplexe les utilisateurs même les plus renseignés

Supersede #564 