### PR TITLE
:bug: Gros bug de pourcentage sur le taux ATMP entreprises > 150 sal

### DIFF
--- a/source/components/conversation/select/SelectTauxRisque.js
+++ b/source/components/conversation/select/SelectTauxRisque.js
@@ -14,7 +14,7 @@ class ReactSelectWrapper extends Component {
 			submit,
 			options,
 			submitOnChange = option => {
-				option.text = option['Taux net'].replace(',', '.')
+				option.text = +option['Taux net'].replace(',', '.') / 100
 				onChange(option.text)
 				submit()
 			},


### PR DESCRIPTION
Fait suite à un changement de la formule : avec la gestion des pourcentages, plus besoin de manipuler des 3.4 puis les diviser par cent... mais j'ai oublié de convertir le fichier de taux d'entrées.