### PR TITLE
Support des centimes dans le simulateur

### DIFF
--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -7,6 +7,7 @@ import withColours from 'Components/utils/withColours'
 import withLanguage from 'Components/utils/withLanguage'
 import withSitePaths from 'Components/utils/withSitePaths'
 import { encodeRuleName } from 'Engine/rules'
+import { serialiseUnit } from 'Engine/units'
 import { compose, isEmpty, isNil, propEq } from 'ramda'
 import React, { Component, PureComponent } from 'react'
 import emoji from 'react-easy-emoji'
@@ -16,13 +17,13 @@ import { Link } from 'react-router-dom'
 import { change, Field, formValueSelector, reduxForm } from 'redux-form'
 import {
 	analysisWithDefaultsSelector,
-	flatRulesSelector
+	flatRulesSelector,
+	inputPrecisionSelector
 } from 'Selectors/analyseSelectors'
 import Animate from 'Ui/animate'
 import AnimatedTargetValue from 'Ui/AnimatedTargetValue'
 import CurrencyInput from './CurrencyInput/CurrencyInput'
 import './TargetSelection.css'
-import { serialiseUnit } from 'Engine/units'
 
 export default compose(
 	withTranslation(),
@@ -317,7 +318,8 @@ let TargetInputOrValue = withLanguage(
 
 const TargetValue = connect(
 	state => ({
-		blurValue: analysisWithDefaultsSelector(state)?.cache.inversionFail
+		blurValue: analysisWithDefaultsSelector(state)?.cache.inversionFail,
+		precision: inputPrecisionSelector(state)
 	}),
 	dispatch => ({
 		setFormValue: (field, name) => dispatch(change('conversation', field, name))
@@ -349,8 +351,15 @@ const TargetValue = connect(
 			let { target, setFormValue, activeInput, setActiveInput } = this.props
 			return () => {
 				if (!target.question) return
-				if (value != null && !Number.isNaN(value))
-					setFormValue(target.dottedName, Math.round(value) + '')
+
+				if (value != null && !Number.isNaN(value)) {
+					const digitsAfterDecimalPoint =
+						this.props.precision === 'cents' ? 2 : 0
+					setFormValue(
+						target.dottedName,
+						value.toFixed(digitsAfterDecimalPoint)
+					)
+				}
 
 				if (activeInput) setFormValue(activeInput, '')
 				setActiveInput(target.dottedName)

--- a/source/components/ui/AnimatedTargetValue.js
+++ b/source/components/ui/AnimatedTargetValue.js
@@ -1,7 +1,10 @@
 /* @flow */
 import withLanguage from 'Components/utils/withLanguage'
+import { compose } from 'ramda'
 import React, { Component, PureComponent } from 'react'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
+import { connect } from 'react-redux'
+import { inputPrecisionSelector } from 'Selectors/analyseSelectors'
 import './AnimatedTargetValue.css'
 
 type Props = {
@@ -11,7 +14,12 @@ type Props = {
 type State = {
 	difference: number
 }
-export default withLanguage(
+export default compose(
+	withLanguage,
+	connect(state => ({
+		precision: inputPrecisionSelector(state)
+	}))
+)(
 	class AnimatedTargetValue extends Component<Props, State> {
 		state = { difference: 0 }
 
@@ -27,13 +35,14 @@ export default withLanguage(
 			})
 		}
 		format = value => {
+			const fractionDigits = this.props.precision === 'cents' ? 2 : 0
 			return value == null
 				? ''
 				: Intl.NumberFormat(this.props.language, {
 						style: 'currency',
 						currency: 'EUR',
-						maximumFractionDigits: 0,
-						minimumFractionDigits: 0
+						maximumFractionDigits: fractionDigits,
+						minimumFractionDigits: fractionDigits
 				  }).format(value)
 		}
 		render() {

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -14,7 +14,6 @@ import { analyse, analyseMany, parseAll } from 'Engine/traverse'
 import {
 	add,
 	defaultTo,
-	propEq,
 	difference,
 	dissoc,
 	equals,
@@ -95,6 +94,18 @@ export let formattedSituationSelector = createSelector(
 export let noUserInputSelector = createSelector(
 	[formattedSituationSelector],
 	situation => !situation || isEmpty(dissoc('période', situation))
+)
+
+export let inputPrecisionSelector = createSelector(
+	[formattedSituationSelector, state => state.form?.conversation?.active],
+	(situation, currentActiveField) => {
+		const currentValue = situation[currentActiveField] || ''
+		if (currentValue.includes('.')) {
+			return 'cents'
+		} else {
+			return 'unit'
+		}
+	}
 )
 
 export let firstStepCompletedSelector = createSelector(


### PR DESCRIPTION
Si l'utilisateur entre un montant en euro précis au centime près, arrondir les résultats affichés au centime près plutôt qu'à l'euro près.

Pas mergable en l'état car il y a des sauts de valeur lors du changement de champs, nécessite de corriger #553 (et en profiter pour supprimer redux-form ?)