### PR TITLE
Ajout d'une règle "rend non applicable"

### DIFF
--- a/source/components/RuleLink.js
+++ b/source/components/RuleLink.js
@@ -1,13 +1,13 @@
 /* @flow */
 import withColours from 'Components/utils/withColours'
 import withSitePaths from 'Components/utils/withSitePaths'
+import { encodeRuleName, nameLeaf } from 'Engine/rules'
 import { compose } from 'ramda'
 import React from 'react'
 import { Link } from 'react-router-dom'
 import './RuleLink.css'
 import type { Règle } from 'Types/RegleTypes'
 import type { ThemeColours } from 'Components/utils/withColours'
-import { encodeRuleName } from 'Engine/rules'
 
 type Props = Règle & {
 	sitePaths: Object,
@@ -29,7 +29,7 @@ const RuleLink = ({
 			to={newPath}
 			className="rule-link"
 			style={{ color: colour, ...style }}>
-			{title}
+			{title || nameLeaf(dottedName)}
 		</Link>
 	)
 }

--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -1,8 +1,11 @@
 import classNames from 'classnames'
-import { makeJsx } from 'Engine/evaluation'
-import { any, compose, identity, path } from 'ramda'
 import { React, T } from 'Components'
+import withSitePaths from 'Components/utils/withSitePaths'
+import { makeJsx } from 'Engine/evaluation'
+import { encodeRuleName } from 'Engine/rules'
+import { any, compose, identity, path } from 'ramda'
 import { Trans, withTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
 import './Algorithm.css'
 // The showValues prop is passed as a context. It used to be delt in CSS (not(.showValues) display: none), both coexist right now
 import { ShowValuesProvider } from './ShowValuesContext'
@@ -35,6 +38,32 @@ let Conditions = ({
 	) : null
 }
 
+let DisabledBy = withSitePaths(({ isDisabledBy, sitePaths }) => {
+	return (
+		isDisabledBy.length > 0 && (
+			<>
+				<h3>Exception : </h3>
+				<p>
+					Cette règle ne s'applique pas pour le{' '}
+					{isDisabledBy.map(r => (
+						<Link
+							style={{
+								textDecoration: 'underline'
+							}}
+							to={
+								sitePaths.documentation.index +
+								'/' +
+								encodeRuleName(r.dottedName)
+							}>
+							{r.title || r.name}
+						</Link>
+					))}
+				</p>
+			</>
+		)
+	)
+})
+
 export default compose(withTranslation())(
 	class Algorithm extends React.Component {
 		render() {
@@ -64,6 +93,7 @@ export default compose(withTranslation())(
 								</section>
 							)}
 						</ShowValuesProvider>
+						<DisabledBy {...rule} />
 					</section>
 				</div>
 			)

--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -8,18 +8,20 @@ import './Algorithm.css'
 import { ShowValuesProvider } from './ShowValuesContext'
 
 let Conditions = ({
+	'rendu non applicable': disabledBy,
 	parentDependency,
 	'applicable si': applicable,
 	'non applicable si': notApplicable
 }) => {
 	let listElements = [
 		parentDependency?.nodeValue === false && (
-			<li key="parentDependency">
-				<span css="background: yellow">
-					<T>Désactivée</T>
-				</span>{' '}
-				<T>car dépend de</T> {makeJsx(parentDependency)}
-			</li>
+			<ShowIfDisabled dependency={parentDependency} key="parent dependency" />
+		),
+		...disabledBy?.explanation?.isDisabledBy?.map(
+			(dependency, i) =>
+				dependency?.nodeValue === true && (
+					<ShowIfDisabled dependency={dependency} key={`dependency ${i}`} />
+				)
 		),
 		applicable && <li key="applicable">{makeJsx(applicable)}</li>,
 		notApplicable && <li key="non applicable">{makeJsx(notApplicable)}</li>
@@ -33,6 +35,17 @@ let Conditions = ({
 			<ul>{listElements}</ul>
 		</section>
 	) : null
+}
+
+function ShowIfDisabled({ dependency }) {
+	return (
+		<li>
+			<span css="background: yellow">
+				<T>Désactivée</T>
+			</span>{' '}
+			<T>car dépend de</T> {makeJsx(dependency)}
+		</li>
+	)
 }
 
 export default compose(withTranslation())(

--- a/source/components/rule/Algorithm.js
+++ b/source/components/rule/Algorithm.js
@@ -1,11 +1,8 @@
 import classNames from 'classnames'
 import { React, T } from 'Components'
-import withSitePaths from 'Components/utils/withSitePaths'
 import { makeJsx } from 'Engine/evaluation'
-import { encodeRuleName } from 'Engine/rules'
 import { any, compose, identity, path } from 'ramda'
 import { Trans, withTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
 import './Algorithm.css'
 // The showValues prop is passed as a context. It used to be delt in CSS (not(.showValues) display: none), both coexist right now
 import { ShowValuesProvider } from './ShowValuesContext'
@@ -38,32 +35,6 @@ let Conditions = ({
 	) : null
 }
 
-let DisabledBy = withSitePaths(({ isDisabledBy, sitePaths }) => {
-	return (
-		isDisabledBy.length > 0 && (
-			<>
-				<h3>Exception : </h3>
-				<p>
-					Cette règle ne s'applique pas pour le{' '}
-					{isDisabledBy.map(r => (
-						<Link
-							style={{
-								textDecoration: 'underline'
-							}}
-							to={
-								sitePaths.documentation.index +
-								'/' +
-								encodeRuleName(r.dottedName)
-							}>
-							{r.title || r.name}
-						</Link>
-					))}
-				</p>
-			</>
-		)
-	)
-})
-
 export default compose(withTranslation())(
 	class Algorithm extends React.Component {
 		render() {
@@ -93,7 +64,7 @@ export default compose(withTranslation())(
 								</section>
 							)}
 						</ShowValuesProvider>
-						<DisabledBy {...rule} />
+						{makeJsx(rule['rendu non applicable'])}
 					</section>
 				</div>
 			)

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -24,6 +24,7 @@ import {
 } from 'Selectors/analyseSelectors'
 import Animate from 'Ui/animate'
 import { AttachDictionary } from '../AttachDictionary'
+import RuleLink from '../RuleLink'
 import { Markdown } from '../utils/markdown'
 import Algorithm from './Algorithm'
 import Examples from './Examples'
@@ -62,7 +63,6 @@ export default compose(
 				flatRule = findRuleByDottedName(flatRules, dottedName)
 			let { type, name, title, description, question, ns, icon } = flatRule,
 				namespaceRules = findRuleByNamespace(flatRules, dottedName)
-
 			let displayedRule = analysedExample || analysedRule
 
 			return (
@@ -164,9 +164,21 @@ export default compose(
 										rule={displayedRule}
 										showValues={valuesToShow || currentExample}
 									/>
+									{displayedRule['rend non applicable'] && (
+										<section id="non-applicable">
+											<h3>Rend non applicable : </h3>
+											<ul>
+												{displayedRule['rend non applicable'].map(ruleName => (
+													<li key={ruleName}>
+														<RuleLink dottedName={ruleName} />
+													</li>
+												))}
+											</ul>
+										</section>
+									)}
 									{flatRule.note && (
 										<section id="notes">
-											<h3>Note: </h3>
+											<h3>Note : </h3>
 											<Markdown source={flatRule.note} />
 										</section>
 									)}

--- a/source/components/rule/Rule.js
+++ b/source/components/rule/Rule.js
@@ -1,4 +1,5 @@
 import { T } from 'Components'
+import PeriodSwitch from 'Components/PeriodSwitch'
 import withColours from 'Components/utils/withColours'
 import withLanguage from 'Components/utils/withLanguage'
 import withSitePaths from 'Components/utils/withSitePaths'
@@ -31,7 +32,6 @@ import Examples from './Examples'
 import RuleHeader from './Header'
 import References from './References'
 import './Rule.css'
-import PeriodSwitch from 'Components/PeriodSwitch'
 
 let LazySource = React.lazy(() => import('./RuleSource'))
 
@@ -166,7 +166,9 @@ export default compose(
 									/>
 									{displayedRule['rend non applicable'] && (
 										<section id="non-applicable">
-											<h3>Rend non applicable : </h3>
+											<h3>
+												<T>Rend non applicable les règles suivantes</T> :{' '}
+											</h3>
 											<ul>
 												{displayedRule['rend non applicable'].map(ruleName => (
 													<li key={ruleName}>

--- a/source/engine/evaluateRule.js
+++ b/source/engine/evaluateRule.js
@@ -11,7 +11,7 @@ export default (cache, situationGate, parsedRules, node) => {
 				'parentDependency',
 				'non applicable si',
 				'applicable si',
-				'désactivé'
+				'rendu non applicable'
 			]),
 			map(value => evaluateNode(cache, situationGate, parsedRules, value))
 		)(node),
@@ -19,7 +19,7 @@ export default (cache, situationGate, parsedRules, node) => {
 			parentDependency,
 			'non applicable si': notApplicable,
 			'applicable si': applicable,
-			désactivé: disabled
+			'rendu non applicable': disabled
 		} = evaluatedAttributes,
 		isApplicable =
 			val(parentDependency) === false ||

--- a/source/engine/evaluateRule.js
+++ b/source/engine/evaluateRule.js
@@ -1,5 +1,5 @@
-import { mergeAll, keys, map, pick, pipe } from 'ramda'
-import { bonus, mergeMissing, evaluateNode } from 'Engine/evaluation'
+import { bonus, evaluateNode, mergeMissing } from 'Engine/evaluation'
+import { keys, map, mergeAll, pick, pipe } from 'ramda'
 import { anyNull, undefOrTrue, val } from './traverse-common-functions'
 
 export default (cache, situationGate, parsedRules, node) => {
@@ -7,20 +7,25 @@ export default (cache, situationGate, parsedRules, node) => {
 	cache.parseLevel++
 
 	let evaluatedAttributes = pipe(
-			pick(['parentDependency', 'non applicable si', 'applicable si']),
+			pick([
+				'parentDependency',
+				'non applicable si',
+				'applicable si',
+				'désactivé'
+			]),
 			map(value => evaluateNode(cache, situationGate, parsedRules, value))
 		)(node),
 		{
 			parentDependency,
 			'non applicable si': notApplicable,
-			'applicable si': applicable
+			'applicable si': applicable,
+			désactivé: disabled
 		} = evaluatedAttributes,
 		isApplicable =
-			val(parentDependency) === false
-				? false
-				: val(notApplicable) === true
-				? false
-				: val(applicable) === false
+			val(parentDependency) === false ||
+			val(notApplicable) === true ||
+			val(applicable) === false ||
+			val(disabled) === true
 				? false
 				: anyNull([notApplicable, applicable, parentDependency])
 				? null
@@ -66,7 +71,6 @@ export default (cache, situationGate, parsedRules, node) => {
 			bonus(condMissing, hasCondition),
 			formulaMissingVariables
 		)
-
 	cache.parseLevel--
 	//		if (keys(condMissing).length) console.log("".padStart(cache.parseLevel-1),{conditions:condMissing, formule:formMissing})
 	//		else console.log("".padStart(cache.parseLevel-1),{formule:formMissing})

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -113,6 +113,12 @@ non applicable si:
 
     Peut être accompagnée du mécanisme 'applicable si'.
 
+désactive:
+  description: |
+    Permet de désactiver certaines règles pour la situation saisie.
+
+    > Ce mécanisme est utile pour encoder les régimes d'exceptions (par exemple le [régime des impatriés]()) sans avoir à modifier la définition des règles de base.
+
 barème:
   type: numeric
   description: |

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -113,9 +113,9 @@ non applicable si:
 
     Peut être accompagnée du mécanisme 'applicable si'.
 
-désactive:
+rend non applicable:
   description: |
-    Permet de désactiver certaines règles pour la situation saisie.
+    Permet de désactiver l'application de certaines règles pour la situation saisie.
 
     > Ce mécanisme est utile pour encoder les régimes d'exceptions (par exemple le [régime des impatriés]()) sans avoir à modifier la définition des règles de base.
 

--- a/source/engine/known-mecanisms.yaml
+++ b/source/engine/known-mecanisms.yaml
@@ -117,7 +117,7 @@ rend non applicable:
   description: |
     Permet de désactiver l'application de certaines règles pour la situation saisie.
 
-    > Ce mécanisme est utile pour encoder les régimes d'exceptions (par exemple le [régime des impatriés]()) sans avoir à modifier la définition des règles de base.
+    > Ce mécanisme est utile pour encoder les régimes d'exceptions (par exemple le [régime des impatriés](/documentation/contrat-salarié/régime-des-impatriés)) sans avoir à modifier la définition des règles de base.
 
 barème:
   type: numeric

--- a/source/engine/parseReference.js
+++ b/source/engine/parseReference.js
@@ -1,15 +1,15 @@
 // Reference to a variable
+import parseRule from 'Engine/parseRule'
 import React from 'react'
 import { Trans } from 'react-i18next'
 import { evaluateNode, makeJsx, rewriteNode } from './evaluation'
+import { getSituationValue } from './getSituationValue'
 import { Leaf, Node } from './mecanismViews/common'
 import {
 	disambiguateRuleReference,
 	findParentDependency,
 	findRuleByDottedName
 } from './rules'
-import { getSituationValue } from './getSituationValue'
-import parseRule from 'Engine/parseRule'
 
 export let parseReference = (rules, rule, parsedRules, filter) => ({
 	fragments

--- a/source/engine/parseRule.js
+++ b/source/engine/parseRule.js
@@ -1,3 +1,4 @@
+import { T } from 'Components'
 import { ShowValuesConsumer } from 'Components/rule/ShowValuesContext'
 import RuleLink from 'Components/RuleLink'
 import evaluate from 'Engine/evaluateRule'
@@ -130,12 +131,12 @@ export default (rules, rule, parsedRules) => {
 
 	parsedRules[rule.dottedName]['rendu non applicable'] = {
 		evaluate: (cache, situation, parsedRules, node) => {
-			const nodeValue = node.explanation.isDisabledBy
-				.map(disablerNode =>
-					evaluateNode(cache, situation, parsedRules, disablerNode)
-				)
-				.some(x => x.nodeValue === true)
-			return rewriteNode(node, nodeValue, node.explanation, {})
+			const isDisabledBy = node.explanation.isDisabledBy.map(disablerNode =>
+				evaluateNode(cache, situation, parsedRules, disablerNode)
+			)
+			const nodeValue = isDisabledBy.some(x => x.nodeValue === true)
+			const explanation = { ...node.explanation, isDisabledBy }
+			return { ...node, explanation, nodeValue }
 		},
 		jsx: (nodeValue, { isDisabledBy }) => {
 			return (
@@ -143,12 +144,12 @@ export default (rules, rule, parsedRules) => {
 					<>
 						<h3>Exception{isDisabledBy.length > 1 && 's'}</h3>
 						<p>
-							Cette règle ne s'applique pas pour :{' '}
+							<T>Cette règle ne s'applique pas pour</T> :{' '}
 							{isDisabledBy.map((rule, i) => (
-								<>
+								<React.Fragment key={i}>
 									{i > 0 && ', '}
 									<RuleLink dottedName={rule.dottedName} />
-								</>
+								</React.Fragment>
 							))}
 						</p>
 					</>

--- a/source/locales/en.yaml
+++ b/source/locales/en.yaml
@@ -764,6 +764,8 @@ Année d'activité: Years of activity
 Commerçant, artisan, ou libéral ?: Trader, craftsman, or liberal?
 Revenir à la documentation: Go back to documentation
 Voir le code source: See the source code
+Rend non applicable les règles suivantes: Makes the following rules not applicable
+Cette règle ne s'applique pas pour: This rule does not apply for
 
 pour les accidents de trajet/travail et maladie pro: for commuting accidents, work accidents and professional illness
 jour: day

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -692,7 +692,7 @@
     Certains dirigeants d'entreprise (c'est notamment le cas pour les SASU) sont considérés par la sécurité sociale comme assimilés aux salariés. Ils sont alors au régime général de la sécurité sociale, avec quelques contraintes cependant. Par exemple, ils ne cotisent pas au chômage, et n'y ont donc pas droit.
   question: Le salarié est-il considéré comme "assimilé salarié" ?
   par défaut: non
-  désactive:
+  rend non applicable:
     - chômage
     - réduction générale
     - AGS
@@ -1763,7 +1763,7 @@
   par défaut: non
   # L'association a but non lucratif ne paie pas d'IS de droit commun article 206 du Code général des impôts
   # -> pas de taxe ni contribution d'apprentissage
-  désactive:
+  rend non applicable:
     - contrat salarié . taxe d'apprentissage
 
 - espace: entreprise
@@ -1964,7 +1964,7 @@
   description: |
     Le statut de jeune entreprise innovante (JEI) a été créé par la loi de finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au moins de leurs charges à de la Recherche et Développement de bénéficier de certaines exonérations.
   par défaut: non
-  désactive:
+  rend non applicable:
     - contrat salarié . réduction générale
 
 - espace: contrat salarié . statut JEI
@@ -2731,7 +2731,7 @@
 
   applicable si:
     toutes ces conditions:
-      - entreprise . effectif > 250
+      - entreprise . effectif >= 250
       - entreprise . ratio alternants < 5%
 
   période: flexible
@@ -2829,7 +2829,7 @@
     Les impatriés sont exonérés de cotisations retraite (régime de base et complémentaire) à condition de justifier d'une contribution minimale versée par ailleurs (par exemple dans une caisse de retraite ou un fond de pension étranger). Ils n’acquièrent aucun droit pendant la durée d’exonération.
 
   note: La durée d’application est fixée au maximum jusqu’au 31 décembre de la huitième année civile suivant la prise de fonctions dans l’entreprise d’accueil.
-  désactive:
+  rend non applicable:
     - vieillesse
     - retraite complémentaire
     - protection sociale . retraite . base

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -692,6 +692,13 @@
     Certains dirigeants d'entreprise (c'est notamment le cas pour les SASU) sont considérés par la sécurité sociale comme assimilés aux salariés. Ils sont alors au régime général de la sécurité sociale, avec quelques contraintes cependant. Par exemple, ils ne cotisent pas au chômage, et n'y ont donc pas droit.
   question: Le salarié est-il considéré comme "assimilé salarié" ?
   par défaut: non
+  désactive:
+    - chômage
+    - réduction générale
+    - AGS
+    - APEC
+    - contribution au dialogue social
+    - statut JEI
   références:
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
 
@@ -1754,6 +1761,10 @@
   description: L'entreprise est une association non lucrative
   question: S'agit-il d'une association à but non lucratif ?
   par défaut: non
+  # L'association a but non lucratif ne paie pas d'IS de droit commun article 206 du Code général des impôts
+  # -> pas de taxe ni contribution d'apprentissage
+  désactive:
+    - contrat salarié . taxe d'apprentissage
 
 - espace: entreprise
   nom: établissement bancaire
@@ -1953,6 +1964,8 @@
   description: |
     Le statut de jeune entreprise innovante (JEI) a été créé par la loi de finances pour 2004 et permet aux PME de moins de 8 ans consacrant 15% au moins de leurs charges à de la Recherche et Développement de bénéficier de certaines exonérations.
   par défaut: non
+  désactive:
+    - contrat salarié . réduction générale
 
 - espace: contrat salarié
   nom: exonération JEI
@@ -1967,7 +1980,6 @@
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
   applicable si: statut JEI
-  non applicable si: assimilé salarié
   période: mois
   formule:
     # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,
@@ -1992,15 +2004,8 @@
     description: https://www.service-public.fr/professionnels-entreprises/vosdroits/F24542
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-generale.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
-
-  non applicable si:
-    une de ces conditions:
-      - assimilé salarié
-      - cotisations . assiette > plafond de l'assiette
-      - statut JEI
-
+  applicable si: cotisations . assiette <= plafond de l'assiette
   période: flexible
-
   formule:
     le minimum de:
       - assiette
@@ -2137,7 +2142,6 @@
 
 - espace: contrat salarié
   nom: retraite complémentaire
-  non applicable si: régime des impatriés
   cotisation:
     branche: retraite
     type de retraite: complémentaire
@@ -2186,7 +2190,6 @@
   references:
     calcul: https://www.service-public.fr/professionnels-entreprises/vosdroits/F31409
 
-  non applicable si: assimilé salarié
   période: flexible
   formule:
     multiplication:
@@ -2223,7 +2226,6 @@
 
 - espace: contrat salarié
   nom: APEC
-  non applicable si: assimilé salarié
   cotisation:
     branche: assurance chômage
     type de retraite: complémentaire
@@ -2261,7 +2263,6 @@
     urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/lassurance-chomage-et-lags/les-taux.html
     changements 2017: https://www.urssaf.fr/portail/home/actualites/toute-lactualite-employeur/contributions-patronales-dassura.html
 
-  non applicable si: assimilé salarié
   période: flexible
   formule:
     multiplication:
@@ -2418,7 +2419,6 @@
     - https://www.service-public.fr/professionnels-entreprises/vosdroits/F33308
 
   période: flexible
-  non applicable si: assimilé salarié
   formule:
     multiplication:
       assiette: cotisations . assiette
@@ -2708,10 +2708,6 @@
     csa: http://www.opcalia.com/employeurs/financer-la-formation-et-lapprentissage/taxe-dapprentissage/contribution-supplementaire-a-lapprentissage-csa/
 
   note: Taxe complexe, comportant notamment des exonérations non prises en compte ici.
-
-  non applicable si: entreprise . association non lucrative
-  # L'association a but non lucratif ne paie pas d'IS de droit commun article 206 du Code général des impôts
-  # -> pas de taxe ni contribution d'apprentissage
   période: flexible
   formule:
     somme:
@@ -2733,10 +2729,10 @@
 - espace: contrat salarié
   nom: contribution supplémentaire à l'apprentissage
 
-  non applicable si:
-    une de ces conditions:
-      - entreprise . effectif < 250
-      - entreprise . ratio alternants >= 5%
+  applicable si:
+    toutes ces conditions:
+      - entreprise . effectif > 250
+      - entreprise . ratio alternants < 5%
 
   période: flexible
   formule:
@@ -2833,6 +2829,10 @@
     Les impatriés sont exonérés de cotisations retraite (régime de base et complémentaire) à condition de justifier d'une contribution minimale versée par ailleurs (par exemple dans une caisse de retraite ou un fond de pension étranger). Ils n’acquièrent aucun droit pendant la durée d’exonération.
 
   note: La durée d’application est fixée au maximum jusqu’au 31 décembre de la huitième année civile suivant la prise de fonctions dans l’entreprise d’accueil.
+  désactive:
+    - vieillesse
+    - retraite complémentaire
+    - protection sociale . retraite . base
   contrôles:
     - si: contrat salarié . régime des impatriés
       niveau: information
@@ -2908,7 +2908,7 @@
 - espace: contrat salarié
   nom: versement transport
   description: Contribution sur les salaires destinée au financement des transports publics.
-  non applicable si: entreprise . effectif < 11
+  applicable si: entreprise . effectif > 10
   cotisation:
     branche: transport
     dû par: employeur
@@ -2928,7 +2928,6 @@
     collecteur: URSSAF
     destinataire: CNAV
     # CTP: 100
-  non applicable si: régime des impatriés
   description: Cotisation au régime de retraite de base des salariés.
   période: flexible
   formule:
@@ -2991,7 +2990,7 @@
   titre: Assiette du forfait social au taux de 8%
   références:
     Fiche urssaf: https://www.urssaf.fr/portail/home/employeur/calculer-les-cotisations/les-taux-de-cotisations/le-forfait-social/le-forfait-social-au-taux-de-8.html
-  non applicable si: entreprise . effectif < 11
+  applicable si: entreprise . effectif > 10
   période: flexible
   formule:
     somme:
@@ -4245,7 +4244,6 @@
   titre: pension de retraite de base
   unité: €
   période: flexible
-  non applicable si: contrat salarié . régime des impatriés
   formule:
     multiplication:
       plafond: plafond sécurité sociale temps plein
@@ -4401,7 +4399,7 @@
 - espace: protection sociale
   nom: revenu moyen
   description: Le revenu utilisé pour le calcul du montant des pensions de retraite et des indemnités journalières de sécurité sociale lors d'un arrêt de travail.
-  notes: Normalement, on prends le revenu moyen des 25 meilleures années pour la retraite et des 3 derniers mois pour les indémnités. Vu qu'on intègre pas la notions de temporalité avec notre simulateur, on simplifie en prenant le même.
+  notes: Normalement, on prend le revenu moyen des 25 meilleures années pour la retraite et des 3 derniers mois pour les indémnités. Vu qu'on intègre pas la notions de temporalité avec notre simulateur, on simplifie en prenant le même.
   unité: €
   période: année
   formule:
@@ -4414,7 +4412,7 @@
   nom: mois cotisés
   unité: mois
   formule: 172 * 3
-  notes: On prends l'hypotèse d'une retraite à taux plein pour un travailleur né en 1973 ou après
+  notes: On prend l'hypothèse d'une retraite à taux plein pour un travailleur né en 1973 ou après
 
 - espace: protection sociale . retraite
   nom: complémentaire salarié

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1566,7 +1566,7 @@
   formule:
     somme:
       - réduction générale
-      - exonération JEI
+      - statut JEI . exonération de cotisations
       - réduction ACRE
       - déduction heures supplémentaires
 
@@ -1967,8 +1967,9 @@
   désactive:
     - contrat salarié . réduction générale
 
-- espace: contrat salarié
-  nom: exonération JEI
+- espace: contrat salarié . statut JEI
+  nom: exonération de cotisations
+  titre: Exonération JEI
   aide:
     type: réduction de cotisations
     démarches: non
@@ -1979,7 +1980,6 @@
     calcul: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-ou-aides-liees-au-s/jeunes-entreprises-innovantes/quelle-exoneration.html
     cumuls: https://www.legisocial.fr/actualites-sociales/2068-comment-declarer-les-cotisations-dallocations-familiales-si-lentreprise-beneficie-du-regime-jei.html
 
-  applicable si: statut JEI
   période: mois
   formule:
     # TODO - le plafonnement à 4,5 SMIC, précalculé pour 09/2017; cette approximation n'est bien sûr pas satisfaisante,

--- a/test/mécanismes/rend-non-applicable.yaml
+++ b/test/mécanismes/rend-non-applicable.yaml
@@ -1,0 +1,15 @@
+- nom: impôt
+  formule: 1000
+
+- nom: exilé fiscal
+  rend non applicable:
+    - impôt
+
+- nom: contribution
+  formule: impôt
+  test: règle désactivé
+  exemples:
+    - nom: evasion fiscale
+      situation:
+        exilé fiscal: oui
+      valeur attendue: 0

--- a/test/mécanismes/rend-non-applicable.yaml
+++ b/test/mécanismes/rend-non-applicable.yaml
@@ -7,7 +7,7 @@
 
 - nom: contribution
   formule: impôt
-  test: règle désactivé
+  test: règle désactivée
   exemples:
     - nom: evasion fiscale
       situation:


### PR DESCRIPTION
Implémentation de #591.

Améliore aussi les pages de documentation d'une part en listant les modifications apportées par un régime d'exception (exemple liste des dispositifs fermés pour les assimilés salariés) et en diminuant l'importance de ces exceptions sur les pages des règles modifiées (exemple on ne parle pas du régime des impatriés comme une "règle d'activation" de la retraite complémentaire tout en haut de la page mais comme une "exception" en bas de page).

Le code est fonctionnel, à faire :

- [x] Ajouter tests
- [x] Décider nom de la règle [edit: vu avec @johangirod]
- [x] Traductions