### PR TITLE
Ajout d'une opération négation et réecriture des règles

### DIFF
--- a/source/components/Distribution.js
+++ b/source/components/Distribution.js
@@ -6,7 +6,6 @@ import Value from 'Components/Value'
 import { findRuleByDottedName } from 'Engine/rules'
 import React, { useState } from 'react'
 import emoji from 'react-easy-emoji'
-import { Trans } from 'react-i18next'
 import { connect } from 'react-redux'
 import { config, Spring } from 'react-spring'
 import { compose } from 'redux'
@@ -51,6 +50,7 @@ function Distribution({
 		répartition,
 		cotisationMaximum,
 		total,
+		cotisations,
 		salaireChargé,
 		salaireNet
 	} = distribution
@@ -107,10 +107,8 @@ function Distribution({
 				<RuleLink {...salaireNet} />
 				<Value {...salaireNet} unit="€" maximumFractionDigits={0} />
 				<span>+</span>
-				<Trans>Cotisations</Trans>
-				<Value maximumFractionDigits={0} unit="€">
-					{total.partPatronale + total.partSalariale}
-				</Value>
+				<RuleLink {...cotisations} />
+				<Value {...cotisations} unit="€" maximumFractionDigits={0} />
 				<span />
 				<div className="distribution-chart__total-border" />
 				<span>=</span>

--- a/source/components/PaySlip.js
+++ b/source/components/PaySlip.js
@@ -103,21 +103,13 @@ export default compose(
 						)
 					})}
 
-					<Line
-						negative
-						rule={getRule(
-							'contrat salarié . cotisations . patronales . réductions de cotisations'
-						)}
-					/>
-					<span />
-
 					{/* Total cotisation */}
 					<div className="payslip__total">
 						<Trans>Total des retenues</Trans>
 					</div>
 					<Value
 						nilValueSymbol="—"
-						{...getRule('contrat salarié . cotisations . patronales . à payer')}
+						{...getRule('contrat salarié . cotisations . patronales')}
 						unit="€"
 						className="payslip__total"
 					/>

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -14,7 +14,7 @@ objectifs:
       - entreprise . chiffre d'affaires minimum
 
 objectifs secondaires:
-  - contrat salarié . temps de travail
+  - contrat salarié . cotisations
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/assimilé.yaml
+++ b/source/components/simulationConfigs/assimilé.yaml
@@ -15,7 +15,6 @@ objectifs:
 
 objectifs secondaires:
   - contrat salarié . temps de travail
-  - contrat salarié . cotisations . patronales . à payer
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -8,7 +8,6 @@ objectifs:
 
 objectifs secondaires:
   - contrat salarié . temps de travail
-  - contrat salarié . cotisations . patronales . à payer
 
 questions:
   à l'affiche:

--- a/source/components/simulationConfigs/salarié.yaml
+++ b/source/components/simulationConfigs/salarié.yaml
@@ -8,6 +8,7 @@ objectifs:
 
 objectifs secondaires:
   - contrat salarié . temps de travail
+  - contrat salarié . cotisations
 
 questions:
   à l'affiche:

--- a/source/engine/grammarFunctions.js
+++ b/source/engine/grammarFunctions.js
@@ -2,10 +2,17 @@
 The advantage of putting them here is to get prettier's JS formatting, since Nealrey doesn't support it https://github.com/kach/nearley/issues/310 */
 import { parseUnit } from 'Engine/units'
 
-export let operation = operationType => ([A, , operator, , B]) => ({
+export let binaryOperation = operationType => ([A, , operator, , B]) => ({
 	[operator]: {
 		operationType,
 		explanation: [A, B]
+	}
+})
+
+export let unaryOperation = operationType => ([operator, , A]) => ({
+	[operator]: {
+		operationType,
+		explanation: [number([{ value: '0' }]), A]
 	}
 })
 

--- a/source/engine/mecanismViews/Somme.css
+++ b/source/engine/mecanismViews/Somme.css
@@ -132,7 +132,7 @@
 }
 
 /* Nested Mecanism */
-.nested .mecanism-somme__row {
+.mecanism-somme__row + .nested {
 	padding-left: 2em;
 	border-top: 1px dashed rgba(51, 51, 80, 0.15);
 }

--- a/source/engine/mecanismViews/Somme.css
+++ b/source/engine/mecanismViews/Somme.css
@@ -25,17 +25,21 @@
 .somme .leaf .name {
 	border: none;
 }
-.somme .operator {
-	text-align: center;
-	width: 1em;
-	padding: 0 0.4em;
-	font-weight: 600;
-	border: none !important;
-	color: black;
-}
 .somme .operator + .element {
 	border-left: none;
 }
+
+.mecanism-somme__row > .element > * > .nodeContent + * {
+	display: none;
+}
+.mecanism-somme__row > .element > * > .nodeContent {
+	display: flex;
+	align-items: center;
+}
+.mecanism-somme__row > .element > * > .nodeContent > .operator:first-child {
+	margin-left: 0;
+}
+
 #rule-rules .somme table .leaf .situationValue {
 	display: none;
 }
@@ -113,7 +117,6 @@
 }
 .mecanism-somme__row .operator {
 	align-self: center;
-	display: none;
 }
 
 .mecanism-somme__row .element .variable,

