### PR TITLE
Suppression de redux-form

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,7 +1,4 @@
 rules:
-  linebreak-style:
-    - 2
-    - unix
   quotes:
     - 1 # While https://github.com/eslint/eslint/issues/9662#issuecomment-353958854 we don't enforce this
     - single
@@ -14,10 +11,13 @@ rules:
   react/jsx-no-target-blank: 0
   react/no-unescaped-entities: 0
   react/display-name: 1
+  react-hooks/rules-of-hooks: error
+  react-hooks/exhaustive-deps: warn
 parser: babel-eslint
 
 plugins:
   - react
+  - react-hooks
   - flowtype
 env:
   browser: true

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
 		"eslint-config-prettier": "^4.0.0",
 		"eslint-plugin-flowtype": "^3.2.1",
 		"eslint-plugin-react": "^7.12.4",
+		"eslint-plugin-react-hooks": "^2.0.1",
 		"express": "^4.16.3",
 		"file-loader": "^1.1.11",
 		"flow-bin": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
 		"react-virtualized-select": "^3.1.3",
 		"reduce-reducers": "^0.1.2",
 		"redux": "^3.7.2",
-		"redux-batched-actions": "^0.4.1",
-		"redux-form": "^8.2.0",
 		"redux-thunk": "^2.3.0",
 		"regenerator-runtime": "^0.13.3",
 		"reselect": "^4.0.0",

--- a/source/Provider.js
+++ b/source/Provider.js
@@ -9,7 +9,6 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { Router } from 'react-router-dom'
 import reducers from 'Reducers/rootReducer'
 import { applyMiddleware, compose, createStore } from 'redux'
-import { enableBatching } from 'redux-batched-actions'
 import thunk from 'redux-thunk'
 import { getIframeOption, inIframe } from './utils'
 
@@ -54,11 +53,7 @@ export default class Provider extends PureComponent {
 			if (this.props.initialStore)
 				this.props.initialStore.lang = this.props.language
 		}
-		this.store = createStore(
-			enableBatching(reducers),
-			this.props.initialStore,
-			storeEnhancer
-		)
+		this.store = createStore(reducers, this.props.initialStore, storeEnhancer)
 		this.props.onStoreCreated && this.props.onStoreCreated(this.store)
 
 		// Remove loader

--- a/source/actions/actions.js
+++ b/source/actions/actions.js
@@ -7,8 +7,6 @@ import type {
 	SetSimulationConfigAction,
 	SetSituationBranchAction
 } from 'Types/ActionsTypes'
-// $FlowFixMe
-import { change, reset } from 'redux-form'
 import { deletePersistedSimulation } from '../storage/persistSimulation'
 import type { Thunk } from 'Types/ActionsTypes'
 
@@ -18,19 +16,19 @@ export const resetSimulation = () => (dispatch: any => void): void => {
 			type: 'RESET_SIMULATION'
 		}: ResetSimulationAction)
 	)
-	dispatch(reset('conversation'))
 }
+
 export const goToQuestion = (question: string): StepAction => ({
 	type: 'STEP_ACTION',
 	name: 'unfold',
 	step: question
 })