--- a/source/engine/mecanismViews/Somme.js
+++ b/source/engine/mecanismViews/Somme.js
@@ -37,7 +37,6 @@ function Row({ v, i, unit }) {
 			key={v.name}
 			// className={isSomme ? '' : 'noNest'}
 			onClick={() => setFolded(!folded)}>
-			<div className="operator blank">{i != 0 && '+'}</div>
 			<div className="element">
 				{makeJsx(v)}
 				{isSomme && (

--- a/source/engine/mecanismViews/Somme.js
+++ b/source/engine/mecanismViews/Somme.js
@@ -34,7 +34,7 @@ function Row({ v, i, unit }) {
 	return [
 		<div
 			className="mecanism-somme__row"
-			key={v.name}
+			key={v.name || i}
 			// className={isSomme ? '' : 'noNest'}
 			onClick={() => setFolded(!folded)}>
 			<div className="element">

--- a/source/engine/mecanisms/operation.js
+++ b/source/engine/mecanisms/operation.js
@@ -35,8 +35,12 @@ export default (k, operatorFunction, symbol) => (recurse, k, v) => {
 			unit={unit}
 			child={
 				<span className="nodeContent">
-					<span className="fa fa" />
-					{makeJsx(explanation[0])}
+					{(explanation[0].nodeValue !== 0 || symbol !== '−') && (
+						<>
+							<span className="fa fa" />
+							{makeJsx(explanation[0])}
+						</>
+					)}
 					<span className="operator">{symbol || k}</span>
 					{makeJsx(explanation[1])}
 				</span>

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1117,7 +1117,7 @@
   par défaut: 800
   # TODO : vérifier et documenter les chiffres
   suggestions:
-    📱: 400
+    📱: 4000
     📱✨ (haut de gamme): 850
     💻: 1200
     💻 + 📱✨: 2050
@@ -1267,7 +1267,7 @@
       - CRDS
       - APEC [salarié]
       - complémentaire santé [salarié]
-      - réduction heures supplémentaires
+      - (- réduction heures supplémentaires)
 
 - espace: contrat salarié . cotisations
   nom: patronales
@@ -1802,7 +1802,7 @@
     type: réduction de cotisations
   unité: €
   période: flexible
-  formule: 0 - rémunération . heures supplémentaires * taux des cotisations réduites
+  formule: rémunération . heures supplémentaires * taux des cotisations réduites
   références:
     Code de la sécurité sociale - Article D241-21: https://www.legifrance.gouv.fr/affichCodeArticle.do?idArticle=LEGIARTI000038056813&cidTexte=LEGITEXT000006073189
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1299,6 +1299,7 @@
       - CDD . majoration chômage
       - CDD . CIF
       - forfait social
+      - (- réductions de cotisations)
 
 - espace: contrat salarié
   nom: rémunération
@@ -1730,7 +1731,10 @@
 
     Des [aides différées](/documentation/aides-employeur) peuvent venir diminuer ce montant.
 
-  formule: rémunération . total sans réduction - cotisations . patronales . réductions de cotisations
+  formule:
+    somme:
+      - brut
+      - cotisations . patronales
 
 - espace: contrat salarié . cotisations . patronales
   nom: réductions de cotisations
@@ -1756,12 +1760,6 @@
   note: La déduction ne s’applique pas aux heures complémentaires
   références:
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-deduction-forfaitaire-patrona/employeurs-concernes.html
-
-- espace: contrat salarié . cotisations . patronales
-  nom: à payer
-  période: flexible
-  unité: €
-  formule: patronales - réductions de cotisations
 
 - espace: contrat salarié
   nom: réduction ACRE
@@ -1825,15 +1823,6 @@
     urssaf.fr: https://www.urssaf.fr/portail/home/employeur/beneficier-dune-exoneration/exonerations-generales/la-reduction-de-cotisations-sala/modalites-de-calcul-et-de-declar.html
     Circulaire DSS/5B/2019/71: http://circulaire.legifrance.gouv.fr/pdf/2019/04/cir_44492.pdf
 
-- espace: contrat salarié . rémunération
-  nom: total sans réduction
-  période: flexible
-  titre: Rémunération totale sans réduction
-  type: salaire
-  formule:
-    somme:
-      - brut
-      - cotisations . patronales
 
 - espace: contrat salarié
   nom: cotisations
@@ -3831,11 +3820,6 @@
     - contrat salarié
 
 - espace: indépendant . cotisations et contributions
-  nom: cotisations à payer
-  période: flexible
-  formule: cotisations - réduction ACRE
-
-- espace: indépendant . cotisations et contributions
   nom: cotisations
   période: flexible
   références:
@@ -3853,9 +3837,10 @@
   nom: cotisations et contributions
   formule:
     somme:
-      - cotisations à payer
+      - cotisations
       - CSG et CRDS
       - formation professionnelle
+      - (- réduction ACRE)
   unité: €
   période: flexible
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -739,7 +739,6 @@
     - temps de travail . temps partiel
     - temps de travail . heures supplémentaires
     - statut JEI
-    - régime des impatriés
     - entreprise . association non lucrative
   références:
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
@@ -1322,14 +1321,15 @@
     C'est la base utilisée pour calculer l'impôt sur le revenu.
   période: flexible
   formule:
-    allègement:
-      assiette: base
-      abattement:
-        somme:
-          - indemnité kilométrique vélo
-          - prime d'impatriation
-          - exonération d'impôt des stagiaires et apprentis
-          - heures supplémentaires défiscalisées
+    somme:
+      - rémunération . net de cotisations
+      - avantages sociaux
+      - CSG [non déductible]
+      - CRDS
+      - (- indemnité kilométrique vélo)
+      - (- prime d'impatriation)
+      - (- exonération d'impôt des stagiaires et apprentis)
+      - (- heures supplémentaires défiscalisées)
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 
@@ -1352,16 +1352,6 @@
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 
-- espace: contrat salarié . rémunération . net imposable
-  nom: base
-  période: flexible
-  formule:
-    somme:
-      - rémunération . net de cotisations
-      - avantages sociaux
-      - CSG [non déductible]
-      - CRDS
-
 - espace: contrat salarié
   nom: prime d'impatriation
   description: La prime d'impatriation est une partie de la rémunération exonérée d'impôt sur le revenu.
@@ -1370,7 +1360,7 @@
   unité: €
   formule:
     multiplication:
-      assiette: rémunération . net imposable . base
+      assiette: rémunération . net
       taux: 30%
   références:
     Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -1321,15 +1321,19 @@
     C'est la base utilisée pour calculer l'impôt sur le revenu.
   période: flexible
   formule:
-    somme:
-      - rémunération . net de cotisations
-      - avantages sociaux
-      - CSG [non déductible]
-      - CRDS
-      - (- indemnité kilométrique vélo)
-      - (- prime d'impatriation)
-      - (- exonération d'impôt des stagiaires et apprentis)
-      - (- heures supplémentaires défiscalisées)
+    allègement:
+      assiette:
+        somme:
+          - rémunération . net de cotisations
+          - avantages sociaux
+          - CSG [non déductible]
+          - CRDS
+      abattement:
+        somme:
+          - indemnité kilométrique vélo
+          - prime d'impatriation
+          - exonération d'impôt des stagiaires et apprentis
+          - heures supplémentaires défiscalisées
   références:
     DSN: https://dsn-info.custhelp.com/app/answers/detail/a_id/2110
 

--- a/source/règles/base.yaml
+++ b/source/règles/base.yaml
@@ -740,6 +740,7 @@
     - temps de travail . heures supplémentaires
     - statut JEI
     - entreprise . association non lucrative
+    - régime des impatriés
   références:
     Le régime des dirigeants: https://www.urssaf.fr/portail/home/employeur/creer/choisir-une-forme-juridique/le-statut-du-dirigeant/les-dirigeants-rattaches-au-regi.html
 
@@ -1116,7 +1117,7 @@
   par défaut: 800
   # TODO : vérifier et documenter les chiffres
   suggestions:
-    📱: 4000
+    📱: 400
     📱✨ (haut de gamme): 850
     💻: 1200
     💻 + 📱✨: 2050
@@ -1364,10 +1365,14 @@
   unité: €
   formule:
     multiplication:
-      assiette: rémunération . net
+      assiette:
+        somme:
+          - rémunération . net
+          - CSG [non déductible]
       taux: 30%
   références:
     Article 155B du Code général des impôts: https://www.legifrance.gouv.fr/affichCodeArticle.do?cidTexte=LEGITEXT000006069577&idArticle=LEGIARTI000006307476&dateTexte=&categorieLien=cid
+    Bofip: https://bofip.impots.gouv.fr/bofip/5677-PGP
 
 - espace: contrat salarié . rémunération
   nom: net
@@ -1717,8 +1722,6 @@
   unité: €
   période: flexible
   description: |
-    C'est la rémunération brute, plus les cotisations patronales, moins les réductions de cotisations sociales.
-
     C'est le total que l'employeur doit verser pour employer un salarié.
 
     > C'est donc aussi une mesure de la valeur apportée par le salarié à l'entreprise : l'employeur est prêt à verser cette somme en contrepartie du travail fourni.

--- a/source/règles/externalized.yaml
+++ b/source/règles/externalized.yaml
@@ -1203,9 +1203,6 @@ contrat salarié . cotisations . patronales . réductions de cotisations:
 ? contrat salarié . cotisations . patronales . réductions de cotisations . déduction heures supplémentaires
 : titre.en: flat-rate deduction for overtime
   titre.fr: déduction forfaitaire pour heures supplémentaires
-contrat salarié . cotisations . patronales . à payer:
-  titre.en: to be paid
-  titre.fr: à payer
 contrat salarié . réduction ACRE:
   titre.en: ACRE reduction
   titre.fr: réduction ACRE

--- a/source/selectors/ficheDePaieSelectors.js
+++ b/source/selectors/ficheDePaieSelectors.js
@@ -85,11 +85,23 @@ export const mergeCotisations: (
 )
 
 const variableToCotisation = (variable: VariableWithCotisation): Cotisation => {
+	let displayedVariable = variable
+	if (
+		// Following :  weird logic to automatically handle negative negated value in sum
+		// $FlowFixMe
+		variable.operationType === 'calculation' &&
+		// $FlowFixMe
+		variable.operator === '−' &&
+		variable.explanation[0].nodeValue === 0
+	) {
+		displayedVariable = variable.explanation[1]
+		console.log(displayedVariable, brancheSelector(displayedVariable))
+	}
 	return mergeCotisations(BLANK_COTISATION, {
-		...variable.explanation,
-		branche: brancheSelector(variable),
+		...displayedVariable.explanation,
+		branche: brancheSelector(displayedVariable),
 		montant: {
-			[duParSelector(variable) === 'salarié'
+			[duParSelector(displayedVariable) === 'salarié'
 				? 'partSalariale'
 				: 'partPatronale']: variable.nodeValue
 		}

--- a/source/selectors/ficheDePaieSelectors.js
+++ b/source/selectors/ficheDePaieSelectors.js
@@ -17,17 +17,6 @@ import {
 import { createSelector } from 'reselect'
 import { analysisWithDefaultsSelector } from 'Selectors/analyseSelectors'
 
-import type { Analysis } from 'Types/Analysis'
-import type {
-	VariableWithCotisation,
-	Cotisation,
-	Cotisations,
-	Branche,
-	FicheDePaie
-} from 'Types/ResultViewTypes'
-
-import type { Règle } from 'Types/RegleTypes'
-
 // These functions help build the payslip. They take the cotisations from the cache, braving all the particularities of the current engine's implementation, handles the part patronale and part salariale, and gives a map by branch.
 
 export const COTISATION_BRANCHE_ORDER: Array<Branche> = [
@@ -85,31 +74,17 @@ export const mergeCotisations: (
 )
 
 const variableToCotisation = (variable: VariableWithCotisation): Cotisation => {
-	let displayedVariable = variable
-	if (
-		// Following :  weird logic to automatically handle negative negated value in sum
-		// $FlowFixMe
-		variable.operationType === 'calculation' &&
-		// $FlowFixMe
-		variable.operator === '−' &&
-		variable.explanation[0].nodeValue === 0
-	) {
-		displayedVariable = variable.explanation[1]
-		console.log(displayedVariable, brancheSelector(displayedVariable))
-	}
 	return mergeCotisations(BLANK_COTISATION, {
-		...displayedVariable.explanation,
-		branche: brancheSelector(displayedVariable),
+		...variable.explanation,
+		branche: brancheSelector(variable),
 		montant: {
-			[duParSelector(displayedVariable) === 'salarié'
+			[duParSelector(variable) === 'salarié'
 				? 'partSalariale'
 				: 'partPatronale']: variable.nodeValue
 		}
 	})
 }
-const groupByBranche = flatRules => (
-	cotisations: Array<Cotisation>
-): Cotisations => {
+const groupByBranche = (cotisations: Array<Cotisation>): Cotisations => {
 	const cotisationsMap = cotisations.reduce(
 		(acc, cotisation) => ({
 			...acc,
@@ -133,6 +108,15 @@ export let analysisToCotisations = analysis => {
 		.reduce(concat, [])
 
 	const cotisations = pipe(
+		map(rule =>
+			// Following :  weird logic to automatically handle negative negated value in sum
+
+			rule.operationType === 'calculation' &&
+			rule.operator === '−' &&
+			rule.explanation[0].nodeValue === 0
+				? { ...rule.explanation[1], nodeValue: rule.nodeValue }
+				: rule
+		),
 		groupBy(prop('dottedName')),
 		values,
 		map(
@@ -146,7 +130,7 @@ export let analysisToCotisations = analysis => {
 				cotisation.montant.partPatronale !== 0 ||
 				cotisation.montant.partSalariale !== 0
 		),
-		groupByBranche(analysis),
+		groupByBranche,
 		filter(([, brancheCotisation]) => !!brancheCotisation)
 	)(variables)
 	return cotisations

--- a/source/selectors/repartitionSelectors.js
+++ b/source/selectors/repartitionSelectors.js
@@ -112,6 +112,7 @@ const répartition = (analysis): ?Répartition => {
 	const getRule = getRuleFromAnalysis(analysis),
 		salaireNet = getRule('contrat salarié . rémunération . net'),
 		salaireChargé = getRule('contrat salarié . rémunération . total'),
+		cotisationsRule = getRule('contrat salarié . cotisations'),
 		réductionsDeCotisations = getRule(
 			'contrat salarié . cotisations . patronales . réductions de cotisations'
 		)
@@ -146,10 +147,8 @@ const répartition = (analysis): ?Répartition => {
 			)
 		)(répartitionMap),
 		// $FlowFixMe
-		total: compose(
-			reduce(mergeWith(add), 0),
-			Object.values
-		)(répartitionMap),
+		total: cotisationsRule.nodeValue,
+		cotisations: cotisationsRule,
 		cotisationMaximum: compose(
 			reduce(max, 0),
 			map(montant => montant.partPatronale + montant.partSalariale),

--- a/test/ficheDePaieSelector.test.js
+++ b/test/ficheDePaieSelector.test.js
@@ -54,7 +54,7 @@ describe('pay slip selector', function() {
 
 	it('should sum all cotisations', function() {
 		let pat = getRuleFromAnalysis(analysis)(
-				'contrat salarié . cotisations . patronales . à payer'
+				'contrat salarié . cotisations . patronales'
 			),
 			sal = getRuleFromAnalysis(analysis)(
 				'contrat salarié . cotisations . salariales'

--- a/test/mécanismes/expressions.yaml
+++ b/test/mécanismes/expressions.yaml
@@ -234,3 +234,32 @@
   formule: -5 * -10
   exemples:
     - valeur attendue: 50
+
+- test: négation de variable
+  formule: '- salaire de base'
+  exemples:
+    - situation:
+        salaire de base: 3000
+      valeur attendue: -3000
+
+- test: négation d'expressions
+  formule: '- (10 * 3 + 5)'
+  exemples:
+    - valeur attendue: -35
+
+- test: variables négatives dans expression
+  formule: 10% * (- salaire de base)
+  exemples:
+    - situation:
+        salaire de base: 3000
+      valeur attendue: -300
+# TODO
+# - test: expression sur plusieurs lignes
+#   formule: >
+#     salaire de base
+#     + 2000
+#     = 3000
+#   exemples:
+#     - situation:
+#         salaire de base: 1000
+#     - valeur attendue: true


### PR DESCRIPTION
Ajoute un opérateur de négation unaire à la grammaire. Réecriture des règles en l'utilisant, de manière à :
- réduire le nombre de variables intermédiaires
- simplifier les pages de documentation, notamment l'affichage des sommes

Abouti à une visualisation directe des cotisations indépendant sans devoir naviguer sur trois pages différentes (#623)

---
Supercede #682 