+
 export const validateStepWithValue = (
 	dottedName,
 	value: any
 ): Thunk<StepAction> => dispatch => {
-	dispatch({ type: 'UPDATE_SITUATION', fieldName: dottedName, value })
-	dispatch(change('conversation', dottedName, value))
+	dispatch(updateSituation(dottedName, value))
 	dispatch({
 		type: 'STEP_ACTION',
 		name: 'fold',
@@ -62,6 +60,12 @@ export const deletePreviousSimulation = () => (
 	})
 	deletePersistedSimulation()
 }
+
+export const updateSituation = (fieldName, value) => ({
+	type: 'UPDATE_SITUATION',
+	fieldName,
+	value
+})
 
 // $FlowFixMe
 export function setExample(name, situation, dottedName) {

--- a/source/actions/actions.js
+++ b/source/actions/actions.js
@@ -67,6 +67,11 @@ export const updateSituation = (fieldName, value) => ({
 	value
 })
 
+export const updatePeriod = toPeriod => ({
+	type: 'UPDATE_PERIOD',
+	toPeriod
+})
+
 // $FlowFixMe
 export function setExample(name, situation, dottedName) {
 	return { type: 'SET_EXAMPLE', name, situation, dottedName }

--- a/source/actions/actions.js
+++ b/source/actions/actions.js
@@ -29,6 +29,7 @@ export const validateStepWithValue = (
 	dottedName,
 	value: any
 ): Thunk<StepAction> => dispatch => {
+	dispatch({ type: 'UPDATE_SITUATION', fieldName: dottedName, value })
 	dispatch(change('conversation', dottedName, value))
 	dispatch({
 		type: 'STEP_ACTION',

--- a/source/components/AttachDictionary.js
+++ b/source/components/AttachDictionary.js
@@ -8,6 +8,7 @@ import Overlay from './Overlay'
 // Il suffit à la section d'appeler une fonction fournie en lui donnant du JSX
 export let AttachDictionary = dictionary => Decorated =>
 	function withDictionary(props) {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [{ explanation, term }, setState] = useState({
 			term: null,
 			explanation: null

--- a/source/components/CurrencyInput/CurrencyInput.js
+++ b/source/components/CurrencyInput/CurrencyInput.js
@@ -1,5 +1,5 @@
 import classnames from 'classnames'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import NumberFormat from 'react-number-format'
 import { debounce } from '../../utils'
 import './CurrencyInput.css'
@@ -22,23 +22,27 @@ let currencyFormat = language => ({
 })
 
 export default function CurrencyInput({
-	value: valueArg,
+	value: valueProp = '',
 	debounce: debounceTimeout,
 	onChange,
 	language,
 	className,
 	...forwardedProps
 }) {
-	const [currentValue, setCurrentValue] = useState(valueArg)
-	const [initialValue] = useState(valueArg)
-	// When the component is rendered with a new "value" argument, we update our local state
-	useEffect(() => {
-		setCurrentValue(valueArg)
-	}, [valueArg])
-	const nextValue = useRef(null)
+	const [initialValue, setInitialValue] = useState(valueProp)
+	const [currentValue, setCurrentValue] = useState(valueProp)
 	const onChangeDebounced = useRef(
 		debounceTimeout ? debounce(debounceTimeout, onChange) : onChange
 	)
+	// We need some mutable reference because the <NumberFormat /> component doesn't provide
+	// the DOM `event` in its custom `onValueChange` handler
+	const nextValue = useRef(null)
+
+	// When the component is rendered with a new "value" prop, we reset our local state
+	if (valueProp !== initialValue) {
+		setCurrentValue(valueProp)
+		setInitialValue(valueProp)
+	}
 
 	const handleChange = event => {
 		// Only trigger the `onChange` event if the value has changed -- and not
@@ -61,19 +65,17 @@ export default function CurrencyInput({
 		thousandSeparator,
 		decimalSeparator
 	} = currencyFormat(language)
-
-	// We display negative numbers iff this was the provided value (but we allow the user to enter them)
+	// We display negative numbers iff this was the provided value (but we disallow the user to enter them)
 	const valueHasChanged = currentValue !== initialValue
 
 	// Autogrow the input
-	const valueLength = (currentValue || '').toString().length
+	const valueLength = currentValue.toString().length
+	const width = `${5 + (valueLength - 5) * 0.75}em`
 
 	return (
 		<div
 			className={classnames(className, 'currencyInput__container')}
-			{...(valueLength > 5
-				? { style: { width: `${5 + (valueLength - 5) * 0.75}em` } }
-				: {})}>
+			{...(valueLength > 5 ? { style: { width } } : {})}>
 			{isCurrencyPrefixed && '€'}
 			<NumberFormat
 				{...forwardedProps}
@@ -84,10 +86,10 @@ export default function CurrencyInput({
 				inputMode="numeric"
 				onValueChange={({ value }) => {
 					setCurrentValue(value)
-					nextValue.current = value.toString().replace(/^\-/, '')
+					nextValue.current = value.toString().replace(/^-/, '')
 				}}
 				onChange={handleChange}
-				value={(currentValue || '').toString().replace('.', decimalSeparator)}
+				value={currentValue.toString().replace('.', decimalSeparator)}
 			/>
 			{!isCurrencyPrefixed && <>&nbsp;€</>}
 		</div>

--- a/source/components/CurrencyInput/CurrencyInput.js
+++ b/source/components/CurrencyInput/CurrencyInput.js
@@ -24,6 +24,7 @@ let currencyFormat = language => ({
 export default function CurrencyInput({
 	value: valueProp = '',
 	debounce: debounceTimeout,
+	currencySymbol = '€',
 	onChange,
 	language,
 	className,
@@ -76,7 +77,7 @@ export default function CurrencyInput({
 		<div
 			className={classnames(className, 'currencyInput__container')}
 			{...(valueLength > 5 ? { style: { width } } : {})}>
-			{isCurrencyPrefixed && '€'}
+			{!currentValue && isCurrencyPrefixed && currencySymbol}
 			<NumberFormat
 				{...forwardedProps}
 				thousandSeparator={thousandSeparator}
@@ -84,6 +85,9 @@ export default function CurrencyInput({
 				allowNegative={!valueHasChanged}
 				className="currencyInput__input"
 				inputMode="numeric"
+				prefix={
+					isCurrencyPrefixed && currencySymbol ? `${currencySymbol} ` : ''
+				}
 				onValueChange={({ value }) => {
 					setCurrentValue(value)
 					nextValue.current = value.toString().replace(/^-/, '')

--- a/source/components/CurrencyInput/CurrencyInput.test.js
+++ b/source/components/CurrencyInput/CurrencyInput.test.js
@@ -24,10 +24,18 @@ describe('CurrencyInput', () => {
 	})
 
 	it('should separate thousand groups', () => {
-		const input1 = getInput(<CurrencyInput value={1000} language="fr" />)
-		const input2 = getInput(<CurrencyInput value={1000} language="en" />)
-		const input3 = getInput(<CurrencyInput value={1000.5} language="en" />)
-		const input4 = getInput(<CurrencyInput value={1000000} language="en" />)
+		const input1 = getInput(
+			<CurrencyInput value={1000} language="fr" currencySymbol={''} />
+		)
+		const input2 = getInput(
+			<CurrencyInput value={1000} language="en" currencySymbol={''} />
+		)
+		const input3 = getInput(
+			<CurrencyInput value={1000.5} language="en" currencySymbol={''} />
+		)
+		const input4 = getInput(
+			<CurrencyInput value={1000000} language="en" currencySymbol={''} />
+		)
 		expect(input1.instance().value).to.equal('1 000')
 		expect(input2.instance().value).to.equal('1,000')
 		expect(input3.instance().value).to.equal('1,000.5')
@@ -90,7 +98,7 @@ describe('CurrencyInput', () => {
 		const clock = useFakeTimers()
 		let onChange = spy()
 		const input = getInput(
-			<CurrencyInput onChange={onChange} debounce={1000} />
+			<CurrencyInput onChange={onChange} debounce={1000} currencySymbol={''} />
 		)
 		input.simulate('change', { target: { value: '1', focus: () => {} } })
 		expect(onChange).not.to.have.been.called
@@ -106,12 +114,12 @@ describe('CurrencyInput', () => {
 	})
 
 	it('should initialize with value of the value prop', () => {
-		const input = getInput(<CurrencyInput value={1} />)
+		const input = getInput(<CurrencyInput value={1} language="fr" />)
 		expect(input.instance().value).to.equal('1')
 	})
 
 	it('should update its value if the value prop changes', () => {
-		const component = mount(<CurrencyInput value={1} />)
+		const component = mount(<CurrencyInput value={1} language="fr" />)
 		component.setProps({ value: 2 })
 		expect(component.find('input').instance().value).to.equal('2')
 	})

--- a/source/components/PercentageField.js
+++ b/source/components/PercentageField.js
@@ -4,7 +4,8 @@ import './PercentageField.css'
 export default function PercentageField({ onChange, value, debounce }) {
 	const [localValue, setLocalValue] = useState(value)
 	const debouncedOnChange = useCallback(
-		debounce ? debounce(debounce, onChange) : onChange
+		debounce ? debounce(debounce, onChange) : onChange,
+		[debounce, onChange]
 	)
 
 	return (

--- a/source/components/PercentageField.js
+++ b/source/components/PercentageField.js
@@ -1,23 +1,21 @@
-import React, { useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import './PercentageField.css'
 
-export default function PercentageField({ input, debounce }) {
-	const [localValue, setLocalValue] = useState(input?.value)
-
-	const debouncedOnChange = debounce
-		? debounce(debounce, input.onChange)
-		: input.onChange
-
-	const onChange = value => {
-		setLocalValue(value)
-		debouncedOnChange(value)
-	}
+export default function PercentageField({ onChange, value, debounce }) {
+	const [localValue, setLocalValue] = useState(value)
+	const debouncedOnChange = useCallback(
+		debounce ? debounce(debounce, onChange) : onChange
+	)
 
 	return (
 		<div>
 			<input
 				className="range"
-				onChange={e => onChange(e.target.value)}
+				onChange={e => {
+					const value = e.target.value
+					setLocalValue(value)
+					debouncedOnChange(value)
+				}}
 				type="range"
 				value={localValue}
 				name="volume"

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -1,36 +1,23 @@
-import { findRuleByDottedName } from 'Engine/rules'
-import React, { useCallback, useEffect } from 'react'
+import React from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import {
-	flatRulesSelector,
-	situationSelector
-} from 'Selectors/analyseSelectors'
+import { situationSelector } from 'Selectors/analyseSelectors'
 import './PeriodSwitch.css'
 
 export default function PeriodSwitch() {
 	const dispatch = useDispatch()
-	const rules = useSelector(flatRulesSelector)
 	const situation = useSelector(situationSelector)
-	const initialPeriod = useSelector(
-		state => state.simulation?.config?.situation?.période
+	const defaultPeriod = useSelector(
+		state => state.simulation?.config?.situation?.période || 'année'
 	)
 	const currentPeriod = situation.période
-	useEffect(() => {
-		!currentPeriod && updatePeriod(initialPeriod || 'année')
-	}, [currentPeriod, initialPeriod, updatePeriod])
-	const updatePeriod = useCallback(
-		toPeriod => {
-			const needConversion = Object.keys(situation).filter(dottedName => {
-				const rule = findRuleByDottedName(rules, dottedName)
-				return rule?.période === 'flexible'
-			})
-			dispatch({ type: 'UPDATE_PERIOD', toPeriod, needConversion })
-		},
-		[dispatch, rules, situation]
-	)
 	let periods = ['mois', 'année']
-	if (initialPeriod === 'année') {
+	const updatePeriod = toPeriod => dispatch({ type: 'UPDATE_PERIOD', toPeriod })
+
+	if (!currentPeriod) {
+		updatePeriod(defaultPeriod)
+	}
+	if (defaultPeriod === 'année') {
 		periods.reverse()
 	}
 

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -1,5 +1,5 @@
 import { findRuleByDottedName } from 'Engine/rules'
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import {
@@ -15,17 +15,20 @@ export default function PeriodSwitch() {
 	const initialPeriod = useSelector(
 		state => state.simulation?.config?.situation?.période
 	)
+	const currentPeriod = situation.période
 	useEffect(() => {
 		!currentPeriod && updatePeriod(initialPeriod || 'année')
-	}, [])
-	const currentPeriod = situation.période
-	const updatePeriod = toPeriod => {
-		const needConversion = Object.keys(situation).filter(dottedName => {
-			const rule = findRuleByDottedName(rules, dottedName)
-			return rule?.période === 'flexible'
-		})
-		dispatch({ type: 'UPDATE_PERIOD', toPeriod, needConversion })
-	}
+	}, [currentPeriod, initialPeriod, updatePeriod])
+	const updatePeriod = useCallback(
+		toPeriod => {
+			const needConversion = Object.keys(situation).filter(dottedName => {
+				const rule = findRuleByDottedName(rules, dottedName)
+				return rule?.période === 'flexible'
+			})
+			dispatch({ type: 'UPDATE_PERIOD', toPeriod, needConversion })
+		},
+		[dispatch, rules, situation]
+	)
 	const periods = ['mois', 'année']
 
 	return (

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -1,3 +1,4 @@
+import { updatePeriod } from 'Actions/actions'
 import React from 'react'
 import { Trans } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
@@ -12,10 +13,9 @@ export default function PeriodSwitch() {
 	)
 	const currentPeriod = situation.période
 	let periods = ['année', 'mois']
-	const updatePeriod = toPeriod => dispatch({ type: 'UPDATE_PERIOD', toPeriod })
 
 	if (!currentPeriod) {
-		updatePeriod(defaultPeriod)
+		dispatch(updatePeriod(defaultPeriod))
 	}
 
 	return (
@@ -27,7 +27,7 @@ export default function PeriodSwitch() {
 							name="période"
 							type="radio"
 							value={period}
-							onChange={() => updatePeriod(period)}
+							onChange={() => dispatch(updatePeriod(period))}
 							checked={currentPeriod === period}
 						/>
 						<span>

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -11,14 +11,11 @@ export default function PeriodSwitch() {
 		state => state.simulation?.config?.situation?.période || 'année'
 	)
 	const currentPeriod = situation.période
-	let periods = ['mois', 'année']
+	let periods = ['année', 'mois']
 	const updatePeriod = toPeriod => dispatch({ type: 'UPDATE_PERIOD', toPeriod })
 
 	if (!currentPeriod) {
 		updatePeriod(defaultPeriod)
-	}
-	if (defaultPeriod === 'année') {
-		periods.reverse()
 	}
 
 	return (

--- a/source/components/PeriodSwitch.js
+++ b/source/components/PeriodSwitch.js
@@ -29,7 +29,10 @@ export default function PeriodSwitch() {
 		},
 		[dispatch, rules, situation]
 	)
-	const periods = ['mois', 'année']
+	let periods = ['mois', 'année']
+	if (initialPeriod === 'année') {
+		periods.reverse()
+	}
 
 	return (
 		<span id="PeriodSwitch">

--- a/source/components/SalaryExplanation.js
+++ b/source/components/SalaryExplanation.js
@@ -6,7 +6,7 @@ import React, { useRef } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
-import { formValueSelector } from 'redux-form'
+import { usePeriod } from 'Selectors/analyseSelectors'
 import * as Animate from 'Ui/animate'
 
 class ErrorBoundary extends React.Component {
@@ -89,20 +89,21 @@ export default compose(
 	)
 })
 
-const PaySlipSection = connect(state => ({
-	period: formValueSelector('conversation')(state, 'période')
-}))(({ period }) => (
-	<section>
-		<h2>
-			<Trans>
-				{period === 'mois'
-					? 'Fiche de paie mensuelle'
-					: 'Détail annuel des cotisations'}
-			</Trans>
-		</h2>
-		<PaySlip />
-	</section>
-))
+function PaySlipSection() {
+	const period = usePeriod()
+	return (
+		<section>
+			<h2>
+				<Trans>
+					{period === 'mois'
+						? 'Fiche de paie mensuelle'
+						: 'Détail annuel des cotisations'}
+				</Trans>
+			</h2>
+			<PaySlip />
+		</section>
+	)
+}
 
 const DistributionSection = () => (
 	<section>

--- a/source/components/SearchButton.js
+++ b/source/components/SearchButton.js
@@ -14,20 +14,19 @@ export default compose(
 )(function SearchButton({ flatRules, invisibleButton }) {
 	const [visible, setVisible] = useState(false)
 	useEffect(() => {
+		const handleKeyDown = e => {
+			if (!(e.ctrlKey && e.key === 'k')) return
+			setVisible(true)
+			e.preventDefault()
+			e.stopPropagation()
+			return false
+		}
 		window.addEventListener('keydown', handleKeyDown)
 
 		return () => {
 			window.removeEventListener('keydown', handleKeyDown)
 		}
 	}, [])
-
-	const handleKeyDown = e => {
-		if (!(e.ctrlKey && e.key === 'k')) return
-		setVisible(true)
-		e.preventDefault()
-		e.stopPropagation()
-		return false
-	}
 
 	const close = () => setVisible(false)
 

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -106,33 +106,45 @@
 	text-decoration: none;
 }
 
-#targetSelection .editable:not(.attractClick) {
-	border: 2px solid rgba(0, 0, 0, 0);
-	border-bottom: 1px dashed #ffffff91;
-	min-width: 2.5em;
-	display: inline-block;
-}
 #targetSelection .targetInputOrValue > :not(.targetInput):not(.attractClick) {
 	margin: 0.2rem 0.6rem;
 }
 
-#targetSelection .attractClick.editable::before {
-	content: '€';
+#targetSelection input {
+	margin: 2.7px 0;
 }
 
-#targetSelection .attractClick,
 #targetSelection .targetInput {
 	width: 5.5em;
 	max-width: 7.5em;
-	display: inline-block;
 	text-align: right;
 	background: rgba(255, 255, 255, 0.2);
-	cursor: text;
 	padding: 0;
 	padding: 0.2rem 0.6rem;
 	border-radius: 0.3rem;
 	border: 2px solid;
 	font-size: inherit;
+}
+
+#targetSelection .editableTarget {
+	max-width: 7.5em;
+	display: inline-block;
+	text-align: right;
+	padding: 0 2px;
+	font-size: inherit;
+}
+
+#targetSelection .targetInputBottomBorder {
+	margin: 0;
+	padding: 0;
+	height: 0;
+	overflow: hidden;
+	position: relative;
+	top: -6px;
+}
+
+#targetSelection .editableTarget + .targetInputBottomBorder {
+	border-bottom: 1px dashed #ffffff91;
 }
 
 #targetSelection .unit {

--- a/source/components/TargetSelection.css
+++ b/source/components/TargetSelection.css
@@ -106,8 +106,8 @@
 	text-decoration: none;
 }
 
-#targetSelection .targetInputOrValue > :not(.targetInput):not(.attractClick) {
-	margin: 0.2rem 0.6rem;
+#targetSelection .targetInputOrValue > :not(.targetInput) {
+	margin: 0 0.6rem;
 }
 
 #targetSelection input {
@@ -136,11 +136,9 @@
 
 #targetSelection .targetInputBottomBorder {
 	margin: 0;
-	padding: 0;
+	padding: 0 2px;
 	height: 0;
 	overflow: hidden;
-	position: relative;
-	top: -6px;
 }
 
 #targetSelection .editableTarget + .targetInputBottomBorder {

--- a/source/components/TargetSelection.js
+++ b/source/components/TargetSelection.js
@@ -41,8 +41,14 @@ export default compose(
 	const situation = useSituation()
 	const dispatch = useDispatch()
 
+	const targets =
+		analysis?.targets.filter(
+			t =>
+				!secondaryObjectives.includes(t.dottedName) &&
+				t.dottedName !== 'contrat salarié . aides employeur'
+		) || []
+
 	useEffect(() => {
-		let targets = getTargets()
 		// Initialize defaultValue for target that can't be computed
 		targets
 			.filter(
@@ -64,21 +70,9 @@ export default compose(
 				)
 			})
 
-		if (initialRender) {
-			setInitialRender(false)
-		}
+		setInitialRender(false)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
-
-	const getTargets = () => {
-		if (!analysis) return []
-		return analysis.targets.filter(
-			t =>
-				!secondaryObjectives.includes(t.dottedName) &&
-				t.dottedName !== 'contrat salarié . aides employeur'
-		)
-	}
-
-	let targets = getTargets()
 
 	return (
 		<div id="targetSelection">

--- a/source/components/Targets.js
+++ b/source/components/Targets.js
@@ -3,16 +3,16 @@ import withSitePaths from 'Components/utils/withSitePaths'
 import { compose } from 'ramda'
 import React from 'react'
 import emoji from 'react-easy-emoji'
-import { connect } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { analysisWithDefaultsSelector } from 'Selectors/analyseSelectors'
 import './Targets.css'
 
 export default compose(
-	connect(state => ({ analysis: analysisWithDefaultsSelector(state) })),
 	withColours,
 	withSitePaths
-)(function Targets({ analysis, colours, sitePaths }) {
+)(function Targets({ colours, sitePaths }) {
+	const analysis = useSelector(analysisWithDefaultsSelector)
 	let { nodeValue, unité: unit, dottedName } = analysis.targets[0]
 	return (
 		<div id="targets">

--- a/source/components/conversation/Conversation.js
+++ b/source/components/conversation/Conversation.js
@@ -3,11 +3,9 @@ import { T } from 'Components'
 import QuickLinks from 'Components/QuickLinks'
 import { getInputComponent } from 'Engine/generateQuestions'
 import { findRuleByDottedName } from 'Engine/rules'
-import { compose } from 'ramda'
 import React from 'react'
 import emoji from 'react-easy-emoji'
-import { connect } from 'react-redux'
-import { reduxForm } from 'redux-form'
+import { useDispatch, useSelector } from 'react-redux'
 import {
 	currentQuestionSelector,
 	flatRulesSelector,
@@ -17,40 +15,30 @@ import * as Animate from 'Ui/animate'
 import Aide from './Aide'
 import './conversation.css'
 
-export default compose(
-	reduxForm({
-		form: 'conversation',
-		destroyOnUnmount: false
-	}),
-	connect(
-		state => ({
-			flatRules: flatRulesSelector(state),
-			currentQuestion: currentQuestionSelector(state),
-			previousAnswers: state.conversationSteps.foldedSteps,
-			nextSteps: nextStepsSelector(state)
-		}),
-		{ validateStepWithValue, goToQuestion }
+export default function Conversation({ customEndMessages }) {
+	const dispatch = useDispatch()
+	const flatRules = useSelector(flatRulesSelector)
+	const currentQuestion = useSelector(currentQuestionSelector)
+	const previousAnswers = useSelector(
+		state => state.conversationSteps.foldedSteps
 	)
-)(function Conversation({
-	nextSteps,
-	previousAnswers,
-	currentQuestion,
-	customEndMessages,
-	flatRules,
-	goToQuestion,
-	validateStepWithValue
-}) {
+	const nextSteps = useSelector(nextStepsSelector)
+
 	const setDefault = () =>
-		validateStepWithValue(
-			currentQuestion,
-			findRuleByDottedName(flatRules, currentQuestion).defaultValue
+		dispatch(
+			validateStepWithValue(
+				currentQuestion,
+				findRuleByDottedName(flatRules, currentQuestion).defaultValue
+			)
 		)
-	const goToPrevious = () => goToQuestion(previousAnswers.slice(-1)[0])
+	const goToPrevious = () =>
+		dispatch(goToQuestion(previousAnswers.slice(-1)[0]))
 	const handleKeyDown = ({ key }) => {
 		if (['Escape'].includes(key)) {
 			setDefault()
 		}
 	}
+
 	return nextSteps.length ? (
 		<>
 			<Aide />
@@ -98,4 +86,4 @@ export default compose(
 			</p>
 		</div>
 	)
-})
+}

--- a/source/components/conversation/InputSuggestions.js
+++ b/source/components/conversation/InputSuggestions.js
@@ -1,21 +1,16 @@
-import { compose, toPairs } from 'ramda'
+import { toPairs } from 'ramda'
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { connect } from 'react-redux'
-import { formValueSelector } from 'redux-form'
+import { usePeriod } from 'Selectors/analyseSelectors'
 
-export default compose(
-	connect(state => ({
-		period: formValueSelector('conversation')(state, 'période')
-	}))
-)(function InputSuggestions({
+export default function InputSuggestions({
 	suggestions,
 	onSecondClick,
 	onFirstClick,
-	rulePeriod,
-	period
+	rulePeriod
 }) {
 	const [suggestion, setSuggestion] = useState(null)
+	const period = usePeriod()
 	const { t } = useTranslation()
 
 	if (!suggestions) return null
@@ -45,4 +40,4 @@ export default compose(
 			})}
 		</div>
 	)
-})
+}

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -38,10 +38,13 @@ export default compose(
 	value: currentValue
 }) {
 	const [touched, setTouched] = useState(false)
-	const onChange = useCallback(value => {
-		setFormValue(value)
-		setTouched(true)
-	})
+	const onChange = useCallback(
+		value => {
+			setFormValue(value)
+			setTouched(true)
+		},
+		[setFormValue]
+	)
 
 	const renderBinaryQuestion = () => {
 		return (

--- a/source/components/conversation/Question.js
+++ b/source/components/conversation/Question.js
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import withColours from 'Components/utils/withColours'
 import { compose, is } from 'ramda'
-import React from 'react'
+import React, { useCallback, useState } from 'react'
 import { Trans } from 'react-i18next'
 import Explicable from './Explicable'
 import { FormDecorator } from './FormDecorator'
@@ -29,46 +29,37 @@ import SendButton from './SendButton'
 export default compose(
 	FormDecorator('question'),
 	withColours
-)(function Question(props) {
-	let {
-		choices,
-		submit,
-		colours,
-		meta: { pristine }
-	} = props
+)(function Question({
+	choices,
+	submit,
+	colours,
+	name,
+	setFormValue,
+	value: currentValue
+}) {
+	const [touched, setTouched] = useState(false)
+	const onChange = useCallback(value => {
+		setFormValue(value)
+		setTouched(true)
+	})
 
 	const renderBinaryQuestion = () => {
-		let {
-			input, // vient de redux-form
-			submit,
-			choices,
-			setFormValue,
-			colours
-		} = props
-
 		return (
 			<div className="binaryQuestionList">
 				{choices.map(({ value, label }) => (
 					<RadioLabel
 						key={value}
-						{...{ value, label, input, submit, colours, setFormValue }}
+						{...{ value, label, currentValue, submit, colours, onChange }}
 					/>
 				))}
 			</div>
 		)
 	}
 	const renderChildren = choices => {
-		let {
-				input, // vient de redux-form
-				submit,
-				setFormValue,
-				colours
-			} = props,
-			{ name } = input,
-			// seront stockées ainsi dans le state :
-			// [parent object path]: dotted name relative to parent
-			relativeDottedName = radioDottedName =>
-				radioDottedName.split(name + ' . ')[1]
+		// seront stockées ainsi dans le state :
+		// [parent object path]: dotted name relative to parent
+		const relativeDottedName = radioDottedName =>
+			radioDottedName.split(name + ' . ')[1]
 
 		return (
 			<ul css="width: 100%">
@@ -78,11 +69,11 @@ export default compose(
 							{...{
 								value: 'non',
 								label: 'Aucun',
-								input,
+								currentValue,
 								submit,
 								colours,
 								dottedName: null,
-								setFormValue
+								onChange
 							}}
 						/>
 					</li>
@@ -101,10 +92,10 @@ export default compose(
 										value: relativeDottedName(dottedName),
 										label: title,
 										dottedName,
-										input,
+										currentValue,
 										submit,
 										colours,
-										setFormValue
+										onChange
 									}}
 								/>
 							</li>
@@ -123,7 +114,7 @@ export default compose(
 			{choiceElements}
 			<SendButton
 				{...{
-					disabled: pristine,
+					disabled: !touched,
 					colours,
 					error: false,
 					submit
@@ -143,14 +134,15 @@ let RadioLabel = props => (
 const RadioLabelContent = compose(withColours)(function RadioLabelContent({
 	value,
 	label,
-	input,
+	currentValue,
+	onChange,
 	submit
 }) {
 	let labelStyle = value === '_' ? { fontWeight: 'bold' } : null,
-		selected = value === input.value
+		selected = value === currentValue
 
 	const click = value => () => {
-		if (input.value == value) submit('dblClick')
+		if (currentValue == value) submit('dblClick')
 	}
 
 	return (
@@ -161,10 +153,10 @@ const RadioLabelContent = compose(withColours)(function RadioLabelContent({
 			<Trans i18nKey={`radio_${label}`}>{label}</Trans>
 			<input
 				type="radio"
-				{...input}
 				onClick={click(value)}
 				value={value}
-				checked={value === input.value ? 'checked' : ''}
+				onChange={evt => onChange(evt.target.value)}
+				checked={value === currentValue ? 'checked' : ''}
 			/>
 		</label>
 	)

--- a/source/components/conversation/RhetoricalQuestion.js
+++ b/source/components/conversation/RhetoricalQuestion.js
@@ -2,7 +2,7 @@ import FormDecorator from 'Components/conversation/FormDecorator'
 import React from 'react'
 
 export default FormDecorator('rhetorical-question')(
-	function RhetoricalQuestion({ input, submit, possibleChoice }) {
+	function RhetoricalQuestion({ value: currentValue, submit, possibleChoice }) {
 		if (!possibleChoice) return null // No action possible, don't render an answer
 
 		let { text, value } = possibleChoice
@@ -10,7 +10,12 @@ export default FormDecorator('rhetorical-question')(
 		return (
 			<span className="answer">
 				<label key={value} className="radio userAnswerButton">
-					<input type="radio" {...input} onClick={submit} value={value} />
+					<input
+						type="radio"
+						checked={value === currentValue}
+						onClick={submit}
+						value={value}
+					/>
 					{text}
 				</label>
 			</span>

--- a/source/components/conversation/SendButton.js
+++ b/source/components/conversation/SendButton.js
@@ -1,28 +1,29 @@
-import React, { useEffect } from 'react'
+import React, { useCallback, useEffect } from 'react'
 import { Trans } from 'react-i18next'
 
 export default function SendButton({ disabled, submit }) {
+	const getAction = useCallback(cause => (!disabled ? submit(cause) : null), [
+		disabled,
+		submit
+	])
 	useEffect(() => {
+		const handleKeyDown = ({ key }) => {
+			if (key !== 'Enter') return
+			getAction('enter')
+		}
+
 		window.addEventListener('keydown', handleKeyDown)
 		return () => {
 			window.removeEventListener('keydown', handleKeyDown)
 		}
-	}, [])
+	}, [getAction])
 
-	const getAction = () => {
-		return cause => (!disabled ? submit(cause) : null)
-	}
-
-	const handleKeyDown = ({ key }) => {
-		if (key !== 'Enter') return
-		getAction()('enter')
-	}
 	return (
 		<button
 			className="ui__ button plain"
 			css="margin-left: 1.2rem"
 			disabled={disabled}
-			onClick={() => getAction()('accept')}>
+			onClick={() => getAction('accept')}>
 			<span className="text">
 				<Trans>Suivant</Trans> →
 			</span>

--- a/source/components/conversation/select/SelectGéo.js
+++ b/source/components/conversation/select/SelectGéo.js
@@ -35,14 +35,14 @@ let getOptions = input =>
 				})
 
 export default FormDecorator('select')(function Select({
-	input: { onChange },
+	setFormValue,
 	submit
 }) {
 	let submitOnChange = option => {
 		tauxVersementTransport(option.code)
 			.then(({ taux }) => {
 				// serialize to not mix our data schema and the API response's
-				onChange(
+				setFormValue(
 					JSON.stringify({
 						...option,
 						...(taux != undefined
@@ -59,7 +59,7 @@ export default FormDecorator('select')(function Select({
 				console.log(
 					'Erreur dans la récupération du taux de versement transport à partir du code commune',
 					error
-				) || onChange(JSON.stringify({ option }))
+				) || setFormValue(JSON.stringify({ option }))
 				submit() // eslint-disable-line no-console
 			})
 	}

--- a/source/components/conversation/select/SelectTauxRisque.js
+++ b/source/components/conversation/select/SelectTauxRisque.js
@@ -5,26 +5,22 @@ import { FormDecorator } from '../FormDecorator'
 import './Select.css'
 import SelectOption from './SelectOption.js'
 
-function ReactSelectWrapper(props) {
-	let {
-		value,
-		onBlur,
-		onChange,
-		submit,
-		options,
-		submitOnChange = option => {
-			option.text = +option['Taux net'].replace(',', '.') / 100
-			onChange(option.text)
-			submit()
-		},
-		selectValue = value && value['Code risque']
-		// but ReactSelect obviously needs a unique identifier
-	} = props
-
+function ReactSelectWrapper({
+	value,
+	onBlur,
+	setFormValue,
+	submit,
+	options,
+	submitOnChange = option => {
+		option.text = +option['Taux net'].replace(',', '.') / 100
+		setFormValue(option.text)
+		submit()
+	},
+	selectValue = value?.['Code risque']
+}) {
 	if (!options) return null
 
 	return (
-		// For redux-form integration, checkout https://github.com/erikras/redux-form/issues/82#issuecomment-143164199
 		<ReactSelect
 			options={options}
 			onChange={submitOnChange}
@@ -40,7 +36,7 @@ function ReactSelectWrapper(props) {
 	)
 }
 
-function Select({ input, submit }) {
+export default FormDecorator('select')(function Select(props) {
 	const [options, setOptions] = useState(null)
 	useEffect(() => {
 		fetch(
@@ -63,9 +59,7 @@ function Select({ input, submit }) {
 
 	return (
 		<div className="select-answer">
-			<ReactSelectWrapper {...input} options={options} submit={submit} />
+			<ReactSelectWrapper {...props} options={options} />
 		</div>
 	)
-}
-
-export default FormDecorator('select')(Select)
+})

--- a/source/components/ui/AnimatedTargetValue.js
+++ b/source/components/ui/AnimatedTargetValue.js
@@ -17,7 +17,7 @@ export default function AnimatedTargetValue({ value }: Props) {
 		}
 		setDifference((value || 0) - (previousValue || 0))
 		setPreviousValue(value)
-	}, [value])
+	}, [previousValue, value])
 	const { i18n } = useTranslation()
 
 	const format = value => {

--- a/source/components/ui/AnimatedTargetValue.js
+++ b/source/components/ui/AnimatedTargetValue.js
@@ -3,12 +3,13 @@ import React, { useEffect, useState } from 'react'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 import { useTranslation } from 'react-i18next'
 import './AnimatedTargetValue.css'
+import { formatCurrency } from 'Components/TargetSelection'
 
 type Props = {
 	value: ?number
 }
 
-export default function AnimatedTargetValue({ value }: Props) {
+export default function AnimatedTargetValue({ value, children }: Props) {
 	const [difference, setDifference] = useState(0)
 	const [previousValue, setPreviousValue] = useState()
 	useEffect(() => {
@@ -20,18 +21,7 @@ export default function AnimatedTargetValue({ value }: Props) {
 	}, [previousValue, value])
 	const { i18n } = useTranslation()
 
-	const format = value => {
-		return value == null
-			? ''
-			: Intl.NumberFormat(i18n.language, {
-					style: 'currency',
-					currency: 'EUR',
-					maximumFractionDigits: 0,
-					minimumFractionDigits: 0
-			  }).format(value)
-	}
-
-	const formattedDifference = format(difference)
+	const formattedDifference = formatCurrency(difference, i18n.language)
 	const shouldDisplayDifference =
 		Math.abs(difference) > 1 && value != null && !Number.isNaN(value)
 	return (
@@ -40,12 +30,13 @@ export default function AnimatedTargetValue({ value }: Props) {
 				{shouldDisplayDifference && (
 					<Evaporate
 						style={{
-							color: difference > 0 ? 'chartreuse' : 'red'
+							color: difference > 0 ? 'chartreuse' : 'red',
+							pointerEvents: 'none'
 						}}>
 						{(difference > 0 ? '+' : '') + formattedDifference}
 					</Evaporate>
 				)}{' '}
-				<span>{Number.isNaN(value) ? '—' : format(value)}</span>
+				{children}
 			</span>
 		</>
 	)

--- a/source/components/ui/animate.js
+++ b/source/components/ui/animate.js
@@ -131,7 +131,10 @@ export function appear({
 	delay = 0,
 	style
 }) {
+	// TODO: We should rename this function Appear
+	// eslint-disable-next-line react-hooks/rules-of-hooks
 	const [show, setShow] = useState(unless)
+	// eslint-disable-next-line react-hooks/rules-of-hooks
 	useEffect(() => {
 		window.setTimeout(() => setShow(true), 0)
 	}, [])

--- a/source/components/utils/withColours.js
+++ b/source/components/utils/withColours.js
@@ -88,7 +88,7 @@ const generateTheme = (themeColour?: ?string): ThemeColours => {
 	}
 }
 
-const ThemeColoursContext: React$Context<ThemeColours> = createContext(
+export const ThemeColoursContext: React$Context<ThemeColours> = createContext(
 	generateTheme()
 )
 

--- a/source/engine/rules.js
+++ b/source/engine/rules.js
@@ -173,8 +173,6 @@ export let findRuleByNamespace = (allRules, ns) =>
 
 export let queryRule = rule => query => path(query.split(' . '))(rule)
 
-// Redux-form stores the form values as a nested object
-// This helper makes a dottedName => value Map
 export let nestedSituationToPathMap = situation => {
 	if (situation == undefined) return {}
 	let rec = (o, currentPath) =>

--- a/source/engine/uniroot.js
+++ b/source/engine/uniroot.js
@@ -79,7 +79,7 @@ export default function uniroot(
 
 			if (
 				p < 0.75 * cb * q - Math.abs(tol_act * q) / 2 &&
-				p < Math.abs(prev_step * q / 2)
+				p < Math.abs((prev_step * q) / 2)
 			) {
 				// If (b + p / q) falls in [b,c] and isn't too large it is accepted
 				new_step = p / q

--- a/source/reducers/storageReducer.js
+++ b/source/reducers/storageReducer.js
@@ -2,27 +2,19 @@
 
 import type { State } from 'Types/State'
 import type { Action } from 'Types/ActionsTypes'
-import {
-	createStateFromSavedSimulation,
-	currentSimulationSelector
-} from 'Selectors/storageSelectors'
+import { createStateFromSavedSimulation } from 'Selectors/storageSelectors'
 
 export default (state: State, action: Action): State => {
 	switch (action.type) {
 		case 'LOAD_PREVIOUS_SIMULATION':
 			return {
 				...state,
-				...createStateFromSavedSimulation(state.previousSimulation)
+				...createStateFromSavedSimulation(state)
 			}
 		case 'DELETE_PREVIOUS_SIMULATION':
 			return {
 				...state,
 				previousSimulation: null
-			}
-		case 'RESET_SIMULATION':
-			return {
-				...state,
-				previousSimulation: currentSimulationSelector(state)
 			}
 		default:
 			return state

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -5,9 +5,7 @@ import {
 import {
 	collectDefaults,
 	disambiguateExampleSituation,
-	findRuleByDottedName,
-	rules as baseRulesEn,
-	rulesFr as baseRulesFr
+	findRuleByDottedName
 } from 'Engine/rules'
 import { analyse, analyseMany, parseAll } from 'Engine/traverse'
 import {
@@ -38,18 +36,10 @@ import { mapOrApply } from '../utils'
 // create a "selector creator" that uses deep equal instead of ===
 const createDeepEqualSelector = createSelectorCreator(defaultMemoize, equals)
 
-/*
- *
- * We must here compute parsedRules, flatRules, analyse which contains both targets and cache objects
- *
- *
- * */
-
-export let flatRulesSelector = createSelector(
-	state => state.lang,
-	(state, props) => props && props.rules,
-	(lang, rules) => rules || (lang === 'en' ? baseRulesEn : baseRulesFr)
-)
+// We must here compute parsedRules, flatRules, analyse which contains both targets and cache objects
+export let flatRulesSelector = (state, props) => {
+	return props?.rules || state?.rules
+}
 
 export let parsedRulesSelector = createSelector(
 	[flatRulesSelector],

--- a/source/selectors/analyseSelectors.js
+++ b/source/selectors/analyseSelectors.js
@@ -87,8 +87,14 @@ export let situationSelector = createDeepEqualSelector(
 )
 
 export let formattedSituationSelector = createSelector(
-	[situationSelector],
-	situation => nestedSituationToPathMap(situation)
+	[situationSelector, state => state.simulation?.situation],
+	(reduxFormsituation, situation) => {
+		const formatedReduxFormSituation = nestedSituationToPathMap(
+			reduxFormsituation
+		)
+		console.log(formatedReduxFormSituation, situation)
+		return formatedReduxFormSituation
+	}
 )
 
 export let noUserInputSelector = createSelector(

--- a/source/selectors/storageSelectors.js
+++ b/source/selectors/storageSelectors.js
@@ -1,28 +1,23 @@
 /* @flow */
-import type { Situation } from 'Types/Situation.js'
 import type { SavedSimulation, State } from 'Types/State.js'
 
-const situationSelector: State => Situation = state =>
-	state.form.conversation?.values
+export const currentSimulationSelector: State => SavedSimulation = state => {
+	return {
+		situation: state.simulation.situation,
+		activeTargetInput: state.activeTargetInput,
+		foldedSteps: state.conversationSteps.foldedSteps
+	}
+}
 
-export const currentSimulationSelector: State => SavedSimulation = state => ({
-	situation: situationSelector(state),
-	activeTargetInput: state.activeTargetInput,
-	foldedSteps: state.conversationSteps.foldedSteps
-})
-
-export const createStateFromSavedSimulation: (
-	?SavedSimulation
-) => ?$Supertype<State> = simulation =>
-	simulation && {
-		activeTargetInput: simulation.activeTargetInput,
-		form: {
-			conversation: {
-				values: simulation.situation
-			}
+export const createStateFromSavedSimulation = state =>
+	state.previousSimulation && {
+		activeTargetInput: state.previousSimulation.activeTargetInput,
+		simulation: {
+			...state.simulation,
+			situation: state.previousSimulation.situation || {}
 		},
 		conversationSteps: {
-			foldedSteps: simulation.foldedSteps
+			foldedSteps: state.previousSimulation.foldedSteps
 		},
 		previousSimulation: null
 	}

--- a/source/sites/mon-entreprise.fr/App.js
+++ b/source/sites/mon-entreprise.fr/App.js
@@ -38,6 +38,7 @@ import Landing from './pages/Landing/Landing.js'
 import SocialSecurity from './pages/SocialSecurity'
 import ÉconomieCollaborative from './pages/ÉconomieCollaborative'
 import { constructLocalizedSitePath } from './sitePaths'
+import { rules as baseRulesEn, rulesFr as baseRulesFr } from 'Engine/rules'
 
 if (process.env.NODE_ENV === 'production') {
 	Raven.config(
@@ -60,6 +61,7 @@ function InFranceRoute({ basename, language }) {
 		setToSessionStorage('lang', language)
 	}, [language])
 	const paths = constructLocalizedSitePath(language)
+	const rules = language === 'en' ? baseRulesEn : baseRulesFr
 	return (
 		<Provider
 			basename={basename}
@@ -68,12 +70,13 @@ function InFranceRoute({ basename, language }) {
 			sitePaths={paths}
 			reduxMiddlewares={middlewares}
 			onStoreCreated={store => {
-				persistEverything()(store)
+				persistEverything({ except: ['rules'] })(store)
 				persistSimulation(store)
 			}}
 			initialStore={{
 				...retrievePersistedState(),
-				previousSimulation: retrievePersistedSimulation()
+				previousSimulation: retrievePersistedSimulation(),
+				rules
 			}}>
 			<RouterSwitch />
 		</Provider>

--- a/source/sites/mon-entreprise.fr/App.js
+++ b/source/sites/mon-entreprise.fr/App.js
@@ -58,7 +58,7 @@ const middlewares = [
 function InFranceRoute({ basename, language }) {
 	useEffect(() => {
 		setToSessionStorage('lang', language)
-	}, [])
+	}, [language])
 	const paths = constructLocalizedSitePath(language)
 	return (
 		<Provider

--- a/source/sites/mon-entreprise.fr/middlewares/trackSimulatorActions.js
+++ b/source/sites/mon-entreprise.fr/middlewares/trackSimulatorActions.js
@@ -1,26 +1,12 @@
 /* @flow */
-
-// $FlowFixMe
-import { actionTypes } from 'redux-form'
 import {
 	currentQuestionSelector,
-	formattedSituationSelector
+	situationSelector
 } from 'Selectors/analyseSelectors'
-import { debounce } from '../../../utils'
 
 import type { Tracker } from 'Components/utils/withTracker'
 
 export default (tracker: Tracker) => {
-	const debouncedUserInputTracking = debounce(1000, action =>
-		tracker.push([
-			'trackEvent',
-			'Simulator',
-			'input',
-			action.meta.field,
-			action.payload
-		])
-	)
-
 	// $FlowFixMe
 	return ({ getState }) => next => action => {
 		next(action)
@@ -31,7 +17,7 @@ export default (tracker: Tracker) => {
 				'Simulator::answer',
 				action.source,
 				action.step,
-				formattedSituationSelector(newState)[action.step]
+				situationSelector(newState)[action.step]
 			])
 
 			if (!currentQuestionSelector(newState)) {
@@ -55,8 +41,15 @@ export default (tracker: Tracker) => {
 			])
 		}
 
-		if (action.type === actionTypes.CHANGE) {
-			debouncedUserInputTracking(action)
+		if (action.type === 'UPDATE_SITUATION' || action.type === 'UPDATE_PERIOD') {
+			tracker.push([
+				'trackEvent',
+				'Simulator',
+				'update situation',
+				...(action.type === 'UPDATE_PERIOD'
+					? ['période', action.toPeriod]
+					: [action.fieldName, action.value])
+			])
 		}
 		if (action.type === 'START_CONVERSATION') {
 			tracker.push([

--- a/source/sites/mon-entreprise.fr/pages/Dev/IntegrationTest.js
+++ b/source/sites/mon-entreprise.fr/pages/Dev/IntegrationTest.js
@@ -23,6 +23,7 @@ export default function IntegrationTest() {
 		script.dataset.couleur = colour
 		domNode.current.innerHTML = ''
 		domNode.current.appendChild(script)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [version])
 	return (
 		<>

--- a/source/sites/mon-entreprise.fr/pages/Iframes/IframeFooter.js
+++ b/source/sites/mon-entreprise.fr/pages/Iframes/IframeFooter.js
@@ -1,7 +1,7 @@
 import LangSwitcher from 'Components/LangSwitcher'
 import marianneSvg from 'Images/marianne.svg'
 import urssafSvg from 'Images/urssaf.svg'
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import emoji from 'react-easy-emoji'
 import { Trans } from 'react-i18next'
 import { Link } from 'react-router-dom'
@@ -9,8 +9,10 @@ import screenfull from 'screenfull'
 import { isIE } from '../../../../utils'
 
 export default function IframeFooter() {
+	const [isFullscreen, setIsFullscreen] = useState(screenfull.isFullscreen)
 	useEffect(() => {
-		screenfull.enabled && screenfull.onchange(() => this.forceUpdate())
+		screenfull.enabled &&
+			screenfull.onchange(() => setIsFullscreen(screenfull.isFullscreen))
 	}, [])
 
 	return (
@@ -44,7 +46,7 @@ export default function IframeFooter() {
 					justifyContent: 'space-between'
 				}}>
 				<LangSwitcher className="ui__ button simple" />
-				{screenfull.enabled && !screenfull.isFullscreen && !isIE() && (
+				{screenfull.enabled && !isFullscreen && !isIE() && (
 					<button
 						className="ui__ button small"
 						onClick={() => {

--- a/source/storage/persistSimulation.js
+++ b/source/storage/persistSimulation.js
@@ -7,7 +7,7 @@ import { deserialize, serialize } from './serializeSimulation'
 import type { State, SavedSimulation } from '../types/State'
 import type { Action } from 'Types/ActionsTypes'
 
-const VERSION = 2
+const VERSION = 3
 
 const LOCAL_STORAGE_KEY = 'embauche.gouv.fr::persisted-simulation::v' + VERSION
 

--- a/source/types/State.js
+++ b/source/types/State.js
@@ -18,11 +18,6 @@ export type FlatRules = {
 	}
 }
 export type State = {
-	form: {
-		conversation: {
-			values: Situation
-		}
-	},
 	previousSimulation: ?SavedSimulation,
 	conversationSteps: {
 		foldedSteps: Array<string>,

--- a/test/conversation.test.js
+++ b/test/conversation.test.js
@@ -9,7 +9,7 @@ import {
 } from '../source/selectors/analyseSelectors'
 let baseState = {
 	conversationSteps: { foldedSteps: [] },
-	form: { conversation: { values: {} } }
+	simulation: { situation: {} }
 }
 
 describe('conversation', function() {
@@ -48,14 +48,11 @@ describe('conversation', function() {
 			rules = rawRules.map(enrichRule)
 
 		let step1 = merge(baseState, {
+			rules,
 			simulation: { config: { objectifs: ['startHere'] } }
 		})
 		let step2 = reducers(
-			assocPath(
-				['form', 'conversation', 'values'],
-				{ top: { aa: '1' } },
-				step1
-			),
+			assocPath(['simulation', 'situation'], { 'top . aa': '1' }, step1),
 			{
 				type: 'STEP_ACTION',
 				name: 'fold',
@@ -65,8 +62,8 @@ describe('conversation', function() {
 
 		let step3 = reducers(
 			assocPath(
-				['form', 'conversation', 'values'],
-				{ top: { bb: '1', aa: '1' } },
+				['simulation', 'situation'],
+				{ 'top . aa': '1', 'top . bb': '1' },
 				step2
 			),
 			{
@@ -86,7 +83,7 @@ describe('conversation', function() {
 			step: 'top . bb'
 		})
 
-		expect(currentQuestionSelector(lastStep, { rules })).to.equal('top . bb')
+		expect(currentQuestionSelector(lastStep)).to.equal('top . bb')
 		expect(lastStep.conversationSteps).to.have.property('foldedSteps')
 		expect(lastStep.conversationSteps.foldedSteps).to.have.lengthOf(0)
 	})
@@ -129,12 +126,13 @@ describe('conversation', function() {
 			rules = rawRules.map(enrichRule)
 
 		let step1 = merge(baseState, {
+			rules,
 			simulation: { config: { objectifs: ['net'] } }
 		})
-		expect(currentQuestionSelector(step1, { rules })).to.equal('brut')
+		expect(currentQuestionSelector(step1)).to.equal('brut')
 
 		let step2 = reducers(
-			assocPath(['form', 'conversation', 'values', 'brut'], '2300', step1),
+			assocPath(['simulation', 'situation', 'brut'], '2300', step1),
 			{
 				type: 'STEP_ACTION',
 				name: 'fold',

--- a/test/ficheDePaieSelector.test.js
+++ b/test/ficheDePaieSelector.test.js
@@ -3,7 +3,7 @@
 import { expect } from 'chai'
 // $FlowFixMe
 import salariéConfig from 'Components/simulationConfigs/salarié.yaml'
-import { getRuleFromAnalysis } from 'Engine/rules'
+import { getRuleFromAnalysis, rules } from 'Engine/rules'
 import { analysisWithDefaultsSelector } from 'Selectors/analyseSelectors'
 import {
 	analysisToCotisationsSelector,
@@ -11,6 +11,7 @@ import {
 } from 'Selectors/ficheDePaieSelectors'
 
 let state = {
+	rules,
 	simulation: {
 		config: salariéConfig,
 		situation: {

--- a/test/ficheDePaieSelector.test.js
+++ b/test/ficheDePaieSelector.test.js
@@ -11,16 +11,12 @@ import {
 } from 'Selectors/ficheDePaieSelectors'
 
 let state = {
-	form: {
-		conversation: {
-			values: {
-				'contrat salarié': { rémunération: { 'brut de base': '2300' } },
-				entreprise: { effectif: '50' }
-			}
-		}
-	},
 	simulation: {
-		config: salariéConfig
+		config: salariéConfig,
+		situation: {
+			'contrat salarié . rémunération . brut de base': '2300',
+			'entreprise . effectif': '50'
+		}
 	},
 	conversationSteps: {
 		foldedSteps: []

--- a/test/real-rules.test.js
+++ b/test/real-rules.test.js
@@ -10,6 +10,7 @@ let runExamples = (examples, rule) =>
 	examples.map(ex => {
 		let runExample = exampleAnalysisSelector(
 				{
+					rules,
 					currentExample: {
 						situation: ex.situation,
 						dottedName: rule.dottedName

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,6 +3553,11 @@ eslint-plugin-flowtype@^3.2.1:
   dependencies:
     lodash "^4.17.15"
 
+eslint-plugin-react-hooks@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz#e898ec26a0a335af6f7b0ad1f0bedda7143ed756"
+  integrity sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==
+
 eslint-plugin-react@^7.12.4:
   version "7.14.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz#911030dd7e98ba49e1b2208599571846a66bdf13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,7 +751,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.2.0", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -3497,11 +3497,6 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-error@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
-  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
-
 es6-promise@^4.0.3:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
@@ -4686,7 +4681,7 @@ hoist-non-react-statics@^2.2.2:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
-hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -4933,11 +4928,6 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
-
-immutable@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
-  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -5799,7 +5789,7 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.15, lodash-es@^4.2.1:
+lodash-es@^4.2.1:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
@@ -8179,29 +8169,6 @@ reduce-reducers@^0.1.2:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/reduce-reducers/-/reduce-reducers-0.1.5.tgz#ff77ca8068ff41007319b8b4b91533c7e0e54576"
   integrity sha512-uoVmQnZQ+BtKKDKpBdbBri5SLNyIK9ULZGOA504++VbHcwouWE+fJDIo8AuESPF9/EYSkI0v05LDEQK6stCbTA==
-
-redux-batched-actions@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/redux-batched-actions/-/redux-batched-actions-0.4.1.tgz#a8de8cef50a1db4f009d5222820c836515597e22"
-  integrity sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA==
-
-redux-form@^8.2.0:
-  version "8.2.6"
-  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-8.2.6.tgz#6840bbe9ed5b2aaef9dd82e6db3e5efcfddd69b1"
-  integrity sha512-krmF7wl1C753BYpEpWIVJ5NM4lUJZFZc5GFUVgblT+jprB99VVBDyBcgrZM3gWWLOcncFyNsHcKNQQcFg8Uanw==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    es6-error "^4.1.1"
-    hoist-non-react-statics "^3.2.1"
-    invariant "^2.2.4"
-    is-promise "^2.1.0"
-    lodash "^4.17.15"
-    lodash-es "^4.17.15"
-    prop-types "^15.6.1"
-    react-is "^16.7.0"
-    react-lifecycles-compat "^3.0.4"
-  optionalDependencies:
-    immutable "3.8.2"
 
 redux-thunk@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes #632 

La suppression de cette dépendance simplifie grandement le code, qui est plus concis (alors que l'on supprime une dépendance !) et plus clair (moins d'indirections). La PR est a parité de fonctionnalités. Cette refacto doit permettre d'enchaîner sur les modifications mentionnées dans #632.